### PR TITLE
Influxdb2 ingress

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
-version: 1.0.6
+version: 1.0.7
 maintainers:
 - name: rawkode
   email: rawkode@influxdata.com

--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
-version: 1.0.7
+version: 1.0.8
 maintainers:
 - name: rawkode
   email: rawkode@influxdata.com

--- a/charts/influxdb2/templates/ingress.yaml
+++ b/charts/influxdb2/templates/ingress.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "influxdb.fullname" . }}
+  labels:
+    {{- include "influxdb.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+    - hosts:
+      - {{ .Values.ingress.hostname | quote }}
+      secretName: {{ .Values.ingress.secretName }}
+{{- end }}
+  rules:
+  - host: {{ .Values.ingress.hostname }}
+    http:
+      paths:
+      - path: {{ .Values.ingress.path }}
+        backend:
+          serviceName: {{ include "influxdb.fullname" . }}
+          servicePort: http
+{{- end -}}

--- a/charts/influxdb2/templates/job-setup-admin.yaml
+++ b/charts/influxdb2/templates/job-setup-admin.yaml
@@ -34,7 +34,7 @@ spec:
           - -c
           - |
             influx setup -f \
-            --host http://{{ template "influxdb.fullname" . }} \
+            --host http://{{ template "influxdb.fullname" . }}:{{ .Values.service.port }} \
             -o {{ .Values.adminUser.organization }} \
             -b {{ .Values.adminUser.bucket }} \
             -u {{ .Values.adminUser.user }} \

--- a/charts/influxdb2/templates/service.yaml
+++ b/charts/influxdb2/templates/service.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - port: 80
-    targetPort: 9999
+  - port: {{ .Values.service.port }}
+    targetPort: http
     protocol: TCP
     name: http
   selector:

--- a/charts/influxdb2/templates/service.yaml
+++ b/charts/influxdb2/templates/service.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ template "influxdb.fullname" . }}
   labels:
     {{- include "influxdb.labels" . | nindent 4 }}
-    app.kubernetes.io/component: backup
 spec:
   type: ClusterIP
   ports:

--- a/charts/influxdb2/values.yaml
+++ b/charts/influxdb2/values.yaml
@@ -53,3 +53,6 @@ persistence:
   # storageClass: "-"
   accessMode: ReadWriteOnce
   size: 50Gi
+
+service:
+  port: 80

--- a/charts/influxdb2/values.yaml
+++ b/charts/influxdb2/values.yaml
@@ -56,3 +56,13 @@ persistence:
 
 service:
   port: 80
+
+ingress:
+  enabled: false
+  tls: false
+  # secretName: my-tls-cert # only needed if tls above is true
+  hostname: influxdb.foobar.com
+  annotations: {}
+    # kubernetes.io/ingress.class: "nginx"
+    # kubernetes.io/tls-acme: "true"
+  path: /


### PR DESCRIPTION
This adds an ingress object to the influxdb2 chart.

The template is almost identical to the one from the influxdb chart, but it uses the named port of the service instead of hardcoding the port number.

The service template has been updated to target the named port of the container and to make the service port customizable.

The job-setup-admin template has been updated to use the custom service port.

The values.yaml file has been updated with the default values for the service and ingress templates that will keep the previous behaviour if not overriden.

- [x] Rebased/mergable
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)