### PR TITLE
fix: key references in statefulset.yaml files

### DIFF
--- a/charts/influxdb-enterprise/Chart.yaml
+++ b/charts/influxdb-enterprise/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.1.3
+version: 0.1.4
 appVersion: 1.8.0
 engine: gotpl
 

--- a/charts/influxdb-enterprise/templates/data-statefulset.yaml
+++ b/charts/influxdb-enterprise/templates/data-statefulset.yaml
@@ -53,9 +53,9 @@ spec:
           secretName: {{ .Values.data.https.secret.name }}
           {{ if or .Values.data.https.secret.crt .Values.data.https.secret.key }}
           items:
-            - key: {{ .Values.data.https.crt }}
+            - key: {{ .Values.data.https.secret.crt }}
               path: tls.crt
-            - key: {{ .Values.data.https.key }}
+            - key: {{ .Values.data.https.secret.key }}
               path: tls.key
           {{ end }}
           {{ end }}

--- a/charts/influxdb-enterprise/templates/meta-statefulset.yaml
+++ b/charts/influxdb-enterprise/templates/meta-statefulset.yaml
@@ -53,9 +53,9 @@ spec:
           secretName: {{ .Values.meta.https.secret.name }}
           {{ if or .Values.meta.https.secret.crt .Values.meta.https.secret.key }}
           items:
-            - key: {{ .Values.meta.https.crt }}
+            - key: {{ .Values.meta.https.secret.crt }}
               path: tls.crt
-            - key: {{ .Values.meta.https.key }}
+            - key: {{ .Values.meta.https.secret.key }}
               path: tls.key
           {{ end }}
           {{ end }}


### PR DESCRIPTION
This PR fixes key references in [data|meta].statefulset.yaml for the chart for 
- secret.key
- secret.crt