### PR TITLE
remote backups

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.7.0
+version: 4.7.1
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/backup-cronjob.yaml
+++ b/charts/influxdb/templates/backup-cronjob.yaml
@@ -31,15 +31,19 @@ spec:
           {{- else }}
             emptyDir: {}
           {{- end }}
-          {{- if .Values.backup.gcs }}
-          {{- if .Values.backup.gcs.serviceAccountSecret }}
+          {{- if .Values.backup.remote.gcs }}
+          {{- if .Values.backup.remote.gcs.serviceAccountSecret }}
           - name: google-cloud-key
             secret:
-              secretName: {{ .Values.backup.gcs.serviceAccountSecret | quote }}
+              secretName: {{ .Values.backup.remote.gcs.serviceAccountSecret | quote }}
           {{- end }}
           {{- end }}
           serviceAccountName: {{ include "influxdb.serviceAccountName" . }}
+          {{- if .Values.backup.remote.enabled }}
           initContainers:
+          {{ else }}
+          containers:
+          {{ end }}
           - name: influxdb-backup
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             volumeMounts:
@@ -55,8 +59,9 @@ spec:
                 -portable /backup/"$(date +%Y%m%d%H%M%S)"
             resources:
               {{- toYaml .Values.backup.resources | nindent 14 }}
+          {{- if .Values.backup.remote.enabled }}
           containers:
-          {{- if .Values.backup.gcs }}
+          {{- if .Values.backup.remote.gcs }}
           - name: gsutil-cp
             image: google/cloud-sdk:alpine
             command:
@@ -71,21 +76,21 @@ spec:
             volumeMounts:
             - name: backup
               mountPath: /backup
-            {{- if .Values.backup.gcs.serviceAccountSecretKey}}
+            {{- if .Values.backup.remote.gcs.serviceAccountSecretKey}}
             - name: google-cloud-key
               mountPath: /var/secrets/google/
             {{- end }}
             env:
               - name: DST_URL
-                value: {{ .Values.backup.gcs.destination}}
-              {{- if .Values.backup.gcs.serviceAccountSecretKey}}
+                value: {{ .Values.backup.remote.gcs.destination}}
+              {{- if .Values.backup.remote.gcs.serviceAccountSecretKey}}
               - name: KEY_FILE
-                value: /var/secrets/google/{{ .Values.backup.gcs.serviceAccountSecretKey }}
+                value: /var/secrets/google/{{ .Values.backup.remote.gcs.serviceAccountSecretKey }}
               {{- end }}
             resources:
               {{- toYaml .Values.backup.resources | nindent 14 }}
           {{- end }}
-          {{- if .Values.backup.azure }}
+          {{- if .Values.backup.remote.azure }}
           - name: azure-cli
             image: microsoft/azure-cli
             command:
@@ -102,15 +107,16 @@ spec:
               - name: SRC_URL
                 value: /backup
               - name: DST_CONTAINER
-                value: {{ .Values.backup.azure.destination_container }}
+                value: {{ .Values.backup.remote.azure.destination_container }}
               - name: DST_PATH
-                value: {{ .Values.backup.azure.destination_path }}
+                value: {{ .Values.backup.remote.azure.destination_path }}
               - name: AZURE_STORAGE_CONNECTION_STRING
                 valueFrom:
                   secretKeyRef:
-                    name: {{ .Values.backup.azure.storageAccountSecret }}
+                    name: {{ .Values.backup.remote.azure.storageAccountSecret }}
                     key: connection-string
             resources:
               {{- toYaml .Values.backup.resources | nindent 14 }}
+          {{- end }}
           {{- end }}
 {{- end }}

--- a/charts/influxdb/templates/backup-pvc.yaml
+++ b/charts/influxdb/templates/backup-pvc.yaml
@@ -12,7 +12,7 @@ spec:
     requests:
       storage: {{ .Values.backup.persistence.size | quote }}
 {{- if .Values.backup.persistence.storageClass }}
-{{- if (eq "-" .Values.persistence.backup.storageClass) }}
+{{- if (eq "-" .Values.backup.persistence.storageClass) }}
   storageClassName: ""
 {{- else }}
   storageClassName: "{{ .Values.persistence.backup.storageClass }}"

--- a/charts/influxdb/templates/backup-pvc.yaml
+++ b/charts/influxdb/templates/backup-pvc.yaml
@@ -15,7 +15,7 @@ spec:
 {{- if (eq "-" .Values.backup.persistence.storageClass) }}
   storageClassName: ""
 {{- else }}
-  storageClassName: "{{ .Values.persistence.backup.storageClass }}"
+  storageClassName: "{{ .Values.backup.persistence.storageClass }}"
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -269,17 +269,18 @@ backup:
   schedule: "0 0 * * *"
   annotations: {}
   podAnnotations: {}
+  remote:
+    enable: false
+    ## Google Cloud Storage
+    # gcs:
+    #    serviceAccountSecret: influxdb-backup-key
+    #    serviceAccountSecretKey: key.json
+    #    destination: gs://bucket/influxdb
 
-  ## Google Cloud Storage
-  # gcs:
-  #    serviceAccountSecret: influxdb-backup-key
-  #    serviceAccountSecretKey: key.json
-  #    destination: gs://bucket/influxdb
-
-  ## Azure
-  ## Secret is expected to have connection string stored in `connection-string` field
-  ## Existing container will be used or private one withing storage account will be created.
-  # azure:
-  #   storageAccountSecret: influxdb-backup-azure-key
-  #   destination_container: influxdb-container
-  #   destination_path: ""
+    ## Azure
+    ## Secret is expected to have connection string stored in `connection-string` field
+    ## Existing container will be used or private one withing storage account will be created.
+    # azure:
+    #   storageAccountSecret: influxdb-backup-azure-key
+    #   destination_container: influxdb-container
+    #   destination_path: ""


### PR DESCRIPTION
While trying to setup the backup cronjob ran into an issue with container spec. I don't hace gcs or azure to do remote offsite copies. Being on prem the backup would be on NFS and backed up to VTL onsite. This patch allows for use cases where remote backup is not available. 