### PR TITLE
influxdb/telegraf: add configurable pod labels

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.8.2
+version: 4.8.3
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/README.md
+++ b/charts/influxdb/README.md
@@ -69,6 +69,7 @@ The following table lists configurable parameters, their descriptions, and their
 | persistence.accessMode | Access mode for the volume | ReadWriteOnce |
 | persistence.size | Storage size | 8Gi |
 | podAnnotations | Annotations for pod | {} |
+| podLabels | Labels for pod | {} |
 | ingress.enabled | Boolean flag to enable or disable ingress | false |
 | ingress.tls | Boolean to enable or disable tls for ingress. If enabled provide a secret in `ingress.secretName` containing TLS private key and certificate. | false |
 | ingress.secretName | Kubernetes secret containing TLS private key and certificate. It is `only` required if `ingress.tls` is enabled. | nil |

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -158,6 +158,9 @@ resources: {}
 # Annotations to be added to InfluxDB pods
 podAnnotations: {}
 
+# Labels to be added to InfluxDB pods
+podLabels: {}
+
 ingress:
   enabled: false
   tls: false

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.7.21
+version: 1.7.22
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "telegraf.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with .Values.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -11,6 +11,8 @@ image:
 
 podAnnotations: {}
 
+podLabels: {}
+
 imagePullSecrets: []
 
 ## Configure args passed to Telegraf containers


### PR DESCRIPTION
This adds the podLabels property to values.yaml to let users specify custom labels on generated pods, e.g. to follow company requirements.

CLA signed.