### PR TITLE
chore: update README and use sensible workflow names

### DIFF
--- a/.github/workflows/helm-charts-release.yaml
+++ b/.github/workflows/helm-charts-release.yaml
@@ -1,4 +1,4 @@
-name: Release Helm Charts
+name: "helm-charts/release"
 
 on:
   push:

--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -1,4 +1,4 @@
-name: Test Helm Charts
+name: "helm-charts/test"
 
 on: pull_request
 

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -1,16 +1,16 @@
-name: Terraform Plan
+name: "terraform/apply"
 
 on:
-  pull_request:
-    branches:
-      - master
+  push:
     paths:
       - ".github/workflows/terraform.yaml"
       - "terraform/**"
+    branches:
+      - master
 
 jobs:
   terraform:
-    name: "Terraform Plan"
+    name: "Terraform Apply"
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
@@ -44,11 +44,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Terraform Plan"
+      - name: "Terraform Apply"
         uses: hashicorp/terraform-github-actions@master
         with:
           tf_actions_version: 0.12.20
-          tf_actions_subcommand: "plan"
+          tf_actions_subcommand: "apply"
           tf_actions_working_dir: "terraform"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -1,16 +1,16 @@
-name: Terraform Apply
+name: "terraform/plan"
 
 on:
-  push:
+  pull_request:
+    branches:
+      - master
     paths:
       - ".github/workflows/terraform.yaml"
       - "terraform/**"
-    branches:
-      - master
 
 jobs:
   terraform:
-    name: "Terraform Apply"
+    name: "Terraform Plan"
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
@@ -44,11 +44,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Terraform Apply"
+      - name: "Terraform Plan"
         uses: hashicorp/terraform-github-actions@master
         with:
           tf_actions_version: 0.12.20
-          tf_actions_subcommand: "apply"
+          tf_actions_subcommand: "plan"
           tf_actions_working_dir: "terraform"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # InfluxData Helm Charts
 
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
-[![](https://github.com/influxdata/helm-charts/workflows/Release%20Master/badge.svg?branch=master)](https://github.com/influxdata/helm-charts/actions)
+[![](https://github.com/influxdata/helm-charts/workflows/helm-charts%2Frelease/badge.svg?branch=master)](https://github.com/influxdata/helm-charts/actions)
 
 This functionality is in beta and is subject to change. The code is provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
 


### PR DESCRIPTION
Superficial change, but I broke the badge name in earlier commits and decided just to "codify" the workflow names