### PR TITLE
feat: add ability to provide volumes and mountPoints

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.7.13
+version: 1.7.14
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -35,9 +35,12 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/telegraf
-        {{- range .Values.volumeMounts}}
+        {{- range .Values.volumeMounts }}
         - name: {{ .name }}
           mountPath: {{ .mountPath }}
+        {{- end }}
+        {{- if .Values.mountPoints }}
+{{ toYaml .Values.mountPoints | indent 8 }}
         {{- end }}
         {{- if .Values.hooks }}
         {{- if or (.Values.hooks.postStart) (.Values.hooks.preStop) }}
@@ -87,6 +90,6 @@ spec:
       - name: config
         configMap:
           name: {{ include "telegraf.fullname" . }}
-      {{- if .Values.volumeMounts }}
-{{ toYaml .Values.volumeMounts | indent 6 }}
-      {{- end}}
+      {{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 6 }}
+      {{- end }}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -17,6 +17,19 @@ env:
   - name: HOSTNAME
     value: "telegraf-polling-service"
 
+# An older "volumeMounts" key was previously added which will likely
+# NOT WORK as you expect. Please use this newer configuration.
+
+# volumes:
+# - name: telegraf-output-influxdb2
+#   configMap:
+#     name: "telegraf-output-influxdb2"
+# mountPoints:
+# - name: telegraf-output-influxdb2
+#   mountPath: /etc/telegraf/conf.d
+#   subPath: influxdb2.conf
+
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 resources: {}


### PR DESCRIPTION
Previously, support was added for this with the `volumeMounts` key. I've opted not to modify this and instead provide a more flexible solution through `volumes` and `mountPoints` keys.

We'll aim to deprecate the older method in a future release.