### PR TITLE
Add telegraf-operator chart

### DIFF
--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -17,6 +17,7 @@ jobs:
         uses: helm/chart-testing-action@v1.0.0-rc.1
         with:
           command: lint
+          config: ct.yaml
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0-alpha.3

--- a/charts/telegraf-operator/.gitignore
+++ b/charts/telegraf-operator/.gitignore
@@ -1,0 +1,2 @@
+stub.yml
+test.yml

--- a/charts/telegraf-operator/.helmignore
+++ b/charts/telegraf-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/telegraf-operator/Chart.lock
+++ b/charts/telegraf-operator/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: cert-manager
-  repository: https://charts.jetstack.io
-  version: v0.14.2
-digest: sha256:1a7838b8f56a6d9dfde5e6a64ef0bf2cd1fd1db20c105471eaa78af4fd9ed342
-generated: "2020-04-22T15:24:20.379526+02:00"

--- a/charts/telegraf-operator/Chart.lock
+++ b/charts/telegraf-operator/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: cert-manager
+  repository: https://charts.jetstack.io
+  version: v0.14.2
+digest: sha256:1a7838b8f56a6d9dfde5e6a64ef0bf2cd1fd1db20c105471eaa78af4fd9ed342
+generated: "2020-04-22T15:24:20.379526+02:00"

--- a/charts/telegraf-operator/Chart.yaml
+++ b/charts/telegraf-operator/Chart.yaml
@@ -1,0 +1,44 @@
+apiVersion: v2
+name: telegraf-operator
+description: A Helm chart for Kubernetes to deploy telegraf-operator
+keywords:
+  - telegraf
+  - telegraf-operator
+  - sidecar
+  - operator
+  - injector
+  - mutatingwebhook
+  - influxdata
+  - influxdb
+
+maintainers:
+- name: gitirabassi
+  email: giacomo@influxdata.com
+- name: rawkode
+  email: rawkode@influxdata.com
+
+kubeVersion: ">= 1.13.0"
+home: https://github.com/influxdata/telegraf-operator
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: v1.0.6
+
+dependencies:
+- name: cert-manager
+  version: v0.14.2
+  repository: https://charts.jetstack.io
+  condition: certManager.chart.enable

--- a/charts/telegraf-operator/Chart.yaml
+++ b/charts/telegraf-operator/Chart.yaml
@@ -31,14 +31,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.0.6
-
-dependencies:
-- name: cert-manager
-  version: v0.14.2
-  repository: https://charts.jetstack.io
-  condition: certManager.chart.enable

--- a/charts/telegraf-operator/README.md
+++ b/charts/telegraf-operator/README.md
@@ -1,0 +1,25 @@
+# Telegraf-operator
+
+> Default installation expects cert-manager to be running in the cluster
+
+## Usage
+
+```console
+helm repo add influxdata https://helm.influxdata.com
+
+helm install telegraf-operator influxdata/telegraf-operator
+
+```
+
+## Contributing & Developing
+
+```shell
+helm template --namespace=telegraf-operator telegraf-operator .
+```
+
+Testing CI template
+```shell
+helm template --namespace=telegraf-operator --values=./ci/values.yaml telegraf-operator .
+```
+
+

