### PR TITLE
Fix rendering of input configuration.

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.7.14
+version: 1.7.16
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/_helpers.tpl
+++ b/charts/telegraf/templates/_helpers.tpl
@@ -211,7 +211,7 @@ Create chart name and version as used by the chart label.
           {{- range $key, $value := $config -}}
           {{- $tp := typeOf $value -}}
           {{- if eq $tp "map[string]interface {}" }}
-      [[inputs.{{ $input }}.{{ $key }}]]
+      [inputs.{{ $input }}.{{ $key }}]
             {{- range $k, $v := $value }}
               {{- $tps := typeOf $v }}
               {{- if eq $tps "string" }}


### PR DESCRIPTION
Nested TOML tables should only be surrounded by a single bracket.

Fixes #97.

Co-authored-by: Zac Bergquist <bergquistz@vmware.com>