### PR TITLE
add scheme to influxDB healthcheck to serve HTTPS

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.4.1
+version: 4.4.2
 appVersion: 1.7.10
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/statefulset.yaml
+++ b/charts/influxdb/templates/statefulset.yaml
@@ -88,12 +88,14 @@ spec:
           httpGet:
             path: /ping
             port: api
+            scheme: {{ .Values.livenessProbe.scheme | default "HTTP" }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 30 }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds | default 5 }}
         readinessProbe:
           httpGet:
             path: /ping
             port: api
+            scheme: {{ .Values.readinessProbe.scheme | default "HTTP" }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 5 }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds | default 1 }}
         {{- if .Values.startupProbe.enabled }}
@@ -101,6 +103,7 @@ spec:
           httpGet:
             path: /ping
             port: api
+            scheme: {{ .Values.startupProbe.scheme | default "HTTP" }}
           failureThreshold: {{ .Values.startupProbe.failureThreshold | default 6 }}
           periodSeconds: {{ .Values.startupProbe.periodSeconds | default 5 }}
         {{- end }}

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -21,15 +21,18 @@ serviceAccount:
 livenessProbe: {}
   # initialDelaySeconds: 30
   # timeoutSeconds: 5
+  # scheme: HTTP
 
 readinessProbe: {}
   # initialDelaySeconds: 5
   # timeoutSeconds: 1
+  # scheme: HTTP
 
 startupProbe:
   enabled: false
   # failureThreshold: 6
   # periodSeconds: 5
+  # scheme: HTTP
 
 ## Specify a service type
 ## NodePort is default


### PR DESCRIPTION
When influxdb is serving HTTPS on API endpoint, the healthcheck probe will fail because it defaults to HTTP get instead of HTTPS, this merge request is to add an option in values.yml to setup HTTPS healthcheck if influxDB is serving HTTP requests.
