### PR TITLE
(Fix #182) Fix releases

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.0.15
+version: 1.0.16
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-operator/Chart.yaml
+++ b/charts/telegraf-operator/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.1
+version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.


### PR DESCRIPTION
This PR should fix the recently failed releases:
- #168 was successfully released as https://github.com/influxdata/helm-charts/releases/tag/telegraf-operator-1.1.1
- #154 should be released as `telegraf-operator-1.1.2` after merge
- #178 should be released as `telegraf-ds-1.0.16` after merge

Although #178 was successfully tagged and released as `telegraf-ds-1.0.15` it was never added to the chart index.
Based on https://github.com/helm/chart-releaser-action/blob/master/cr.sh#L56 the GitHub action will not detect `1.0.15` to be added to the index as far as I can tell. I have no easy way to test it without self hosting a chart repo myself, any guidance is welcome if you maintainers have more experience with the chart-releaser-action.

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)