### PR TITLE
feat(influxdb2): add optional values for password and token

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
-version: 1.0.4
+version: 1.0.5
 maintainers:
 - name: rawkode
   email: rawkode@influxdata.com

--- a/charts/influxdb2/README.md
+++ b/charts/influxdb2/README.md
@@ -49,3 +49,7 @@ The [InfluxDB](https://quay.io/influxdb/influxdb:2.0.0-beta) image stores data i
 If persistence is enabled, a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) associated with StatefulSet is provisioned. The volume is created using dynamic volume provisioning. In case of a disruption (for example, a node drain), Kubernetes ensures that the same volume is reattached to the Pod, preventing any data loss. However, when persistence is **not enabled**, InfluxDB data is stored in an empty directory, so if a Pod restarts, data is lost.
 
 Check out our [Slack channel](https://www.influxdata.com/slack) for support and information.
+
+## Fixed Auth Credentials
+
+If you need to use fixed token and/or password you can fill `adminUser.password` and `adminUser.token` on your values file to avoid using random values generation.

--- a/charts/influxdb2/templates/secret.yaml
+++ b/charts/influxdb2/templates/secret.yaml
@@ -5,5 +5,14 @@ metadata:
     {{- include "influxdb.labels" . | nindent 4 }}
   name: {{ template "influxdb.fullname" . }}-auth
 data:
-  admin-password: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- if .Values.adminUser.token }}
+  admin-token: {{ .Values.adminUser.token  | b64enc | quote }}
+  {{- else }}
   admin-token: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end }}
+
+  {{- if .Values.adminUser.password }}
+  admin-password: {{ .Values.adminUser.password | b64enc | quote }}
+  {{- else }}
+  admin-password: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end }}

--- a/charts/influxdb2/values.yaml
+++ b/charts/influxdb2/values.yaml
@@ -30,6 +30,10 @@ adminUser:
   organization: "influxdata"
   bucket: "default"
   user: "admin"
+  ## Leave empty to generate a random password and token.
+  ## Or fill any of these values to use fixed values.
+  password: ""
+  token: ""
 
 ## Persist data to a persistent volume
 ##


### PR DESCRIPTION
- [x] CHANGELOG.md updated (<<<< can't find CHANGELOG.md anywhere in this repo)
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


This PR makes `adminUser.password` and `adminUser.token` optional values that can be set on user's `value.yaml` file. 

Current users of this chart won't  need to change anything if they want to keep using random values as usual. 

One usecase for this feature is to use the chart inside an operator created with the [operator-framework/operator-sdk](https://github.com/operator-framework/operator-sdk). In this case the reconciliation algorithm used by the SDK will handle the secrets and recreate it during its lifecycle. So, setting a fixed token and password gives more control over the admin credentials.

Closes #145 

