### PR TITLE
InfluxDB backup to Amazon S3 (or compatible)

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.7.0
+version: 4.8.0
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/README.md
+++ b/charts/influxdb/README.md
@@ -101,6 +101,7 @@ The following table lists configurable parameters, their descriptions, and their
 | backup.enabled | Enable backups, if `true` must configure one of the storage providers | `false` |
 | backup.gcs | Google Cloud Storage config | `nil`
 | backup.azure | Azure Blob Storage config | `nil`
+| backup.s3 | Amazon S3 (or compatible) config | `nil`
 | backup.schedule | Schedule to run jobs in cron format | `0 0 * * *` |
 | backup.annotations | Annotations for backup cronjob | {} |
 | backup.podAnnotations | Annotations for backup cronjob pods | {} |

--- a/charts/influxdb/templates/backup-cronjob.yaml
+++ b/charts/influxdb/templates/backup-cronjob.yaml
@@ -38,6 +38,13 @@ spec:
               secretName: {{ .Values.backup.gcs.serviceAccountSecret | quote }}
           {{- end }}
           {{- end }}
+          {{- if .Values.backup.s3 }}
+          {{- if .Values.backup.s3.credentialsSecret }}
+          - name: aws-credentials-secret
+            secret:
+              secretName: {{ .Values.backup.s3.credentialsSecret | quote }}
+          {{- end }}
+          {{- end }}
           serviceAccountName: {{ include "influxdb.serviceAccountName" . }}
           initContainers:
           - name: influxdb-backup
@@ -110,6 +117,32 @@ spec:
                   secretKeyRef:
                     name: {{ .Values.backup.azure.storageAccountSecret }}
                     key: connection-string
+            resources:
+              {{- toYaml .Values.backup.resources | nindent 14 }}
+          {{- end }}
+          {{- if .Values.backup.s3 }}
+          - name: aws-cli
+            image: amazon/aws-cli
+            command:
+            - /bin/sh
+            args:
+            - '-c'
+            - |
+              aws {{- if .Values.backup.s3.endpointUrl }} --endpoint-url={{ .Values.backup.s3.endpointUrl }} {{- end }} s3 cp --recursive "$SRC_URL" "$DST_URL"
+            volumeMounts:
+            - name: backup
+              mountPath: /backup
+            {{- if .Values.backup.s3.credentialsSecret}}
+            - name: aws-credentials-secret
+              mountPath: /var/secrets/aws/
+            {{- end }}
+            env:
+              - name: AWS_CONFIG_FILE
+                value: /var/secrets/aws/credentials
+              - name: SRC_URL
+                value: /backup
+              - name: DST_URL
+                value: {{ .Values.backup.s3.destination }}
             resources:
               {{- toYaml .Values.backup.resources | nindent 14 }}
           {{- end }}

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -283,3 +283,14 @@ backup:
   #   storageAccountSecret: influxdb-backup-azure-key
   #   destination_container: influxdb-container
   #   destination_path: ""
+
+  ## Amazon S3 or compatible
+  ## Secret is expected to have AWS (or compatible) credentials stored in `credentials` field.
+  ## Please look at https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where
+  ## for the credentials format.
+  ## The bucket should already exist.
+  # s3:
+  #   credentialsSecret: aws-credentials-secret
+  #   destination: s3://bucket/path
+  #   ## Optional. Specify if you're using an alternate S3 endpoint.
+  #   # endpointUrl: ""


### PR DESCRIPTION
Add support for backup of InfluxDB to Amazon S3 (or compatible). To use it please create the following secret:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: aws-credentials-secret
  namespace: your-influxdb-namespace
type: Opaque
stringData:
  credentials: |
    [default]
    aws_access_key_id=XXXXXXXXXXXXXXXXXXXX
    aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
```

and edit the `backup.s3` section in _values.yaml_.