### PR TITLE
set collectd service as a UDP service

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.7.1
+version: 4.7.2
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.7.0
+version: 4.7.1
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/service.yaml
+++ b/charts/influxdb/templates/service.yaml
@@ -25,6 +25,7 @@ spec:
   {{- if .Values.config.collectd.enabled }}
   - name: collectd
     port: {{ .Values.config.collectd.bind_address | default 25826 }}
+    protocol: UDP
     targetPort: collectd
   {{- end }}
   {{- if .Values.config.udp.enabled }}

--- a/charts/influxdb/templates/statefulset.yaml
+++ b/charts/influxdb/templates/statefulset.yaml
@@ -65,6 +65,7 @@ spec:
         {{- if .Values.config.collectd.enabled }}
         - name: collectd
           containerPort: {{ .Values.config.collectd.bind_address |  default 25826 }}
+          protocol: UDP
         {{- end }}
         {{- if .Values.config.udp.enabled }}
         - name: udp


### PR DESCRIPTION
This commit sets `collectd` service as UDP instead of TCP.

fixes #107