### PR TITLE
feat: Add support for hostNetwork: true to telegraf-ds

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.0.9
+version: 1.0.10
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -68,3 +68,7 @@ spec:
       - name: config
         configMap:
           name:  {{ include "telegraf.fullname" . }}
+      hostNetwork: {{ default .Values.hostNetwork  false }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -40,6 +40,13 @@ env:
 ##
 tolerations: []
 
+## If the DaemonSet should run on the host's network namespace
+## hostNetwork: true
+
+## If using hostNetwork=true, set dnsPolicy to ClusterFirstWithHostNet
+## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#
+## dnsPolicy: ClusterFirstWithHostNet
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true


### PR DESCRIPTION
To get stats for all network interfaces, it's nice to be able to run with hostNetwork: true. And if you do that, you also want to set dnsPolicy to ClusterFirstWithHostNet.

This adds the `hostNetwork` and `dnsPolicy` options to telegraf-ds values