### PR TITLE
[telegraf] used wrong variable on parsing the telegraf configuration

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.7.17
+version: 1.7.18
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/_helpers.tpl
+++ b/charts/telegraf/templates/_helpers.tpl
@@ -237,7 +237,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
               {{- end }}
               {{- if eq $tps "[]interface {}"}}
         {{ $k }} = [
-                {{- $numOut := len $value }}
+                {{- $numOut := len $v }}
                 {{- $numOut := sub $numOut 1 }}
                 {{- range $b, $val := $v }}
                   {{- $i := int64 $b }}


### PR DESCRIPTION
I've tried to use `tagdrop` on the MongoDB Input Plugin:
```yaml
    - mongodb:
        ...
        tagdrop:
          db_name:
            - "a"
            - "b"
            - "c"
```

This leads to incorrect TOML (On the first element is the `,` missing):
```toml
      [inputs.mongodb.tagdrop]
        db_name = [
            "a"
            "b",
            "c",
        ]
```

The provided change fixes this.

---

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)