### PR TITLE
fix(influxdb): pass boolean conf values as is to configmap

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.3.5
+version: 4.3.6
 appVersion: 1.7.10
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/configmap.yaml
+++ b/charts/influxdb/templates/configmap.yaml
@@ -12,7 +12,12 @@ data:
     [meta]
       dir = "/var/lib/influxdb/meta"
       {{- range $key, $value := index .Values.config.meta }}
+      {{- $tp := typeOf $value }}
+      {{- if eq $tp "string" }}
       {{ $key }} = {{ $value | quote }}
+      {{- else }}
+      {{ $key }} = {{ $value }}
+      {{- end  }}
       {{- end }}
 
       {{- if .Values.enterprise.enabled }}
@@ -24,44 +29,84 @@ data:
       dir = "/var/lib/influxdb/data"
       wal-dir = "/var/lib/influxdb/wal"
       {{- range $key, $value := index .Values.config.data }}
+      {{- $tp := typeOf $value }}
+      {{- if eq $tp "string" }}
       {{ $key }} = {{ $value | quote }}
+      {{- else }}
+      {{ $key }} = {{ $value }}
+      {{- end  }}
       {{- end }}
 
     [coordinator]
       {{- range $key, $value := index .Values.config.coordinator }}
+      {{- $tp := typeOf $value }}
+      {{- if eq $tp "string" }}
       {{ $key }} = {{ $value | quote }}
+      {{- else }}
+      {{ $key }} = {{ $value }}
+      {{- end  }}
       {{- end }}
 
     [retention]
       {{- range $key, $value := index .Values.config.retention }}
+      {{- $tp := typeOf $value }}
+      {{- if eq $tp "string" }}
       {{ $key }} = {{ $value | quote }}
+      {{- else }}
+      {{ $key }} = {{ $value }}
+      {{- end  }}
       {{- end }}
 
     [shard-precreation]
       {{- range $key, $value := index .Values.config.shard_precreation }}
+      {{- $tp := typeOf $value }}
+      {{- if eq $tp "string" }}
       {{ $key }} = {{ $value | quote }}
+      {{- else }}
+      {{ $key }} = {{ $value }}
+      {{- end  }}
       {{- end }}
 
     [monitor]
       {{- range $key, $value := index .Values.config.monitor }}
+      {{- $tp := typeOf $value }}
+      {{- if eq $tp "string" }}
       {{ $key }} = {{ $value | quote }}
+      {{- else }}
+      {{ $key }} = {{ $value }}
+      {{- end  }}
       {{- end }}
 
     [subscriber]
       {{- range $key, $value := index .Values.config.subscriber }}
+      {{- $tp := typeOf $value }}
+      {{- if eq $tp "string" }}
       {{ $key }} = {{ $value | quote }}
+      {{- else }}
+      {{ $key }} = {{ $value }}
+      {{- end  }}
       {{- end }}
 
     [http]
       {{- range $key, $value := index .Values.config.http }}
+      {{- $tp := typeOf $value }}
+      {{- if eq $tp "string" }}
       {{ $key }} = {{ $value | quote }}
+      {{- else }}
+      {{ $key }} = {{ $value }}
+      {{- end  }}
       {{- end }}
 
     # TODO: allow multiple graphite listeners
 
     [[graphite]]
       {{- range $key, $value := index .Values.config.graphite }}
+      {{- $tp := typeOf $value }}
+      {{- if eq $tp "string" }}
       {{ $key }} = {{ $value | quote }}
+      {{- else }}
+      {{ $key }} = {{ $value }}
+      {{- end  }}
       {{- end }}
       {{- if .Values.config.graphite.templates }}
       templates = [
@@ -75,31 +120,56 @@ data:
 
     [[collectd]]
       {{- range $key, $value := index .Values.config.collectd }}
+      {{- $tp := typeOf $value }}
+      {{- if eq $tp "string" }}
       {{ $key }} = {{ $value | quote }}
+      {{- else }}
+      {{ $key }} = {{ $value }}
+      {{- end  }}
       {{- end }}
 
     # TODO: allow multiple opentsdb listeners with templates
 
     [[opentsdb]]
       {{- range $key, $value := index .Values.config.opentsdb }}
+      {{- $tp := typeOf $value }}
+      {{- if eq $tp "string" }}
       {{ $key }} = {{ $value | quote }}
+      {{- else }}
+      {{ $key }} = {{ $value }}
+      {{- end  }}
       {{- end }}
 
     # TODO: allow multiple udp listeners with templates
 
     [[udp]]
       {{- range $key, $value := index .Values.config.udp }}
+      {{- $tp := typeOf $value }}
+      {{- if eq $tp "string" }}
       {{ $key }} = {{ $value | quote }}
+      {{- else }}
+      {{ $key }} = {{ $value }}
+      {{- end  }}
       {{- end }}
 
     [continuous_queries]
       {{- range $key, $value := index .Values.config.continuous_queries }}
+      {{- $tp := typeOf $value }}
+      {{- if eq $tp "string" }}
       {{ $key }} = {{ $value | quote }}
+      {{- else }}
+      {{ $key }} = {{ $value }}
+      {{- end  }}
       {{- end }}
 
     [logging]
       {{- range $key, $value := index .Values.config.logging }}
+      {{- $tp := typeOf $value }}
+      {{- if eq $tp "string" }}
       {{ $key }} = {{ $value | quote }}
+      {{- else }}
+      {{ $key }} = {{ $value }}
+      {{- end  }}
       {{- end }}
 
     {{ if .Values.enterprise.enabled -}}


### PR DESCRIPTION
My influxdb `config` object contains some boolean values which was causing this error to be thrown:
```sh
run: parse config: toml: cannot load TOML value of type string into a Go boolean
```

The influxdb configuration requires boolean values to not be quoted and strings to be quoted. With the type check update, a resulting config snippet as follows:
```toml
     [http]
       auth-enabled = true
       bind-address = ":8086"
       bind-socket = "/var/run/influxdb.sock"
       enabled = true
       flux-enabled = true
       https-certificate = "/etc/ssl/influxdb.pem"
       https-enabled = false
       log-enabled = true
```

Snippet of my values:
```yaml
config:
  logging:
    level: warn
  http:
    bind-address: :8086
    auth-enabled: true
    flux-enabled: true
    log-enabled: true
    write-tracing: false
    pprof-enabled: true
    https-enabled: false
    https-certificate: /etc/ssl/influxdb.pem
```

