### PR TITLE
Add extraContainers option for running custom sidecar workloads in the InfluxDB pod

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.8.2
+version: 4.8.7
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.8.1
+version: 4.8.2
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/README.md
+++ b/charts/influxdb/README.md
@@ -80,6 +80,7 @@ The following table lists configurable parameters, their descriptions, and their
 | env | environment variables for influxdb container | {} |
 | volumes | `volumes` stanza(s) to be used in the main container | nil |
 | mountPoints | `volumeMount` stanza(s) to be used in the main container | nil |
+| extraContainers | Additional containers to be added to the pod | {} |
 | config.reporting_disabled | [Details](https://docs.influxdata.com/influxdb/v1.7/administration/config/#reporting-disabled-false) | false |
 | config.rpc | RPC address for backup and storage | {} |
 | config.meta | [Details](https://docs.influxdata.com/influxdb/v1.7/administration/config/#meta) | {} |

--- a/charts/influxdb/templates/statefulset.yaml
+++ b/charts/influxdb/templates/statefulset.yaml
@@ -125,6 +125,9 @@ spec:
         {{- if .Values.mountPoints }}
 {{ toYaml .Values.mountPoints | indent 8 }}
         {{- end }}
+      {{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 6}}
+      {{- end }}
       volumes:
       - name: config
         configMap:

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -177,6 +177,11 @@ ingress:
 #     mountPath: /etc/ssl/certs/selfsigned/
 #     readOnly: true
 
+## Additional containers to be added to the pod.
+extraContainers: {}
+#  - name: my-sidecar
+#    image: nginx:latest
+
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##


### PR DESCRIPTION
Currently, there is no option to add custom sidecar containers in the InfluxDB pod. A common use case for this extension can be monitoring, for example running a custom Prometheus exporter monitoring arbitrary resource consumption (in our case the database disk usage).

This PR enables adding custom sidecar workloads in the InfluxDB pod by defining `extraContainers` in `values.yaml` file.

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [ ] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)