--- a/charts/telegraf-operator/ci/test-values.yaml
+++ b/charts/telegraf-operator/ci/test-values.yaml
@@ -1,0 +1,50 @@
+replicaCount: 3
+image:
+  repository: quay.io/influxdb/telegraf-operator
+  pullPolicy: IfNotPresent
+  sidecarImage: "docker.io/library/telegraf:1.14.1"
+
+classes:
+  secretName: "telegraf-operator-classes"
+  default: "infra"
+  data:
+    infra: |
+      [[outputs.influxdb]]
+        urls = ["http://influxdb.influxdb:8086"]
+      [global_tags]
+        env = "ci"
+        hostname = "$HOSTNAME"
+        nodename = "$NODENAME"
+        type = "infra"
+
+certManager:
+  chart:
+    enable: false
+  certificate:
+    enable: false
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+serviceAccount:
+  # Annotations to add to the service account
+  annotations: {}
+podSecurityContext: {}
+  # fsGroup: 2000
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/telegraf-operator/templates/_helpers.tpl
+++ b/charts/telegraf-operator/templates/_helpers.tpl
@@ -1,0 +1,74 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "telegraf-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "telegraf-operator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "telegraf-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "telegraf-operator.labels" -}}
+helm.sh/chart: {{ include "telegraf-operator.chart" . }}
+{{ include "telegraf-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "telegraf-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "telegraf-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "telegraf-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "telegraf-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate certificates for telegraf-operator mutating webhook 
+*/}}
+{{- define "telegraf-operator.gen-certs" -}}
+{{- $altNames := list ( printf "%s.%s" (include "telegraf-operator.name" .) .Release.Namespace ) ( printf "%s.%s.svc" (include "telegraf-operator.name" .) .Release.Namespace ) -}}
+{{- $ca := genCA "telegraf-operator-ca" 365 -}}
+{{- $cert := genSignedCert ( include "telegraf-operator.name" . ) nil $altNames 365 $ca -}}
+tls.crt: {{ $cert.Cert | b64enc }}
+tls.key: {{ $cert.Key | b64enc }}
+{{- end -}}

--- a/charts/telegraf-operator/templates/certificate.yml
+++ b/charts/telegraf-operator/templates/certificate.yml
@@ -1,4 +1,4 @@
-{{- if .Values.certManager.certificate.enable -}}
+{{- if .Values.certManager.enable -}}
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:

