### PR TITLE
[telegraf-ds] add net input plugin to have node network metrics

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.0.7
+version: 1.0.8
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/README.md
+++ b/charts/telegraf-ds/README.md
@@ -75,6 +75,7 @@ This chart deploys the following by default:
   * [`kernel`](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/kernel)
   * [`kubernetes`](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/kubernetes)
   * [`mem`](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mem)
+  * [`net`](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/net)
   * [`processes`](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/processes)
   * [`swap`](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/swap)
   * [`system`](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/system)

--- a/charts/telegraf-ds/templates/configmap.yaml
+++ b/charts/telegraf-ds/templates/configmap.yaml
@@ -18,6 +18,7 @@ data:
     [[inputs.diskio]]
     [[inputs.kernel]]
     [[inputs.mem]]
+    [[inputs.net]]
     [[inputs.processes]]
     [[inputs.swap]]
     [[inputs.system]]


### PR DESCRIPTION
All network metrics are not necessary in `kubernetes_nodes.network*` so adding `inputs.net` is required to have node network metrics.