### PR TITLE
[telegraf-operator] Fix certificate issue related to helm upgrade

### DIFF
--- a/charts/telegraf-operator/Chart.yaml
+++ b/charts/telegraf-operator/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.2
+version: 1.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/telegraf-operator/templates/_helpers.tpl
+++ b/charts/telegraf-operator/templates/_helpers.tpl
@@ -105,7 +105,7 @@ metadata:
   labels:
     {{- include "telegraf-operator.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": "pre-install"
+    "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
   tls.crt: {{ $cert.Cert | b64enc }}

--- a/charts/telegraf-operator/templates/deployment.yaml
+++ b/charts/telegraf-operator/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
     metadata:
       labels:
         {{- include "telegraf-operator.selectorLabels" . | nindent 8 }}
+{{- if eq .Values.certManager.enable false }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/tls.yml") . | sha256sum }}
+{{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
After helm upgrade for non cert manager installation, the CA in webhook is updated, but secret left unchanged what leads to tls errors (certificates aren't signed by the new CA).

This PR additionally add annotations (as recommended in [official documentation](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments)) to reload deployment in case of secret change. It's required to reload certificates from secret as k8s uses new CA to validate requests