### PR TITLE
clean up labels for telegraf/telegraf-ds

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.0.11
+version: 1.0.12
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/templates/_helpers.tpl
+++ b/charts/telegraf-ds/templates/_helpers.tpl
@@ -32,6 +32,23 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Common labels
+*/}}
+{{- define "telegraf.labels" -}}
+helm.sh/chart: {{ include "telegraf.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "telegraf.selectorLabels" . }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "telegraf.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "telegraf.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
   CUSTOM TEMPLATES: This section contains templates that make up the different parts of the telegraf configuration file.
   - global_tags section
   - agent section

--- a/charts/telegraf-ds/templates/configmap.yaml
+++ b/charts/telegraf-ds/templates/configmap.yaml
@@ -3,10 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "telegraf.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "telegraf.name" . }}
-    helm.sh/chart: {{ include "telegraf.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "telegraf.labels" . | nindent 4 }}
 data:
   telegraf.conf: |+
     {{ template "global_tags" .Values.config.global_tags }}

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -3,9 +3,7 @@ kind: DaemonSet
 metadata:
   name: {{ include "telegraf.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "telegraf.name" . }}
-    helm.sh/chart: {{ include "telegraf.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "telegraf.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/telegraf-ds/templates/role.yaml
+++ b/charts/telegraf-ds/templates/role.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: influx:stats:viewer
   labels:
+    {{- include "telegraf.labels" . | nindent 4 }}
     rbac.authorization.k8s.io/aggregate-view-telegraf-stats: "true"
 rules:
   - apiGroups: ["metrics.k8s.io"]

--- a/charts/telegraf-ds/templates/rolebinding.yaml
+++ b/charts/telegraf-ds/templates/rolebinding.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: influx:telegraf:viewer
+  labels:
+    {{- include "telegraf.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "telegraf.fullname" . }}

--- a/charts/telegraf-ds/templates/serviceaccount.yaml
+++ b/charts/telegraf-ds/templates/serviceaccount.yaml
@@ -4,8 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ include "telegraf.serviceAccountName" . }}
   labels:
-    app: {{ include "telegraf.name" . }}
-    chart: {{ include "telegraf.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "telegraf.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.7.16
+version: 1.7.17
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/_helpers.tpl
+++ b/charts/telegraf/templates/_helpers.tpl
@@ -32,6 +32,24 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Common labels
+*/}}
+{{- define "telegraf.labels" -}}
+helm.sh/chart: {{ include "telegraf.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "telegraf.selectorLabels" . }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "telegraf.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "telegraf.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+
+{{/*
   CUSTOM TEMPLATES: This section contains templates that make up the different parts of the telegraf configuration file.
   - global_tags section
   - agent section

--- a/charts/telegraf/templates/configmap.yaml
+++ b/charts/telegraf/templates/configmap.yaml
@@ -3,10 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "telegraf.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "telegraf.name" . }}
-    helm.sh/chart: {{ include "telegraf.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "telegraf.labels" . | nindent 4 }}
 data:
   telegraf.conf: |+
     {{ template "global_tags" .Values.config.global_tags }}

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -3,9 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "telegraf.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "telegraf.name" . }}
-    helm.sh/chart: {{ include "telegraf.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "telegraf.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/telegraf/templates/role.yaml
+++ b/charts/telegraf/templates/role.yaml
@@ -8,6 +8,8 @@ kind: Role
 metadata:
   name: {{ template "telegraf.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "telegraf.labels" . | nindent 4 }}
 rules:
 {{ toYaml .Values.rbac.rules | indent 2 }}
 {{- end }}

--- a/charts/telegraf/templates/rolebinding.yaml
+++ b/charts/telegraf/templates/rolebinding.yaml
@@ -7,6 +7,8 @@ kind: RoleBinding
 {{- end }}
 metadata:
   name: {{ template "telegraf.fullname" . }}
+  labels:
+    {{- include "telegraf.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "telegraf.fullname" . }}

--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -4,10 +4,7 @@ kind: Service
 metadata:
   name: {{ include "telegraf.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "telegraf.name" . }}
-    helm.sh/chart: {{ include "telegraf.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "telegraf.labels" . | nindent 4 }}
   {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
@@ -66,6 +63,5 @@ spec:
   {{- end -}}
   {{- end }}
   selector:
-    app.kubernetes.io/name: {{ include "telegraf.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "telegraf.selectorLabels" . | nindent 4 }}
 {{- end -}}

--- a/charts/telegraf/templates/serviceaccount.yaml
+++ b/charts/telegraf/templates/serviceaccount.yaml
@@ -4,8 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ template "telegraf.serviceAccountName" . }}
   labels:
-    app: {{ template "telegraf.name" . }}
-    chart: {{ template "telegraf.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "telegraf.labels" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
I've noticed the labels for telegraf & telegraf-ds were a bit messed up.
Refactored them into template variables and made sure they are consistent throughout the charts.

- [x] Rebased/mergable
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)