### PR TITLE
Prepend basepath to liveness and readiness probes.

### DIFF
--- a/charts/chronograf/Chart.yaml
+++ b/charts/chronograf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: chronograf
-version: 1.1.15
+version: 1.1.16
 appVersion: 1.8.0
 description: Open-source web application written in Go and React.js that provides
   the tools to visualize your monitoring data and easily create alerting and automation

--- a/charts/chronograf/templates/deployment.yaml
+++ b/charts/chronograf/templates/deployment.yaml
@@ -158,11 +158,19 @@ spec:
           name: api
         livenessProbe:
           httpGet:
+            {{- if .Values.env.BASE_PATH }}
+            path: {{ .Values.env.BASE_PATH }}/ping
+            {{- else }}
             path: /ping
+            {{- end}}
             port: api
         readinessProbe:
           httpGet:
+            {{- if .Values.env.BASE_PATH }}
+            path: {{ .Values.env.BASE_PATH }}/ping
+            {{- else }}
             path: /ping
+            {{- end}}
             port: api
         volumeMounts:
         - name: data


### PR DESCRIPTION
* Support Chronograf `--basepath`, `$BASE_PATH` options in chart.

- [x ] CHANGELOG.md updated (Uses documented Chronograf environment variable, env: {} is documented.)
    https://docs.influxdata.com/chronograf/v1.8/administration/config-options/#basepath-p
- [x ] Rebased/mergable
- [ x] Tests pass (See Below)
- [ x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

`helm template chronograf --set env.BASE_PATH="/chronograf"`

```
        env:
        - name: "BASE_PATH"
          value: "/chronograf"
        - name: "HOST_PAGE_DISABLED"
          value: "true"
        ports:
        - containerPort: 8888
          name: api
        livenessProbe:
          httpGet:
            path: /chronograf/ping
            port: api
        readinessProbe:
          httpGet:
            path: /chronograf/ping
            port: api
```

`helm template chronograf`

```
        env:
        - name: "HOST_PAGE_DISABLED"
          value: "true"
        ports:
        - containerPort: 8888
          name: api
        livenessProbe:
          httpGet:
            path: /ping
            port: api
        readinessProbe:
          httpGet:
            path: /ping
            port: api
```

