### PR TITLE
chore: allows for overridable ingress path

### DIFF
--- a/charts/chronograf/Chart.yaml
+++ b/charts/chronograf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: chronograf
-version: 1.1.10
+version: 1.1.11
 appVersion: 1.8.0
 description: Open-source web application written in Go and React.js that provides
   the tools to visualize your monitoring data and easily create alerting and automation

--- a/charts/chronograf/templates/ingress.yaml
+++ b/charts/chronograf/templates/ingress.yaml
@@ -21,7 +21,7 @@ spec:
   - host: {{ .Values.ingress.hostname }}
     http:
       paths:
-      - path: /
+      - path: {{ .Values.ingress.path }}
         backend:
           serviceName: {{ template "chronograf.fullname" . }}
           servicePort: 80

--- a/charts/chronograf/values.yaml
+++ b/charts/chronograf/values.yaml
@@ -66,6 +66,7 @@ ingress:
     # kubernetes.io/ingress.class: "nginx"
     # secretName: my-tls-cert
     # kubernetes.io/tls-acme: "true"
+  path: /
 
 ## OAuth Settings for OAuth Providers
 ## More information -> https://github.com/influxdata/chronograf/blob/master/docs/auth.md

--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.4.7
+version: 4.4.8
 appVersion: 1.7.10
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/ingress.yaml
+++ b/charts/influxdb/templates/ingress.yaml
@@ -18,7 +18,7 @@ spec:
   - host: {{ .Values.ingress.hostname }}
     http:
       paths:
-      - path: /
+      - path: {{ .Values.ingress.path }}
         backend:
           serviceName: {{ include "influxdb.fullname" . }}
           servicePort: 8086

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -164,6 +164,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: "nginx"
     # kubernetes.io/tls-acme: "true"
+  path: /
 
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/


### PR DESCRIPTION
Modifies ingress path for chronograf and influxdb charts
Makes ingress path a template variable
Moves default path to values config
Bumps chart versions
Resolves: https://github.com/influxdata/helm-charts/issues/45