### PR TITLE
Mount license from secret using configurable key, instead of hardcoded key

### DIFF
--- a/charts/influxdb-enterprise/templates/data-statefulset.yaml
+++ b/charts/influxdb-enterprise/templates/data-statefulset.yaml
@@ -40,6 +40,9 @@ spec:
       - name: license
         secret:
           secretName: {{ .Values.license.secret.name }}
+          items:
+          - key: {{ .Values.license.secret.key }}
+            path: license.json
       {{- end }}
       {{- if .Values.data.https.enabled }}
       - name: tls
@@ -99,8 +102,7 @@ spec:
             mountPath: /var/lib/influxdb
           {{- if .Values.license.secret }}
           - name: license
-            mountPath: /var/run/secrets/influxdb/license.json
-            subPath: json
+            mountPath: /var/run/secrets/influxdb/
           {{- end }}
           {{- if .Values.data.https.enabled }}
           - name: tls

--- a/charts/influxdb-enterprise/templates/meta-statefulset.yaml
+++ b/charts/influxdb-enterprise/templates/meta-statefulset.yaml
@@ -40,6 +40,9 @@ spec:
       - name: license
         secret:
           secretName: {{ .Values.license.secret.name }}
+          items:
+          - key: {{ .Values.license.secret.key }}
+            path: license.json
       {{- end }}
       {{- if .Values.meta.https.enabled }}
       - name: tls
@@ -101,8 +104,7 @@ spec:
             mountPath: /var/lib/influxdb
           {{- if .Values.license.secret }}
           - name: license
-            mountPath: /var/run/secrets/influxdb/license.json
-            subPath: json
+            mountPath: /var/run/secrets/influxdb/
           {{- end }}
           {{- if .Values.meta.https.enabled }}
           - name: tls


### PR DESCRIPTION
As per documented configuration in [values.yaml](https://github.com/influxdata/helm-charts/blob/master/charts/influxdb-enterprise/values.yaml#L17), when `license` is using `secret` configuration, `key` can be set to anything.

Without this patch, `/var/run/secrets/influxdb/license.json` will be mounted as a directory!! Making the bug very difficult to discover.

This patch enables the configuration work as per documentation.