### PR TITLE
Adds optional securityContext config

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.4.4
+version: 4.4.5
 appVersion: 1.7.10
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/README.md
+++ b/charts/influxdb/README.md
@@ -75,6 +75,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | nodeSelector | Node labels for pod assignment | {} |
 | affinity | [Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for pod assignment |  {|
 | tolerations | [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) for pod assignment | [] |
+| securityContext | [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for pod | {} |
 | env | environment variables for influxdb container | {} |
 | config.reporting_disabled | [Details](https://docs.influxdata.com/influxdb/v1.7/administration/config/#reporting-disabled-false) | false |
 | config.rpc | RPC address for backup and storage | {} |

--- a/charts/influxdb/templates/statefulset.yaml
+++ b/charts/influxdb/templates/statefulset.yaml
@@ -38,6 +38,10 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -28,6 +28,10 @@ readinessProbe: {}
   # timeoutSeconds: 1
   # scheme: HTTP
 
+securityContext: {}
+  # runAsUser: 999
+  # runAsGroup: 999
+
 startupProbe:
   enabled: false
   # failureThreshold: 6


### PR DESCRIPTION
Allows chart to be run as non-root user. This is required in environments where pod security policies prohibit running containers as root.