### PR TITLE
Adds missing quote

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.7.6
+version: 1.7.7
 appVersion: 1.13
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/_helpers.tpl
+++ b/charts/telegraf/templates/_helpers.tpl
@@ -215,7 +215,7 @@ Create chart name and version as used by the chart label.
             {{- range $k, $v := $value }}
               {{- $tps := typeOf $v }}
               {{- if eq $tps "string" }}
-        {{ $k }} = {{ $v }}
+        {{ $k }} = {{ $v | quote }}
               {{- end }}
               {{- if eq $tps "[]interface {}"}}
         {{ $k }} = [


### PR DESCRIPTION
The current implementation produces an invalid TOML when using tags in inputs. 

Example:
```yaml
- http_response:
    address: https://foobar.com/healthz
    tags:
      team: a-team
```

Produces:
```
[[inputs.http_response]]
    address = "https://foobar.com/healthz"
    [[inputs.http_response.tags]]
      team = a-team
```