### PR TITLE
[influxdb] Fix config rendering.

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.3.4
+version: 4.3.5
 appVersion: 1.7.10
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/configmap.yaml
+++ b/charts/influxdb/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
     [meta]
       dir = "/var/lib/influxdb/meta"
       {{- range $key, $value := index .Values.config.meta }}
-      {{ $key }} = {{ $value }}
+      {{ $key }} = {{ $value | quote }}
       {{- end }}
 
       {{- if .Values.enterprise.enabled }}
@@ -24,44 +24,44 @@ data:
       dir = "/var/lib/influxdb/data"
       wal-dir = "/var/lib/influxdb/wal"
       {{- range $key, $value := index .Values.config.data }}
-      {{ $key }} = {{ $value }}
+      {{ $key }} = {{ $value | quote }}
       {{- end }}
 
     [coordinator]
       {{- range $key, $value := index .Values.config.coordinator }}
-      {{ $key }} = {{ $value }}
+      {{ $key }} = {{ $value | quote }}
       {{- end }}
 
     [retention]
       {{- range $key, $value := index .Values.config.retention }}
-      {{ $key }} = {{ $value }}
+      {{ $key }} = {{ $value | quote }}
       {{- end }}
 
     [shard-precreation]
       {{- range $key, $value := index .Values.config.shard_precreation }}
-      {{ $key }} = {{ $value }}
+      {{ $key }} = {{ $value | quote }}
       {{- end }}
 
     [monitor]
       {{- range $key, $value := index .Values.config.monitor }}
-      {{ $key }} = {{ $value }}
+      {{ $key }} = {{ $value | quote }}
       {{- end }}
 
     [subscriber]
       {{- range $key, $value := index .Values.config.subscriber }}
-      {{ $key }} = {{ $value }}
+      {{ $key }} = {{ $value | quote }}
       {{- end }}
 
     [http]
       {{- range $key, $value := index .Values.config.http }}
-      {{ $key }} = {{ $value }}
+      {{ $key }} = {{ $value | quote }}
       {{- end }}
 
     # TODO: allow multiple graphite listeners
 
     [[graphite]]
       {{- range $key, $value := index .Values.config.graphite }}
-      {{ $key }} = {{ $value }}
+      {{ $key }} = {{ $value | quote }}
       {{- end }}
       {{- if .Values.config.graphite.templates }}
       templates = [
@@ -75,31 +75,31 @@ data:
 
     [[collectd]]
       {{- range $key, $value := index .Values.config.collectd }}
-      {{ $key }} = {{ $value }}
+      {{ $key }} = {{ $value | quote }}
       {{- end }}
 
     # TODO: allow multiple opentsdb listeners with templates
 
     [[opentsdb]]
       {{- range $key, $value := index .Values.config.opentsdb }}
-      {{ $key }} = {{ $value }}
+      {{ $key }} = {{ $value | quote }}
       {{- end }}
 
     # TODO: allow multiple udp listeners with templates
 
     [[udp]]
       {{- range $key, $value := index .Values.config.udp }}
-      {{ $key }} = {{ $value }}
+      {{ $key }} = {{ $value | quote }}
       {{- end }}
 
     [continuous_queries]
       {{- range $key, $value := index .Values.config.continuous_queries }}
-      {{ $key }} = {{ $value }}
+      {{ $key }} = {{ $value | quote }}
       {{- end }}
 
     [logging]
       {{- range $key, $value := index .Values.config.logging }}
-      {{ $key }} = {{ $value }}
+      {{ $key }} = {{ $value | quote }}
       {{- end }}
 
     {{ if .Values.enterprise.enabled -}}


### PR DESCRIPTION
Provided that int values can be quoted in the config, this fixes the issue where strings are not quoted in the rendered config.

e.g. the value:

```
config:
  http:
    max_row_limit: 0
  logging:
    format: json
```

renders in the configmap, prior to this commit:
```
    [http]
      max_row_limit = 0
[...]
    [logging]
      format = json
```

Which results in the following error: `run: parse config: Near line 43 (last key parsed 'logging.format'): expected value but found "json" instead`

While this commit renders:

```
    [http]
      max_row_limit = "0"
[...]
    [logging]
      format = "json"
```

which produces no error.