### PR TITLE
prevent random password change on upgrade

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
-version: 1.0.6
+version: 1.0.7
 maintainers:
 - name: rawkode
   email: rawkode@influxdata.com

--- a/charts/influxdb2/templates/secret.yaml
+++ b/charts/influxdb2/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- $previous := (lookup "v1" "Secret" .Release.Namespace (printf "%s-auth" (include "influxdb.fullname" . ))) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,12 +8,16 @@ metadata:
 data:
   {{- if .Values.adminUser.token }}
   admin-token: {{ .Values.adminUser.token  | b64enc | quote }}
+  {{- else if $previous }}
+  admin-token: {{ index $previous.data "admin-token" }}
   {{- else }}
   admin-token: {{ randAlphaNum 32 | b64enc | quote }}
   {{- end }}
 
   {{- if .Values.adminUser.password }}
   admin-password: {{ .Values.adminUser.password | b64enc | quote }}
+  {{- else if $previous }}
+  admin-password: {{ index $previous.data "admin-password" }}
   {{- else }}
   admin-password: {{ randAlphaNum 32 | b64enc | quote }}
   {{- end }}


### PR DESCRIPTION
Currently, the passwords generated in `*-influxdb2-auth` secret are changed on every upgrade. However, the job setting up the admin account is executed only after installation. This makes the secret inconsistent with the running configuration and causes confusion.
This is a known issue when using `randAlphaNum` discussed [here](https://github.com/helm/charts/issues/5167). I have applied the solution suggested in a comment there.
- [ ] CHANGELOG.md updated
- [X] Rebased/mergable
- [ ] Tests pass
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
