### PR TITLE
update deprecated deployment api version from extensions/v1beta1 to apps/v1

### DIFF
--- a/charts/kapacitor/Chart.yaml
+++ b/charts/kapacitor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kapacitor
-version: 1.2.7
+version: 1.2.8
 appVersion: 1.5.4
 description: InfluxDB's native data processing engine. It can process both stream
   and batch data from InfluxDB.

--- a/charts/kapacitor/templates/deployment.yaml
+++ b/charts/kapacitor/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $bl := empty .Values.influxURL }}
 {{- if not $bl }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kapacitor.fullname" . }}
@@ -11,6 +11,9 @@ metadata:
     app: {{ template "kapacitor.fullname" . }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "kapacitor.fullname" . }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
Kubernetes removed the api version extensions/v1beta1 of deployments with version 1.16 the new api version is apps/v1

```
apiVersion "extensions/v1beta1/Deployment" was removed in Kubernetes 1.16. Use "apps/v1/Deployment" instead.
See https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals for more information.
```

This PR updates the deployment specification of kapacitor to use the new api version.