### PR TITLE
Fix resources indentation

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -3,5 +3,6 @@ appVersion: 2.0.0-beta
 
 name: influxdb2
 description: A Helm chart for InfluxDB v2
+home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
 version: 1.0.3

--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -11,7 +11,3 @@ maintainers:
   email: rawkode@influxdata.com
 - name: gitirabassi
   email: giacomo@influxdata.com
-- name: aisuko
-  email: urakiny@gmail.com
-- name: naseemkullah
-  email: naseem@transit.app

--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -4,4 +4,4 @@ appVersion: 2.0.0-beta
 name: influxdb2
 description: A Helm chart for InfluxDB v2
 type: application
-version: 1.0.2
+version: 1.0.3

--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -6,3 +6,12 @@ description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
 version: 1.0.3
+maintainers:
+- name: rawkode
+  email: rawkode@influxdata.com
+- name: gitirabassi
+  email: giacomo@influxdata.com
+- name: aisuko
+  email: urakiny@gmail.com
+- name: naseemkullah
+  email: naseem@transit.app

--- a/charts/influxdb2/templates/statefulset.yaml
+++ b/charts/influxdb2/templates/statefulset.yaml
@@ -48,7 +48,7 @@ spec:
           - name: data
             mountPath: /root/.influxdbv2
           resources:
-            {{ toYaml .Values.resources | indent 12 }}
+            {{ .Values.resources | toYaml | nindent 12 | trim }}
 
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
Overriding the `resources` section using a simple `values.yaml` fails due to wrong indentation of the resulting yaml.

Specifying this `values.yaml`:
```
resources:
  limits:
    cpu: 100m
    memory: 128Mi
  requests:
    cpu: 100m
    memory: 128Mi
```
with
```
helm template -f values.yaml influxdata/influxdb2 --debug
```
results in
```
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: influxdb2
      app.kubernetes.io/instance: RELEASE-NAME
  serviceName: "RELEASE-NAME-influxdb2"
  template:
    metadata:
      labels:
        app.kubernetes.io/name: influxdb2
        app.kubernetes.io/instance: RELEASE-NAME
    spec:
      volumes:
        - name: data
          persistentVolumeClaim:
            claimName: RELEASE-NAME-influxdb2
      containers:
        - name: influxdb2
          image: "quay.io/influxdb/influxdb:2.0.0-beta"
          imagePullPolicy: IfNotPresent
          ports:
            - name: http
              containerPort: 9999
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /health
              port: http
          readinessProbe:
            httpGet:
              path: /health
              port: http
          volumeMounts:
          - name: data
            mountPath: /root/.influxdbv2
          resources:
                        limits:
              cpu: 100m
              memory: 128Mi
            requests:
              cpu: 100m
              memory: 128Mi
```
This PR fixes the indentation issue with the `resources` section, as you can see `limits` is not correctly indented.