### PR TITLE
WIP: feat: add possibility to use separately configmap

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.7.17
+version: 1.7.18
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/configmap.yaml
+++ b/charts/telegraf/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingConfigMapName }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -21,3 +22,4 @@ data:
     {{ template "inputs" .Values.config.inputs -}}
     [[inputs.internal]]
       collect_memstats = false
+{{- end }}

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -87,7 +87,11 @@ spec:
       volumes:
       - name: config
         configMap:
+        {{- if not .Values.existingConfigMapName }}
           name: {{ include "telegraf.fullname" . }}
+        {{- else }}
+          name: {{ .Values.existingConfigMapName }}
+        {{- end }}
       {{- if .Values.volumes }}
 {{ toYaml .Values.volumes | indent 6 }}
       {{- end }}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -95,6 +95,11 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+## If this is set, the config value will be ignored and the configuration from entered
+## configmap will be used. At this configmap musst be an entry with the name `telegraf.conf`. The value
+## of this entry musst be a valid Telegraf TOML configuration.
+# existingConfigMapName: telegraf-configuration
+
 ## Exposed telegraf configuration
 ## For full list of possible values see `/docs/all-config-values.yaml` and `/docs/all-config-values.toml`
 ## ref: https://docs.influxdata.com/telegraf/v1.1/administration/configuration/


### PR DESCRIPTION
Regarding #111 I've implemented a way to provide a TOML configuration without writing complex YAML stuff.

I've tested it with theses commands:

```shell
# There should be the normal configmap like there were no changes:
helm upgrade --install --debug --dry-run my-release .

# The normal configmap which normally will be provided by the helm chart should
# be missing and at the deployment this should be existing
# `spec.template.spec.volumes[0].configMap.name: telegraf-configuration`
helm upgrade --install --debug --dry-run my-release \
    --set existingConfigMapName=telegraf-configuration .
```

---
- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [ ] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)