### PR TITLE
fix(enterprise): HTTPs config for data port

### DIFF
--- a/charts/influxdb-enterprise/Chart.yaml
+++ b/charts/influxdb-enterprise/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.1.4
+version: 0.1.5
 appVersion: 1.8.0
 engine: gotpl
 

--- a/charts/influxdb-enterprise/templates/bootstrap-job.yaml
+++ b/charts/influxdb-enterprise/templates/bootstrap-job.yaml
@@ -48,6 +48,12 @@ spec:
         command:
           - influx
         args:
+        {{- if .Values.data.https.enabled }}
+          - -ssl 
+        {{- if .Values.data.https.insecure }}
+          - -unsafeSsl
+        {{ end }}
+        {{ end }}
           - -host
           - {{ include "influxdb-enterprise.fullname" . }}-data
           - -execute
@@ -83,6 +89,12 @@ spec:
         command:
           - influx
         args:
+        {{- if .Values.data.https.enabled }}
+          - -ssl 
+        {{- if .Values.data.https.insecure }}
+          - -unsafeSsl
+        {{ end }}
+        {{ end }}
           - -host
           - {{ include "influxdb-enterprise.fullname" . }}-data
           - -import
@@ -114,6 +126,12 @@ spec:
         command:
           - influx
         args:
+        {{- if .Values.data.https.enabled }}
+          - -ssl 
+        {{- if .Values.data.https.insecure }}
+          - -unsafeSsl
+        {{ end }}
+        {{ end }}
           - -host
           - {{ include "influxdb-enterprise.fullname" . }}-data
           - -import

--- a/charts/influxdb-enterprise/templates/data-configmap.yaml
+++ b/charts/influxdb-enterprise/templates/data-configmap.yaml
@@ -13,6 +13,14 @@ data:
     {{ if .Values.bootstrap.auth.secretName }}
     [http]
     auth-enabled = true
+
+    {{ if .Values.data.https.enabled }}
+    https-enabled = true
+
+    https-certificate = "/var/run/secrets/tls/tls.crt"
+    https-private-key = "/var/run/secrets/tls/tls.key"
+    {{ end }}
+
     {{ end }}
 
     [enterprise]


### PR DESCRIPTION
This PR fixes the data-configmap under the [http] section of the TOML 

Currently using the same x509s as the [cluster] settings, but will still want to update chart to support different DNS names for RPC and HTTP.