### PR TITLE
Use nindent for statefulset tolerations etc.

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
-version: 1.0.5
+version: 1.0.6
 maintainers:
 - name: rawkode
   email: rawkode@influxdata.com

--- a/charts/influxdb2/templates/statefulset.yaml
+++ b/charts/influxdb2/templates/statefulset.yaml
@@ -52,15 +52,15 @@ spec:
 
       {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{ toYaml . | indent 8 }}
+        {{ toYaml . | nindent 8 | trim }}
       {{- end }}
 
       {{- with .Values.affinity }}
       affinity:
-        {{ toYaml . | indent 8 }}
+        {{ toYaml . | nindent 8 | trim }}
       {{- end }}
 
       {{- with .Values.tolerations }}
       tolerations:
-        {{ toYaml . | indent 8 }}
+        {{ toYaml . | nindent 8 | trim }}
       {{- end }}


### PR DESCRIPTION
Otherwise the first line will be indented up to the existing indent on the line:

```
           tolerations:
                - key: mykeyhere
          operator: EXISTS
```
> Error: YAML parse error on influxdb2/templates/statefulset.yaml: error converting YAML to JSON: yaml: line 51: did not find expected key
helm.go:94: [debug] error converting YAML to JSON: yaml: line 51: did not find expected key

vs.

```
      tolerations:
        - key: mykey
          operator: EXISTS
```

- [ ] CHANGELOG.md updated  (can't find it?)
- [x] Rebased/mergable 
- [x] Tests pass (cant find it - ran helm template command locally?)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)