### PR TITLE
feat: add extra volume mounting functionality to influxdb chart

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.4.8
+version: 4.4.9
 appVersion: 1.7.10
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/README.md
+++ b/charts/influxdb/README.md
@@ -77,6 +77,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | tolerations | [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) for pod assignment | [] |
 | securityContext | [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for pod | {} |
 | env | environment variables for influxdb container | {} |
+| volumes | `volumes` stanza(s) to be used in the main container | nil |
+| mountPoints | `volumeMount` stanza(s) to be used in the main container | nil |
 | config.reporting_disabled | [Details](https://docs.influxdata.com/influxdb/v1.7/administration/config/#reporting-disabled-false) | false |
 | config.rpc | RPC address for backup and storage | {} |
 | config.meta | [Details](https://docs.influxdata.com/influxdb/v1.7/administration/config/#meta) | {} |
@@ -250,6 +252,22 @@ spec:
 
 At which point the data from the new `<db name>_bak` dbs would have to be side loaded into the original dbs.
 Please see [InfluxDB documentation for more restore examples](https://docs.influxdata.com/influxdb/v1.7/administration/backup_and_restore/#restore-examples).
+
+## Mounting extra volumes
+
+Extra volumes can be mounted by providing the `volumes` and `mountPoints` keys, consistent
+with the behavior of other charts provided by Influxdata.
+
+```yaml
+volumes:
+  - name: ssl-cert-volume
+    secret:
+      secretName: secret-name
+mountPoints:
+  - name: ssl-cert-volume
+    mountPath: /etc/ssl/certs/selfsigned/
+    readOnly: true
+```
 
 ## Upgrading
 

--- a/charts/influxdb/templates/statefulset.yaml
+++ b/charts/influxdb/templates/statefulset.yaml
@@ -121,6 +121,9 @@ spec:
         - name: init
           mountPath: /docker-entrypoint-initdb.d
         {{- end }}
+        {{- if .Values.mountPoints }}
+{{ toYaml .Values.mountPoints | indent 8 }}
+        {{- end }}
       volumes:
       - name: config
         configMap:
@@ -139,6 +142,9 @@ spec:
       - name: {{ include "influxdb.fullname" . }}-data
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim }}
+      {{- end }}
+      {{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 6 }}
       {{- end }}
   # Must use volume claim template in enterprise mode
   {{- if and .Values.persistence.enabled (or (not .Values.persistence.existingClaim) .Values.enterprise.enabled) }}

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -166,6 +166,17 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   path: /
 
+
+## Add custom volume and volumeMounts
+# volumes:
+#   - name: ssl-cert-volume
+#     secret:
+#       secretName: secret-name
+# mountPoints:
+#   - name: ssl-cert-volume
+#     mountPath: /etc/ssl/certs/selfsigned/
+#     readOnly: true
+
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##


### PR DESCRIPTION
This PR adds the functionality to mount extra volumes to the main `influxdb` container.

CC @rawkode

- Follows the conventions laid out in #88 
- Closes #89 