### PR TITLE
Remove duplication of key config.graphite.templates

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.4.5
+version: 4.4.6
 appVersion: 1.7.10
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/configmap.yaml
+++ b/charts/influxdb/templates/configmap.yaml
@@ -101,12 +101,14 @@ data:
 
     [[graphite]]
       {{- range $key, $value := index .Values.config.graphite }}
+      {{- if ne $key "templates"}}
       {{- $tp := typeOf $value }}
       {{- if eq $tp "string" }}
       {{ $key }} = {{ $value | quote }}
       {{- else }}
       {{ $key }} = {{ $value }}
       {{- end  }}
+      {{- end }}
       {{- end }}
       {{- if .Values.config.graphite.templates }}
       templates = [


### PR DESCRIPTION
When using the key config.graphite.templates, it's being rendered twice. The first format is broken and it's preventing influxdb from starting:

>    [[graphite]]
      database = "app_metrics"
      enabled = true
      retention_policy = "month"
      separator = "_"
      templates = [*.micro.service.record host.measurement.app..action.test.testField *.micro.service.record host.measurement.app2..action.test.testField2 *.micro.service.record host.measurement.app3..action.test.testField3]
      templates = [
          "*.micro.service.record host.measurement.app..action.test.testField",
          "*.micro.service.record host.measurement.app2..action.test.testField2",
          "*.micro.service.record host.measurement.app3..action.test.testField3",
      ]

This PR is fixing the issue. 