### PR TITLE
allow passing args in telegraf/telegraf-ds

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.0.12
+version: 1.0.13
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -26,6 +26,10 @@ spec:
         imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        {{- if .Values.args }}
+        args:
+{{ toYaml .Values.args | indent 8 }}
+        {{- end }}
         env:
         - name: HOSTIP
           valueFrom:

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -17,6 +17,9 @@ resources:
     memory: 2Gi
     cpu: 1
 
+## Configure args passed to Telegraf containers
+args: []
+
 env:
   # This pulls HOSTNAME from the node, not the pod.
   - name: HOSTNAME

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.7.17
+version: 1.7.18
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
         imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        {{- if .Values.args }}
+        args:
+{{ toYaml .Values.args | indent 8 }}
+        {{- end }}
         env:
 {{ toYaml .Values.env | indent 8 }}
         volumeMounts:

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -13,6 +13,9 @@ podAnnotations: {}
 
 imagePullSecrets: []
 
+## Configure args passed to Telegraf containers
+args: []
+
 env:
   - name: HOSTNAME
     value: "telegraf-polling-service"


### PR DESCRIPTION
Added support to telegraf/telegraf-ds chart to be able to pass command line args to Telegraf containers, e.g. for customers needing support to load configs from telegraf.d config-directory volumes.

- [x] Rebased/mergable
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)