### PR TITLE
[InfluxDB Helm] Add support for loadbalancerIP

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.7.0
+version: 4.8.0
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/README.md
+++ b/charts/influxdb/README.md
@@ -59,6 +59,7 @@ The following table lists configurable parameters, their descriptions, and their
 | readinessProbe | Health check for pod | {} |
 | startupProbe | Health check for pod | {} |
 | service.type | Kubernetes service type | ClusterIP |
+| service.loadBalancerIP | A user-specified IP address for service type LoadBalancer to use as External IP (if supported) | nil |
 | persistence.enabled | Boolean to enable and disable persistance | true |
 | persistence.existingClaim | An existing PersistentVolumeClaim, ignored if enterprise.enabled=true | nil |
 | persistence.storageClass | If set to "-", storageClassName: "", which disables dynamic provisioning. If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.  (gp2 on AWS, standard on GKE, AWS & OpenStack |  |

--- a/charts/influxdb/templates/service.yaml
+++ b/charts/influxdb/templates/service.yaml
@@ -40,3 +40,6 @@ spec:
   {{- end }}
   selector:
     {{- include "influxdb.selectorLabels" . | nindent 4 }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}


### PR DESCRIPTION
Some loadbalancer (i.e. MetalLB) support spec.loadbalancerIP to specify an IP address for a service. I'd like the influx helm chart to support this in Values.

Tested on my own cluster against MetalLB:
my values.yml:
```
...
service:
  type: LoadBalancer
  loadBalancerIP: 192.168.1.56
```
```
k get services -n monitoring
NAME       TYPE           CLUSTER-IP       EXTERNAL-IP    PORT(S)                         AGE
influxdb   LoadBalancer   10.152.183.118   192.168.1.56   8086:31518/TCP,8088:31932/TCP   7m19s
```

Default deploy with default values post-change also successful.

Signed-off-by: Dennis Zhang <dennis.zhang.nrg@gmail.com>

- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)