### PR TITLE
[telegraf-ds] Make inputs configurable

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.0.16
+version: 1.0.17
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/templates/configmap.yaml
+++ b/charts/telegraf-ds/templates/configmap.yaml
@@ -10,30 +10,6 @@ data:
     {{ template "agent" .Values.config.agent }}
     {{ template "processors" .Values.config.processors }}
     {{ template "aggregators" .Values.config.aggregators }}
+    {{ template "inputs" .Values.config.inputs }}
     {{ template "outputs" .Values.config.outputs }}
     {{ template "monitor_self" .Values.config.monitor_self }}
-
-    [[inputs.diskio]]
-    [[inputs.kernel]]
-    [[inputs.mem]]
-    [[inputs.net]]
-    [[inputs.processes]]
-    [[inputs.swap]]
-    [[inputs.system]]
-
-    [[inputs.cpu]]
-    percpu = true
-    totalcpu = true
-    collect_cpu_time = false
-    report_active = false
-
-    [[inputs.disk]]
-    ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
-
-    [[inputs.docker]]
-    endpoint = "unix:///var/run/docker.sock"
-
-    [[inputs.kubernetes]]
-    url = "https://$HOSTIP:10250"
-    bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
-    insecure_skip_verify = true

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -84,6 +84,27 @@ config:
     logfile: ""
     hostname: "$HOSTNAME"
     omit_hostname: false
+  inputs:
+    - cpu:
+        percpu: true
+        totalcpu: true
+        collect_cpu_time: false
+        report_active: false
+    - disk:
+        ignore_fs: ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
+    - diskio:
+    - docker:
+        endpoint: "unix:///var/run/docker.sock"
+    - kernel:
+    - kubernetes:
+        url: "https://$HOSTIP:10250"
+        bearer_token: "/run/secrets/kubernetes.io/serviceaccount/token"
+        insecure_skip_verify: true
+    - mem:
+    - net:
+    - processes:
+    - swap:
+    - system:
   outputs:
     - influxdb:
         urls:


### PR DESCRIPTION
Modifying `config.inputs` allows the addition but not removal of predefined inputs. To disable an input the `ConfigMap` must be modified after the chart is installed. For example, the `docker` input will fail if using a different container runtime. It would be better if the list of enabled inputs could be configured in `values.yaml` in the same way outputs are configured.