--- a/charts/telegraf-operator/templates/certificate.yml
+++ b/charts/telegraf-operator/templates/certificate.yml
@@ -1,0 +1,18 @@
+{{- if .Values.certManager.certificate.enable -}}
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: {{ include "telegraf-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "telegraf-operator.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+  - "{{ include "telegraf-operator.fullname" . }}.{{ .Values.namespace }}.svc"
+  isCA: true
+  issuerRef:
+    kind: Issuer
+    name: telegraf-operator-issuer
+    namespace: {{ .Release.Namespace }}
+  secretName: telegraf-operator-tls
+{{- end -}}

--- a/charts/telegraf-operator/templates/clusterrole.yml
+++ b/charts/telegraf-operator/templates/clusterrole.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "telegraf-operator.labels" . | nindent 4 }}
+  name: {{ include "telegraf-operator.fullname" . }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - '*'

--- a/charts/telegraf-operator/templates/clusterrolebinding.yml
+++ b/charts/telegraf-operator/templates/clusterrolebinding.yml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "telegraf-operator.labels" . | nindent 4 }}
+  name: {{ include "telegraf-operator.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "telegraf-operator.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "telegraf-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/telegraf-operator/templates/deployment.yaml
+++ b/charts/telegraf-operator/templates/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "telegraf-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "telegraf-operator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "telegraf-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "telegraf-operator.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--telegraf-default-class={{ .Values.classes.default }}"
+            - --telegraf-classes-directory=/etc/telegraf-operator
+            - --enable-default-internal-plugin
+            - "--telegraf-image={{ .Values.image.sidecarImage }}"
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          ports:
+            - name: https
+              containerPort: 9443
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /etc/certs
+              name: certs
+              readOnly: true
+            - mountPath: /etc/telegraf-operator
+              name: classes
+              readOnly: true
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "telegraf-operator.fullname" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+      - name: certs
+        secret:
+          secretName: telegraf-operator-tls
+      - name: classes
+        secret:
+          secretName: {{ .Values.classes.secretName }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/telegraf-operator/templates/issuer.yml
+++ b/charts/telegraf-operator/templates/issuer.yml
@@ -1,4 +1,4 @@
-{{- if .Values.certManager.certificate.enable -}}
+{{- if .Values.certManager.enable -}}
 apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:

--- a/charts/telegraf-operator/templates/issuer.yml
+++ b/charts/telegraf-operator/templates/issuer.yml
@@ -1,0 +1,11 @@
+{{- if .Values.certManager.certificate.enable -}}
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: telegraf-operator-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "telegraf-operator.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+{{- end -}}

--- a/charts/telegraf-operator/templates/mutatingwebhookconfiguration.yml
+++ b/charts/telegraf-operator/templates/mutatingwebhookconfiguration.yml
@@ -1,0 +1,26 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/{{ include "telegraf-operator.fullname" . }}"
+  labels:
+    {{- include "telegraf-operator.labels" . | nindent 4 }}
+  name: {{ include "telegraf-operator.fullname" . }}
+webhooks:
+- clientConfig:
+    service:
+      name: {{ include "telegraf-operator.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-v1-pod
+  failurePolicy: Ignore
+  name: telegraf.influxdata.com
+  rules:
+  - apiGroups:
+    - '*'
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - DELETE
+    resources:
+    - pods

--- a/charts/telegraf-operator/templates/pdb.yml
+++ b/charts/telegraf-operator/templates/pdb.yml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "telegraf-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "telegraf-operator.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      {{- include "telegraf-operator.labels" . | nindent 6 }}

--- a/charts/telegraf-operator/templates/secret-classes.yml
+++ b/charts/telegraf-operator/templates/secret-classes.yml
@@ -1,0 +1,23 @@
+{{- if .Values.classes.data }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.classes.secretName }}
+  namespace: {{ .Release.Namespace }}
+stringData: {{ .Values.classes.data | toYaml | nindent 2 }}
+{{- end }}
+---
+{{- if eq .Values.certManager.certificate.enable false -}}
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: telegraf-operator-tls
+  labels:
+    {{- include "telegraf-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+data:
+{{ ( include "telegraf-operator.gen-certs" . ) | indent 2 }}
+{{- end }}

--- a/charts/telegraf-operator/templates/secret-classes.yml
+++ b/charts/telegraf-operator/templates/secret-classes.yml
@@ -7,7 +7,7 @@ metadata:
 stringData: {{ .Values.classes.data | toYaml | nindent 2 }}
 {{- end }}
 ---
-{{- if eq .Values.certManager.certificate.enable false -}}
+{{- if eq .Values.certManager.enable false -}}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls

--- a/charts/telegraf-operator/templates/service.yaml
+++ b/charts/telegraf-operator/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "telegraf-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "telegraf-operator.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    {{- include "telegraf-operator.selectorLabels" . | nindent 4 }}

--- a/charts/telegraf-operator/templates/serviceaccount.yaml
+++ b/charts/telegraf-operator/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "telegraf-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "telegraf-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+

--- a/charts/telegraf-operator/values.yaml
+++ b/charts/telegraf-operator/values.yaml
@@ -1,0 +1,42 @@
+replicaCount: 3
+image:
+  repository: quay.io/influxdb/telegraf-operator
+  pullPolicy: IfNotPresent
+  sidecarImage: "docker.io/library/telegraf:1.14.1"
+
+classes:
+  secretName: "telegraf-operator-classes"
+  default: "infra"
+  data: {}
+
+certManager:
+  chart:
+    enable: false
+  certificate:
+    enable: true
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+serviceAccount:
+  # Annotations to add to the service account
+  annotations: {}
+podSecurityContext: {}
+  # fsGroup: 2000
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/telegraf-operator/values.yaml
+++ b/charts/telegraf-operator/values.yaml
@@ -10,10 +10,7 @@ classes:
   data: {}
 
 certManager:
-  chart:
-    enable: false
-  certificate:
-    enable: true
+  enable: false
 
 imagePullSecrets: []
 nameOverride: ""

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,7 @@
+remote: origin
+target-branch: master
+chart-dirs:
+  - charts
+chart-repos:
+  - "jetstack=https://charts.jetstack.io"
+debug: true


### PR DESCRIPTION
Closes https://github.com/influxdata/telegraf-operator/issues/7

This will need https://github.com/influxdata/telegraf-operator/milestone/2 to be completed

I need helm configuring this to be proper helm etiquette

What is the proper way of adding a secret with helm? @naseemkullah 

I'm thinking of adding `influxdb` as a dependency and then adding the secret to send telegraf data to influxdb instance. 

This can't be done with influxdbV2 because of all the initialization and token distribution