### PR TITLE
Update template parser

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.7.1
+version: 1.7.2
 appVersion: 1.13
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/_helpers.tpl
+++ b/charts/telegraf/templates/_helpers.tpl
@@ -133,7 +133,7 @@ Create chart name and version as used by the chart label.
               {{- end }}
               {{- if eq $tps "[]interface {}"}}
         {{ $k }} = [
-                {{- $numOut := len $value }}
+                {{- $numOut := len $v }}
                 {{- $numOut := sub $numOut 1 }}
                 {{- range $b, $val := $v }}
                   {{- $i := int64 $b }}
@@ -207,6 +207,9 @@ Create chart name and version as used by the chart label.
               {{- end }}
       ]
           {{- end }}
+          {{- end }}
+          {{- range $key, $value := $config -}}
+          {{- $tp := typeOf $value -}}
           {{- if eq $tp "map[string]interface {}" }}
       [[inputs.{{ $input }}.{{ $key }}]]
             {{- range $k, $v := $value }}
@@ -228,6 +231,9 @@ Create chart name and version as used by the chart label.
                 {{- end }}
         ]
               {{- end }}
+              {{- end }}
+              {{- range $k, $v := $value }}
+              {{- $tps := typeOf $v }}
               {{- if eq $tps "map[string]interface {}"}}
         [[inputs.{{ $input }}.{{ $key }}.{{ $k }}]]
                 {{- range $foo, $bar := $v }}
@@ -290,6 +296,9 @@ Create chart name and version as used by the chart label.
               {{- end }}
       ]
           {{- end }}
+          {{- end }}
+          {{- range $key, $value := $config -}}
+          {{- $tp := typeOf $value -}}
           {{- if eq $tp "map[string]interface {}" }}
       [[processors.{{ $processor }}.{{ $key }}]]
             {{- range $k, $v := $value }}
@@ -299,7 +308,7 @@ Create chart name and version as used by the chart label.
               {{- end }}
               {{- if eq $tps "[]interface {}"}}
         {{ $k }} = [
-                {{- $numOut := len $value }}
+                {{- $numOut := len $v }}
                 {{- $numOut := sub $numOut 1 }}
                 {{- range $b, $val := $v }}
                   {{- $i := int64 $b }}
@@ -311,8 +320,137 @@ Create chart name and version as used by the chart label.
                 {{- end }}
         ]
               {{- end }}
+              {{- end }}
+              {{- range $k, $v := $value }}
+              {{- $tps := typeOf $v }}
               {{- if eq $tps "map[string]interface {}"}}
         [processors.{{ $processor }}.{{ $key }}.{{ $k }}]
