### PR TITLE
Auth job variables

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.2.8
+version: 4.3.0
 appVersion: 1.7.9
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/post-install-set-auth.yaml
+++ b/charts/influxdb/templates/post-install-set-auth.yaml
@@ -7,9 +7,10 @@ metadata:
     {{- include "influxdb.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": {{ .Values.setDefaultUser.hookDeletePolicy }}
 spec:
   activeDeadlineSeconds: {{ .Values.setDefaultUser.activeDeadlineSeconds }}
+  backoffLimit: {{ .Values.setDefaultUser.backoffLimit }}
   template:
     metadata:
       labels:

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -98,6 +98,16 @@ setDefaultUser:
   ##
   activeDeadline: 300
 
+  ## Specify the number of retries before considering job as failed.
+  ## https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#pod-backoff-failure-policy
+  ##
+  backoffLimit: 6
+
+  ## Hook delete policy for helm.
+  ## Default: hookDeletePolicy: hook-succeeded
+  ##
+  hookDeletePolicy: hook-succeeded
+
   ## Restart policy for job
   ## Default: OnFailure
   restartPolicy: OnFailure


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds to variables for configuration of the post install auth job. This is to help in scenarios where the installation is taking longer but will eventually finish if given more time. 

#### Special notes for your reviewer:

Both of the variables default to either the previous value or the kubernetes default value.