### PR TITLE
fix deprecation of ingress api version

### DIFF
--- a/charts/chronograf/Chart.yaml
+++ b/charts/chronograf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: chronograf
-version: 1.1.10
+version: 1.1.11
 appVersion: 1.8.0
 description: Open-source web application written in Go and React.js that provides
   the tools to visualize your monitoring data and easily create alerting and automation

--- a/charts/chronograf/templates/ingress.yaml
+++ b/charts/chronograf/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "chronograf.fullname" . }}


### PR DESCRIPTION
The api version of `extensions/v1beta1` for the `ingress` kind is deprecated:

> warning: extensions/v1beta1/Ingress is deprecated by networking/v1beta1/Ingress and not supported by Kubernetes v1.20+ clusters.

This PR will update the api version to `networking.k8s.io/v1beta1`