### PR TITLE
[telegraf] Support Annotations for ServiceAccount

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.7.23
+version: 1.7.24
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.7.24
+version: 1.7.26
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/serviceaccount.yaml
+++ b/charts/telegraf/templates/serviceaccount.yaml
@@ -5,4 +5,8 @@ metadata:
   name: {{ template "telegraf.serviceAccountName" . }}
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -113,6 +113,8 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+  # Annotations for the ServiceAccount
+  annotations: {}
 
 ## Exposed telegraf configuration
 ## For full list of possible values see `/docs/all-config-values.yaml` and `/docs/all-config-values.toml`


### PR DESCRIPTION
- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

I did not find a CHANGELOG to update.

Added this to allow users to make use of GKE IAM Workload or EKS IAM Role for Service Accounts.

```
$ helm template charts/telegraf -s templates/serviceaccount.yaml  --set "serviceAccount.annotations.foo=bar" --set "serviceAccount.annotations.bar=baz"
---
# Source: telegraf/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: RELEASE-NAME-telegraf
  labels:
    helm.sh/chart: telegraf-1.7.23
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: RELEASE-NAME
  annotations:
    bar: baz
    foo: bar

```