### PR TITLE
Kapacitor sideloads

### DIFF
--- a/charts/kapacitor/Chart.yaml
+++ b/charts/kapacitor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kapacitor
-version: 1.2.10
+version: 1.3.0
 appVersion: 1.5.4
 description: InfluxDB's native data processing engine. It can process both stream
   and batch data from InfluxDB.

--- a/charts/kapacitor/README.md
+++ b/charts/kapacitor/README.md
@@ -66,6 +66,20 @@ The following table lists the configurable parameters of the Kapacitor chart and
 | `envVars` | Environment variables to set initial Kapacitor configuration (https://hub.docker.com/_/kapacitor/) | `{}` |
 | `influxURL` | InfluxDB url used to interact with Kapacitor (also can be set with ```envVars.KAPACITOR_INFLUXDB_0_URLS_0```) | `http://influxdb-influxdb.tick:8086` |
 | `existingSecret` | Name of an existing Secrect used to set the environment variables for the InfluxDB user and password. The expected keys in the secret are `influxdb-user` and `influxdb-password`. |
+| `rbac.create` | Create and use RBAC resources | `true` |
+| `rbac.namespaced` | Creates Role and Rolebinding instead of the default ClusterRole and ClusteRoleBindings for the Kapacitor instance  | `false` |
+| `serviceAccount.annotations` | ServiceAccount annotations | `{}` |
+| `serviceAccount.create` | Create service account | `true` |
+| `serviceAccount.name` | Service account name to use, when empty will be set to created account if `serviceAccount.create` is set else to `default` | `` |
+| `sidecar.image` | Sidecar image | `kiwigrid/k8s-sidecar:0.1.116` |
+| `sidecar.imagePullPolicy` | Sidecar image pull policy | `IfNotPresent` |
+| `sidecar.resources` | Sidecar resources | `{}` |
+| `sidecar.skipTlsVerify` | Set to true to skip tls verification for kube api calls | `nil` |
+| `sidecar.sideload.enabled` | Enables the search for sideloads and adds/updates/deletes them in Kapacitor | `false` |
+| `sidecar.sideload.label` | Label that configmaps with sideloads should have to be added | `kapacitor_sideload` |
+| `sidecar.sideload.searchNamespace` | If specified, the sidecar will search for sideload configmaps inside this namespace. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify ALL to search in all namespaces | `nil` |
+| `sidecar.sideload.folder` | Folder in the pod that should hold the collected sideloads. This path will be mounted. | `/var/lib/kapacitor/sideload` |
+| `namespaceOverride` | Override the deployment namespace | `""` (`Release.Namespace`) |
 
 The configurable parameters of the Kapacitor chart and the default values are listed in `values.yaml`.
 
@@ -94,3 +108,24 @@ helm upgrade --install my-release -f values.yaml influxdata/kapacitor
 The [Kapacitor](https://hub.docker.com/_/kapacitor/) image stores data in the `/var/lib/kapacitor` directory in the container.
 
 The chart optionally mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning.
+
+## Sidecar for sideloads
+
+If the parameter `sidecar.sideload.enabled` is set, a sidecar container is deployed in the Kapacitor
+pod. This container watches all configmaps in the cluster and filters out the ones with
+a label as defined in `sidecar.sideload.label`. The files defined in those configmaps are written
+to a folder and can be accessed by TICKscripts. Changes to the configmaps are monitored and the files
+are deleted/updated.
+
+Example sideload config:
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kapacitor-sideload-influxdb-httpd-clienterror
+  labels:
+    kapacitor_sideload: "1"
+data:
+  influxdb-httpd-clienterror.yml: |
+    [...]
+```

--- a/charts/kapacitor/templates/_helpers.tpl
+++ b/charts/kapacitor/templates/_helpers.tpl
@@ -14,3 +14,25 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account
+*/}}
+{{- define "kapacitor.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "kapacitor.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "kapacitor.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/kapacitor/templates/clusterrole.yaml
+++ b/charts/kapacitor/templates/clusterrole.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.rbac.create (not .Values.rbac.namespaced) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "kapacitor.fullname" . }}-clusterrole
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    app: {{ template "kapacitor.fullname" . }}
+{{- if .Values.sidecar.sideload.enabled }}
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "watch", "list"]
+{{- else }}
+rules: []
+{{- end}}
+{{- end}}

--- a/charts/kapacitor/templates/clusterrolebinding.yaml
+++ b/charts/kapacitor/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.rbac.create (not .Values.rbac.namespaced) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "kapacitor.fullname" . }}-clusterrolebinding
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    app: {{ template "kapacitor.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kapacitor.serviceAccountName" . }}
+    namespace: {{ template "kapacitor.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "kapacitor.fullname" . }}-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/kapacitor/templates/deployment.yaml
+++ b/charts/kapacitor/templates/deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kapacitor.fullname" . }}
+  namespace: {{ template "kapacitor.namespace" . }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
@@ -19,6 +20,7 @@ spec:
       labels:
         app: {{ template "kapacitor.fullname" . }}
     spec:
+      serviceAccountName: {{ template "kapacitor.serviceAccountName" . }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -49,8 +51,43 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /var/lib/kapacitor
+{{- if .Values.sidecar.sideload.enabled }}
+        - name: sc-sideload-volume
+          mountPath: {{ .Values.sidecar.sideload.folder | quote }}
+{{- end}}
         resources:
 {{ toYaml .Values.resources | indent 12 }}
+{{- if .Values.sidecar.sideload.enabled }}
+      - name: {{ .Chart.Name }}-sc-sideload
+        image: "{{ .Values.sidecar.image }}"
+        imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+        env:
+        - name: METHOD
+          value: WATCH
+        - name: LABEL
+          value: "{{ .Values.sidecar.sideload.label }}"
+        - name: FOLDER
+          value: "/var/lib/kapacitor/sideload"
+        - name: RESOURCE
+          value: "configmap"
+        {{- if .Values.sidecar.sideload.searchNamespace }}
+        - name: NAMESPACE
+          value: "{{ .Values.sidecar.sideload.searchNamespace }}"
+        {{- end }}
+        {{- if .Values.sidecar.skipTlsVerify }}
+        - name: SKIP_TLS_VERIFY
+          value: "{{ .Values.sidecar.skipTlsVerify }}"
+        {{- end }}
+        - name: REQ_METHOD
+          value: POST
+        - name: REQ_URL
+          value: "http://localhost:9092/kapacitor/v1/sideload/reload"
+        resources:
+{{ toYaml .Values.sidecar.resources | indent 12 }}
+        volumeMounts:
+          - name: sc-sideload-volume
+            mountPath: "/var/lib/kapacitor/sideload"
+{{- end }}
       volumes:
         - name: data
         {{- if .Values.persistence.enabled }}
@@ -59,4 +96,8 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end }}
+      {{- if .Values.sidecar.sideload.enabled }}
+        - name: sc-sideload-volume
+          emptyDir: {}
+      {{- end -}}
 {{- end }}

--- a/charts/kapacitor/templates/role.yaml
+++ b/charts/kapacitor/templates/role.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.rbac.create .Values.rbac.namespaced -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "kapacitor.fullname" . }}
+  namespace: {{ template "kapacitor.namespace" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    app: {{ template "kapacitor.fullname" . }}
+{{- if .Values.sidecar.sideload.enabled }}
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "watch", "list"]
+{{- else }}
+rules: []
+{{- end }}
+{{- end }}

--- a/charts/kapacitor/templates/rolebinding.yaml
+++ b/charts/kapacitor/templates/rolebinding.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.rbac.create .Values.rbac.namespaced -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ template "kapacitor.fullname" . }}
+  namespace: {{ template "kapacitor.namespace" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    app: {{ template "kapacitor.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "kapacitor.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "kapacitor.serviceAccountName" . }}
+  namespace: {{ template "kapacitor.namespace" . }}
+roleRef:
+  kind: Role
+  name: {{ template "kapacitor.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/kapacitor/templates/serviceaccount.yaml
+++ b/charts/kapacitor/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "kapacitor.serviceAccountName" . }}
+  namespace: {{ template "kapacitor.namespace" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    app: {{ template "kapacitor.fullname" . }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end -}}

--- a/charts/kapacitor/values.yaml
+++ b/charts/kapacitor/values.yaml
@@ -67,7 +67,7 @@ resources:
 ##
 # existingSecret: influxdb-auth
 
-## Role based access role
+## Role based access control
 rbac:
   create: true
   namespaced: false
@@ -78,7 +78,7 @@ serviceAccount:
   create: true
   name:
 
-## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
+## Sidecars that collect the configmaps with specified label and stores the included files into the respective folders
 sidecar:
   image: kiwigrid/k8s-sidecar:0.1.116
   imagePullPolicy: IfNotPresent

--- a/charts/kapacitor/values.yaml
+++ b/charts/kapacitor/values.yaml
@@ -66,3 +66,36 @@ resources:
 ## `influxdb-user` and `influxdb-password`.
 ##
 # existingSecret: influxdb-auth
+
+## Role based access role
+rbac:
+  create: true
+  namespaced: false
+
+## Service account
+serviceAccount:
+  annotations: {}
+  create: true
+  name:
+
+## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
+sidecar:
+  image: kiwigrid/k8s-sidecar:0.1.116
+  imagePullPolicy: IfNotPresent
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 100Mi
+    # requests:
+    #   cpu: 50m
+    #   memory: 50Mi
+  ## skipTlsVerify Set to true to skip tls verification for kube api calls
+  # skipTlsVerify: true
+  sideload:
+    enabled: false
+    label: kapacitor_sideload
+    searchNamespace: null
+    folder: /var/lib/kapacitor/sideload
+
+## Override the deployment namespace
+namespaceOverride: ""


### PR DESCRIPTION
This PR will allow to load sideload files from config maps. The sideload files will be be placed in /var/lib/kapacitor/sideload by default but is customizable through `sidecar.sideload.folder`.
Please see the updated Readme for all new available values.

This change is based on the functionality to load dashboards in the grafana chart (https://github.com/helm/charts/tree/master/stable/grafana)

Example config map:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: kapacitor-sideload-influxdb-httpd-clienterror
  labels:
    kapacitor_sideload: "1"
data:
  influxdb-httpd-clienterror.yml: |
    [...]
```

Please let me know what you think about this. Since I'm pretty new to Kapacitor I'm open to shape this to additional needs that I'm currently not aware of.