### PR TITLE
feat: add option to use PVC for backups -- thanks monotek

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.4.11
+version: 4.5.0
 appVersion: 1.7.10
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/README.md
+++ b/charts/influxdb/README.md
@@ -104,6 +104,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | backup.schedule | Schedule to run jobs in cron format | `0 0 * * *` |
 | backup.annotations | Annotations for backup cronjob | {} |
 | backup.podAnnotations | Annotations for backup cronjob pods | {} |
+| backup.persistence.enabled | Boolean to enable and disable persistance | false |
+| backup.persistence.storageClass | If set to "-", storageClassName: "", which disables dynamic provisioning. If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.  (gp2 on AWS, standard on GKE, AWS & OpenStack |  |
+| backup.persistence.annotations | Annotations for volumeClaimTemplates | nil |
+| backup.persistence.accessMode | Access mode for the volume | ReadWriteOnce |
+| backup.persistence.size | Storage size | 8Gi |
 
 The [full image documentation](https://hub.docker.com/_/influxdb/) contains more information about running InfluxDB in docker.
 

--- a/charts/influxdb/README.md
+++ b/charts/influxdb/README.md
@@ -109,6 +109,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | backup.persistence.annotations | Annotations for volumeClaimTemplates | nil |
 | backup.persistence.accessMode | Access mode for the volume | ReadWriteOnce |
 | backup.persistence.size | Storage size | 8Gi |
+| backup.resources | Resources requests and limits for `backup` pods | `ephemeral-storage: 8Gi` |
 
 The [full image documentation](https://hub.docker.com/_/influxdb/) contains more information about running InfluxDB in docker.
 
@@ -192,6 +193,18 @@ When enabled, the[`backup-cronjob`](./templates/backup-cronjob.yaml) runs on the
 ```sh
 kubectl create job --from=cronjobs/influxdb-backup influx-backup-$(date +%Y%m%d%H%M%S)
 ```
+
+#### Backup Storage
+
+The backup process consists of an init-container that writes the backup to a
+local volume, which is by default an `emptyDir`, shared to the runtime container
+which uploads the backup to the configured object store.
+
+In order to avoid filling the node's disk space, it is recommended to set a sufficient
+`ephemeral-storage` request or enable persistence, which allocates a PVC.
+
+Furthermore, if no object store provider is available, one can simply use the
+PVC as the final storage destination when `persistence` is enabled.
 
 ### Restores
 

--- a/charts/influxdb/templates/backup-cronjob.yaml
+++ b/charts/influxdb/templates/backup-cronjob.yaml
@@ -50,7 +50,9 @@ spec:
             args:
             - '-c'
             - |
-              influxd backup -host {{ include "influxdb.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.config.rpc.bind_address | default 8088 }} -portable /backup/$(date +%Y%m%d%H%M%S)
+              influxd backup \
+                -host {{ include "influxdb.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.config.rpc.bind_address | default 8088 }} \
+                -portable /backup/"$(date +%Y%m%d%H%M%S)"
           containers:
           {{- if .Values.backup.gcs }}
           - name: gsutil-cp

--- a/charts/influxdb/templates/backup-cronjob.yaml
+++ b/charts/influxdb/templates/backup-cronjob.yaml
@@ -25,7 +25,12 @@ spec:
           restartPolicy: OnFailure
           volumes:
           - name: backup
+          {{- if .Values.backup.persistence.enabled }}
+            persistentVolumeClaim:
+              claimName: {{ include "influxdb.fullname" . }}-backup
+          {{- else }}
             emptyDir: {}
+          {{- end }}
           {{- if .Values.backup.gcs }}
           {{- if .Values.backup.gcs.serviceAccountSecret }}
           - name: google-cloud-key

--- a/charts/influxdb/templates/backup-cronjob.yaml
+++ b/charts/influxdb/templates/backup-cronjob.yaml
@@ -53,6 +53,8 @@ spec:
               influxd backup \
                 -host {{ include "influxdb.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.config.rpc.bind_address | default 8088 }} \
                 -portable /backup/"$(date +%Y%m%d%H%M%S)"
+            resources:
+              {{- toYaml .Values.backup.resources | nindent 14 }}
           containers:
           {{- if .Values.backup.gcs }}
           - name: gsutil-cp
@@ -80,6 +82,8 @@ spec:
               - name: KEY_FILE
                 value: /var/secrets/google/{{ .Values.backup.gcs.serviceAccountSecretKey }}
               {{- end }}
+            resources:
+              {{- toYaml .Values.backup.resources | nindent 14 }}
           {{- end }}
           {{- if .Values.backup.azure }}
           - name: azure-cli
@@ -106,5 +110,7 @@ spec:
                   secretKeyRef:
                     name: {{ .Values.backup.azure.storageAccountSecret }}
                     key: connection-string
+            resources:
+              {{- toYaml .Values.backup.resources | nindent 14 }}
           {{- end }}
 {{- end }}

--- a/charts/influxdb/templates/backup-pvc.yaml
+++ b/charts/influxdb/templates/backup-pvc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.backup.enabled .Values.persistence.backup.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "influxdb.fullname" . }}-backup
+  labels:
+    {{- include "influxdb.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.backup.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.backup.persistence.size | quote }}
+{{- if .Values.backup.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.backup.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.backup.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/influxdb/templates/backup-pvc.yaml
+++ b/charts/influxdb/templates/backup-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.backup.enabled .Values.persistence.backup.enabled }}
+{{- if and .Values.backup.enabled .Values.backup.persistence.enabled }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -242,6 +242,17 @@ initScripts:
 
 backup:
   enabled: false
+  ## By default emptyDir is used as a transitory volume before uploading to object store.
+  ## As such, ensure that a sufficient ephemeral storage request is set to prevent node disk filling completely.
+  resources:
+    requests:
+      # memory: 512Mi
+      # cpu: 2
+      ephemeral-storage: "8Gi"
+    # limits:
+      # memory: 1Gi
+      # cpu: 4
+      # ephemeral-storage: "16Gi"
   ## If backup destination is PVC, or want to use intermediate PVC before uploading to object store.
   persistence:
     enabled: false

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -242,6 +242,19 @@ initScripts:
 
 backup:
   enabled: false
+  ## If backup destination is PVC, or want to use intermediate PVC before uploading to object store.
+  persistence:
+    enabled: false
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    annotations:
+    accessMode: ReadWriteOnce
+    size: 8Gi
   schedule: "0 0 * * *"
   annotations: {}
   podAnnotations: {}


### PR DESCRIPTION
cc @monotek

Heavily inspired by @monoteks suggestions, this allows users to use a PVC either as their long term or intermediary storage for backups. Disabled by default.


Anyway we could get your approval @monotek?