### PR TITLE
[influxdb] Add existingClaim option.

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.3.6
+version: 4.4.0
 appVersion: 1.7.10
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/README.md
+++ b/charts/influxdb/README.md
@@ -60,7 +60,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | startupProbe | Health check for pod | {} |
 | service.type | Kubernetes service type | ClusterIP |
 | persistence.enabled | Boolean to enable and disable persistance | true |
-| persistence.existingClaim | An existing PersistentVolumeClaim | nil |
+| persistence.existingClaim | An existing PersistentVolumeClaim, ignored if enterprise.enabled=true | nil |
 | persistence.storageClass | If set to "-", storageClassName: "", which disables dynamic provisioning. If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.  (gp2 on AWS, standard on GKE, AWS & OpenStack |  |
 | persistence.annotations | Annotations for volumeClaimTemplates | nil |
 | persistence.accessMode | Access mode for the volume | ReadWriteOnce |

--- a/charts/influxdb/README.md
+++ b/charts/influxdb/README.md
@@ -60,6 +60,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | startupProbe | Health check for pod | {} |
 | service.type | Kubernetes service type | ClusterIP |
 | persistence.enabled | Boolean to enable and disable persistance | true |
+| persistence.existingClaim | An existing PersistentVolumeClaim | nil |
 | persistence.storageClass | If set to "-", storageClassName: "", which disables dynamic provisioning. If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.  (gp2 on AWS, standard on GKE, AWS & OpenStack |  |
 | persistence.annotations | Annotations for volumeClaimTemplates | nil |
 | persistence.accessMode | Access mode for the volume | ReadWriteOnce |

--- a/charts/influxdb/templates/statefulset.yaml
+++ b/charts/influxdb/templates/statefulset.yaml
@@ -126,7 +126,12 @@ spec:
       - name: {{ include "influxdb.fullname" . }}-data
         emptyDir: {}
       {{- end }}
-{{- if .Values.persistence.enabled }}
+      {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
+      - name: {{ include "influxdb.fullname" . }}-data
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim }}
+      {{- end }}
+  {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
   volumeClaimTemplates:
     - metadata:
         name: {{ include "influxdb.fullname" . }}-data
@@ -147,4 +152,4 @@ spec:
         storageClassName: "{{ .Values.persistence.storageClass }}"
       {{- end }}
       {{- end }}
-{{- end }}
+  {{- end }}

--- a/charts/influxdb/templates/statefulset.yaml
+++ b/charts/influxdb/templates/statefulset.yaml
@@ -126,12 +126,14 @@ spec:
       - name: {{ include "influxdb.fullname" . }}-data
         emptyDir: {}
       {{- end }}
-      {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
+      # Cannot use existing claim in enterprise mode
+      {{- if and .Values.persistence.enabled .Values.persistence.existingClaim (not .Values.enterprise.enabled) }}
       - name: {{ include "influxdb.fullname" . }}-data
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim }}
       {{- end }}
-  {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+  # Must use volume claim template in enterprise mode
+  {{- if and .Values.persistence.enabled (or (not .Values.persistence.existingClaim) .Values.enterprise.enabled) }}
   volumeClaimTemplates:
     - metadata:
         name: {{ include "influxdb.fullname" . }}-data

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -44,6 +44,10 @@ service:
 ##
 persistence:
   enabled: true
+  ## A manually managed Persistent Volume and Claim
+  ## Requires persistence.enabled: true
+  ## If defined, PVC must be created manually before volume will be bound
+  # existingClaim:
   ## influxdb data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
The option to provide a pre existing PVC to mount was removed during the move from Deployment to StatefulSet via https://github.com/helm/charts/pull/17619/files. Seeing that influxdb OSS runs as a single replica, mounting a pre existing PVC remains a valid option, especially helpful for data continuity across cluster rebuilds where the user recreates a PVC claiming the original (and retained) PV.