### PR TITLE
Changing telegraf-operator kubeVersion to support EKS

### DIFF
--- a/charts/telegraf-operator/Chart.yaml
+++ b/charts/telegraf-operator/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/telegraf-operator/Chart.yaml
+++ b/charts/telegraf-operator/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
 - name: rawkode
   email: rawkode@influxdata.com
 
-kubeVersion: ">= 1.13.0"
+kubeVersion: ">= 1.13.0-r0"
 home: https://github.com/influxdata/telegraf-operator
 # A chart can be either an 'application' or a 'library' chart.
 #


### PR DESCRIPTION
This PR fixes https://github.com/influxdata/helm-charts/issues/150