### PR TITLE
Fix underscores and dashes in service.yaml

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.7.19
+version: 1.7.20
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -34,16 +34,16 @@ spec:
     protocol: "UDP"
     name: "statsd"
     {{- end }}
-    {{- if eq $key "tcp-listener" }}
+    {{- if eq $key "tcp_listener" }}
   - port: {{ trimPrefix ":" $value.service_address | int64 }}
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
-    name: "tcp_listener"
+    name: "tcp-listener"
     {{- end }}
-    {{- if eq $key "udp-listener" }}
+    {{- if eq $key "udp_listener" }}
   - port: {{ trimPrefix ":" $value.service_address | int64 }}
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
     protocol: "UDP"
-    name: "udp_listener"
+    name: "udp-listener"
     {{- end }}
     {{- if eq $key "webhooks" }}
   - port: {{ trimPrefix ":" $value.service_address | int64 }}


### PR DESCRIPTION
This PR fixes service.yaml for `tcp_listener` and `udp_listener`.

When you set `udp_listener` or `tcp_listener` in `values.yaml`, the comparison fails and the service isn't correctly setup. Fixing the comparison shows that the Kubernetes port name is also incorrect, it needs dashes instead of underscores. This PR fixes both issues for each listener.

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [ ] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)