### PR TITLE
feat(influxdb): add backup retention

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.8.2
+version: 4.8.9
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.8.1
+version: 4.8.2
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/files/backup-retention-script.sh
+++ b/charts/influxdb/files/backup-retention-script.sh
@@ -1,0 +1,66 @@
+#! /usr/bin/env bash
+
+set -e
+
+# This script wants these variable to be set.
+
+## S3_BUCKET <- The name of the bucket where the backups are stored
+## S3_ENDPOINT <- The endpoint of the S3 service
+## AWS_ACCESS_KEY_ID <- Access credentials        
+## AWS_SECRET_ACCESS_KEY <- Access credentials
+## DAYS_TO_RETAIN <- The TTL for the backups === number of backups to keep.
+
+# Sanity check to avoid removing all backups.
+[[ "$DAYS_TO_RETAIN" -lt 1 ]] && DAYS_TO_RETAIN=1
+
+function get_records {
+    before_date="$1"
+
+    aws s3api list-objects \
+        --bucket ${S3_BUCKET} \
+        --endpoint-url ${S3_ENDPOINT} \
+        --query "Contents[?LastModified<='${before_date}'][].{Key: Key}"
+}
+
+function remove_old_backups {
+    before_date=$(date --iso-8601=seconds -d "-${DAYS_TO_RETAIN} days")  
+    now=$(date --iso-8601=seconds)
+
+    del_records=$(get_records "${before_date}")
+    all_records=$(get_records "${now}")
+
+    del_paths=()
+    all_paths=()
+    
+    function _jq {
+        echo ${row} | base64 --decode | jq -r ${1}
+    }
+
+    for row in $(echo "${del_records}" | jq -r '.[] | @base64'); do       
+        del_paths+=($(_jq '.Key'))                
+    done
+
+    for row in $(echo "${all_records}" | jq -r '.[] | @base64'); do
+        all_paths+=($(_jq '.Key'))                
+    done
+
+    # Number of backups left if all old backups are removed.
+    left=$((${#all_paths[@]} - ${#del_paths[@]}))
+
+    # We ALWAYS keep N backups even if their TTL has expired!
+    if (( ${left} < ${DAYS_TO_RETAIN} )); then
+        num_to_delete=$((${#all_paths[@]} - ${DAYS_TO_RETAIN}))
+    else
+        num_to_delete=${#del_paths[@]}
+    fi
+
+    for path in "${del_paths[@]::${num_to_delete}}"; do
+        aws s3 rm "s3://${S3_BUCKET}/${path}" \
+            --endpoint-url "${S3_ENDPOINT}"
+    done
+}
+
+# Installs jq.
+yum install -y jq
+
+remove_old_backups

--- a/charts/influxdb/templates/backup-retention-configmap.yaml
+++ b/charts/influxdb/templates/backup-retention-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.backupRetention.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "influxdb.fullname" . }}-backup-retention
+  labels:
+    {{- include "influxdb.labels" . | nindent 4 }}
+data:
+  backup-retention.sh: |-
+    {{- .Files.Get "files/backup-retention-script.sh" | nindent 4 }}
+{{- end }}

--- a/charts/influxdb/templates/backup-retention-cronjob.yaml
+++ b/charts/influxdb/templates/backup-retention-cronjob.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.backupRetention.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "influxdb.fullname" . }}-backup-retention
+  labels:
+    {{- include "influxdb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup-retention
+  annotations:
+    {{- toYaml .Values.backupRetention.annotations | nindent 4 }}
+spec:
+  schedule: {{ .Values.backupRetention.schedule | quote }}
+  startingDeadlineSeconds: {{ .Values.backupRetention.startingDeadlineSeconds }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          {{- if .Values.backupRetention.podAnnotations }}
+          annotations:
+            {{ toYaml .Values.backupRetention.podAnnotations | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "influxdb.selectorLabels" . | nindent 12 }}
+        spec:
+          restartPolicy: OnFailure
+          volumes:
+          - name: scripts
+            configMap:
+              name: {{ include "influxdb.fullname" . }}-backup-retention
+          {{- if .Values.backupRetention.gcs }}
+          {{- if .Values.backupRetention.gcs.serviceAccountSecret }}
+          - name: google-cloud-key
+            secret:
+              secretName: {{ .Values.backupRetention.gcs.serviceAccountSecret | quote }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.backupRetention.s3 }}
+          {{- if .Values.backupRetention.s3.credentialsSecret }}
+          - name: aws-credentials-secret
+            secret:
+              secretName: {{ .Values.backupRetention.s3.credentialsSecret | quote }}
+          {{- end }}
+          {{- end }}
+          serviceAccountName: {{ include "influxdb.serviceAccountName" . }}
+          containers:
+          {{- if .Values.backupRetention.gcs }}
+          {{- end }}
+          {{- if .Values.backupRetention.azure }}
+          {{- end }}
+          {{- if .Values.backupRetention.s3 }}
+          - name: aws-cli
+            image: amazon/aws-cli
+            command: ['/bin/bash']
+            args: ['/scripts/backup-retention.sh']
+            volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+            {{- if .Values.backupRetention.s3.credentialsSecret}}
+            - name: aws-credentials-secret
+              mountPath: /var/secrets/aws/
+            {{- end }}
+            env:
+              - name: AWS_CONFIG_FILE
+                value: /var/secrets/aws/credentials
+              - name: DAYS_TO_RETAIN
+                value: {{ .Values.backupRetention.daysToRetain | quote }}
+              - name: S3_BUCKET
+                value: {{ .Values.backupRetention.s3.bucketName }}
+              - name: S3_ENDPOINT
+                value: {{ .Values.backupRetention.s3.endpointUrl }}
+            resources:
+              {{- toYaml .Values.backupRetention.resources | nindent 14 }}
+          {{- end }}
+{{- end }}

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -294,3 +294,23 @@ backup:
   #   destination: s3://bucket/path
   #   ## Optional. Specify if you're using an alternate S3 endpoint.
   #   # endpointUrl: ""
+
+backupRetention:
+  enabled: false
+  resources:
+    requests:
+      # memory: 512Mi
+      # cpu: 2
+    # limits:
+      # memory: 1Gi
+      # cpu: 4
+  schedule: "0 0 * * *"
+  startingDeadlineSeconds:
+  annotations: {}
+  podAnnotations: {}
+  daysToRetain: 7
+  # s3:
+  #   credentialsSecret: aws-credentials-secret
+  #   bucketName: bucket
+  #   ## Optional. Specify if you're using an alternate S3 endpoint.
+  #   # endpointUrl: ""


### PR DESCRIPTION
This PR enables automatic time-based retention of InfluxDB backups with implementation for S3 and placeholders for other storage providers.

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [ ] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)