+                {{- range $foo, $bar := $v }}
+                {{- $tp := typeOf $bar -}}
+                {{- if eq $tp "string" }}
+            {{ $foo }} = {{ $bar | quote }}
+                {{- end }}
+                {{- if eq $tp "int" }}
+            {{ $foo }} = {{ $bar }}
+                {{- end }}
+                {{- if eq $tp "float64" }}
+            {{ $foo }} = {{ int64 $bar }}
+                {{- end }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- end }}
+    {{- end }}
+    {{- end }}
+    {{ end }}
+{{- end }}
+{{- end -}}
+
+
+{{- define "aggregators" -}}
+{{- range $aggregatorIdx, $configObject := . -}}
+    {{- range $aggregator, $config := . -}}
+
+    [[aggregators.{{- $aggregator }}]]
+    {{- if $config -}}
+    {{- $tp := typeOf $config -}}
+    {{- if eq $tp "map[string]interface {}" -}}
+        {{- range $key, $value := $config -}}
+          {{- $tp := typeOf $value -}}
+          {{- if eq $tp "string" }}
+      {{ $key }} = {{ $value | quote }}
+          {{- end }}
+          {{- if eq $tp "float64" }}
+      {{ $key }} = {{ $value | int64 }}
+          {{- end }}
+          {{- if eq $tp "int" }}
+      {{ $key }} = {{ $value | int64 }}
+          {{- end }}
+          {{- if eq $tp "bool" }}
+      {{ $key }} = {{ $value }}
+          {{- end }}
+          {{- if eq $tp "[]interface {}" }}
+      {{ $key }} = [
+              {{- $numOut := len $value }}
+              {{- $numOut := sub $numOut 1 }}
+              {{- range $b, $val := $value }}
+                {{- $i := int64 $b }}
+                {{- $tp := typeOf $val }}
+                {{- if eq $i $numOut }}
+                  {{- if eq $tp "string" }}
+        {{ $val | quote }}
+                  {{- end }}
+                  {{- if eq $tp "float64" }}
+        {{ $val | int64 }}
+                  {{- end }}
+                {{- else }}
+                  {{- if eq $tp "string" }}
+        {{ $val | quote }},
+                  {{- end}}
+                  {{- if eq $tp "float64" }}
+        {{ $val | int64 }},
+                  {{- end }}
+                {{- end }}
+              {{- end }}
+      ]
+          {{- end }}
+          {{- end }}
+          {{- range $key, $value := $config -}}
+          {{- $tp := typeOf $value -}}
+          {{- if eq $tp "map[string]interface {}" }}
+      [[aggregators.{{ $aggregator }}.{{ $key }}]]
+            {{- range $k, $v := $value }}
+              {{- $tps := typeOf $v }}
+              {{- if eq $tps "string" }}
+        {{ $k }} = {{ $v | quote }}
+              {{- end }}
+              {{- if eq $tps "[]interface {}"}}
+        {{ $k }} = [
+                {{- $numOut := len $v }}
+                {{- $numOut := sub $numOut 1 }}
+                {{- range $b, $val := $v }}
+                  {{- $i := int64 $b }}
+                  {{- $tv := typeOf $val -}}
+                  {{- if eq $i $numOut }}
+                      {{- if eq $tv "string" }}
+                  {{ $val | quote }}
+                      {{- end }}
+                      {{- if eq $tv "float64" }}
+                        {{- $xval := float64 (int64 $val) -}}
+                        {{- if eq $val $xval -}}
+                  {{ $val | float64 }}.0
+                        {{- else -}}
+                  {{ $val | float64 }}
+                        {{- end -}}
+                      {{- end }}
+                      {{- if eq $tv "int64" }}
+                  {{ $val | int64 }}
+                      {{- end }}
+                  {{- else }}
+                      {{- if eq $tv "string" }}
+                  {{ $val | quote }},
+                      {{- end }}
+                      {{- if eq $tv "float64" }}
+                        {{- $xval := float64 (int64 $val) -}}
+                        {{- if eq $val $xval -}}
+                  {{ $val | float64 }}.0,
+                        {{- else -}}
+                  {{ $val | float64 }},
+                        {{- end -}}
+                      {{- end }}
+                      {{- if eq $tv "int64" }}
+                  {{ $val | int64 }},
+                      {{- end }}
+                  {{- end }}
+                {{- end }}
+        ]
+              {{- end }}
+              {{- end }}
+              {{- range $k, $v := $value }}
+              {{- $tps := typeOf $v }}
+              {{- if eq $tps "map[string]interface {}"}}
+        [aggregators.{{ $aggregator }}.{{ $key }}.{{ $k }}]
                 {{- range $foo, $bar := $v }}
                 {{- $tp := typeOf $bar -}}
                 {{- if eq $tp "string" }}

--- a/charts/telegraf/templates/configmap.yaml
+++ b/charts/telegraf/templates/configmap.yaml
@@ -12,5 +12,6 @@ data:
     {{ template "global_tags" .Values.config.global_tags }}
     {{ template "agent" .Values.config.agent }}
     {{ template "processors" .Values.config.processors }}
+    {{ template "aggregators" .Values.config.aggregators }}
     {{ template "outputs" .Values.config.outputs }}
     {{ template "inputs" .Values.config.inputs -}}


### PR DESCRIPTION
#### CHANGE/FIX
- Fix an error that template get wrong length of elements
- Fix an error that uncontrollable orders of map make the toml wrong. i.e.
Yaml
```yaml
- d:
    b
    c
    a:
       - x
       - y 
```
Current TOML
```toml
[d]
    [a]
       x
       y
    b
    c
```
Expected
```toml
[d]
    b
    c
    [a]
       x
       y
```
- Add aggregators supported
