### PR TITLE
Version Bumps

### DIFF
--- a/charts/influxdb-enterprise/Chart.yaml
+++ b/charts/influxdb-enterprise/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.7
+version: 0.1.8
 appVersion: 1.8.0
 engine: gotpl
 

--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,23 +1,23 @@
 apiVersion: v1
 name: influxdb
-version: 4.8.3
+version: 4.8.4
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:
-- influxdb
-- database
-- timeseries
-- influxdata
+  - influxdb
+  - database
+  - timeseries
+  - influxdata
 home: https://www.influxdata.com/time-series-platform/influxdb/
 sources:
-- https://github.com/influxdata/influxdb
+  - https://github.com/influxdata/influxdb
 maintainers:
-- name: rawkode
-  email: rawkode@influxdata.com
-- name: gitirabassi
-  email: giacomo@influxdata.com
-- name: aisuko
-  email: urakiny@gmail.com
-- name: naseemkullah
-  email: naseem@transit.app
+  - name: rawkode
+    email: rawkode@influxdata.com
+  - name: gitirabassi
+    email: giacomo@influxdata.com
+  - name: aisuko
+    email: urakiny@gmail.com
+  - name: naseemkullah
+    email: naseem@transit.app
 engine: gotpl

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v1
 name: telegraf
-version: 1.7.22
+version: 1.7.23
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
 keywords:
-- telegraf
-- collector
-- timeseries
-- influxdata
-- influxdb
-- agent
+  - telegraf
+  - collector
+  - timeseries
+  - influxdata
+  - influxdb
+  - agent
 home: https://www.influxdata.com/time-series-platform/telegraf/
 maintainers:
-- name: rawkode
-  email: rawkode@influxdata.com
-- name: gitirabassi
-  email: giacomo@influxdata.com
+  - name: rawkode
+    email: rawkode@influxdata.com
+  - name: gitirabassi
+    email: giacomo@influxdata.com
 engine: gotpl


### PR DESCRIPTION
There was an InfluxDB Enterprise PR merged 6 days ago that caused a few charts to publish, as its version wasn't incremented.

This should hopefully get everything up to date.