### PR TITLE
feat(influxdb): Add values to the environment from a secret

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.8.4
+version: 4.8.5
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/statefulset.yaml
+++ b/charts/influxdb/templates/statefulset.yaml
@@ -90,6 +90,11 @@ spec:
             value: "$(_HOSTNAME).{{ include "influxdb.fullname" . }}"
         {{- end }}
         {{- end }}
+        {{- if .Values.envFromSecret }}
+        envFrom:
+        - secretRef:
+            name: {{ .Values.envFromSecret }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /ping

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -213,6 +213,12 @@ env: {}
   # - name: INFLUXDB_DB
   #   value: "demo"
 
+## The name of a secret in the same kubernetes namespace which contain values
+## to be added to the environment.
+## This can be used, for example, to set the INFLUXDB_HTTP_SHARED_SECRET
+## environment variable.
+envFromSecret: {}
+
 ## InfluxDB configuration
 ## ref: https://docs.influxdata.com/influxdb/v1.7/administration/config
 config:


### PR DESCRIPTION

This PR adds to the InfluxDB chart a [similar mechanism we have in the Chronograf chart](https://github.com/influxdata/helm-charts/blob/master/charts/chronograf/values.yaml#L122-L124) to add values to the environment from a secret. 

I need this to set the `INFLUXDB_HTTP_SHARED_SECRET` to configure [auth using JWT tokens.](https://docs.influxdata.com/influxdb/v1.8/administration/authentication_and_authorization/#authenticate-using-jwt-tokens)

I've tested the manifest generated from this change using `helm template . <my values yaml>` and `kubectl -f apply <manifest yaml>` and verified that the `shared-secret` configuration is present in the `[http]` session of the InfluxDB config. 
