### PR TITLE
feat: add option to set startingDeadlineSeconds for InfluxDB backup

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.8.5
+version: 4.8.8
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.8.4
+version: 4.8.5
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/README.md
+++ b/charts/influxdb/README.md
@@ -107,6 +107,7 @@ The following table lists configurable parameters, their descriptions, and their
 | backup.azure | Azure Blob Storage config | `nil`
 | backup.s3 | Amazon S3 (or compatible) config | `nil`
 | backup.schedule | Schedule to run jobs in cron format | `0 0 * * *` |
+| backup.startingDeadlineSeconds | Deadline in seconds for starting the job if it misses its scheduled time for any reason | `nil` |
 | backup.annotations | Annotations for backup cronjob | {} |
 | backup.podAnnotations | Annotations for backup cronjob pods | {} |
 | backup.persistence.enabled | Boolean to enable and disable persistance | false |

--- a/charts/influxdb/templates/backup-cronjob.yaml
+++ b/charts/influxdb/templates/backup-cronjob.yaml
@@ -10,6 +10,7 @@ metadata:
     {{- toYaml .Values.backup.annotations | nindent 4 }}
 spec:
   schedule: {{ .Values.backup.schedule | quote }}
+  startingDeadlineSeconds: {{ .Values.backup.startingDeadlineSeconds }}
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -272,6 +272,7 @@ backup:
     accessMode: ReadWriteOnce
     size: 8Gi
   schedule: "0 0 * * *"
+  startingDeadlineSeconds: ""
   annotations: {}
   podAnnotations: {}
 


### PR DESCRIPTION
Currently, there is no option to set the `startingDeadlineSeconds` for the InfluxDB backup job, which would be useful in situations when the backup CronJob Controller is disabled for a longer period and then enabled again. With the current setting, according to the Kubernetes [documentation](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-job-limitations), if there are more than 100 missed schedules, then it does not start the job anymore. This PR exposes the configuration parameter in `values.yaml` file to enable more accurate configuration of the backup procedure.

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [ ] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)