### PR TITLE
Added templating for 2 load balancers to telegraf enable LoadBalancer Service

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.7.23
+version: 1.7.24
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -1,8 +1,9 @@
 {{- if .Values.service.enabled -}}
+{{- if eq .Values.service.type "LoadBalancer" -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "telegraf.fullname" . }}
+  name: {{ include "telegraf.fullname" . -}}-tcp
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
   {{- if .Values.service.annotations }}
@@ -11,6 +12,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP -}}
+  loadbalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
   - port: 8888
     targetPort: 8888
@@ -64,4 +68,104 @@ spec:
   {{- end }}
   selector:
     {{- include "telegraf.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "telegraf.fullname" . -}}-udp
+  labels:
+    {{- include "telegraf.labels" . | nindent 4 }}
+  {{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP -}}
+  loadbalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+  {{- range $objectKey, $objectValue := .Values.config.inputs }}
+  {{- range $key, $value := . -}}
+    {{- if eq $key "statsd" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    protocol: "UDP"
+    name: "statsd"
+    {{- end }}
+    {{- if eq $key "udp_listener" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    protocol: "UDP"
+    name: "udp-listener"
+    {{- end }}
+  {{- end -}}
+  {{- end }}
+  {{- range $objectKey, $objectValue := .Values.config.outputs }}
+  {{- range $key, $value := . -}}
+    {{- $tp := typeOf $value -}}
+    {{- if eq $key "prometheus_client" }}
+  - port: {{ trimPrefix ":" $value.listen | int64 }}
+    targetPort: {{ trimPrefix ":" $value.listen | int64 }}
+    name: "prometheus-client"
+    {{- end }}
+  {{- end -}}
+  {{- end }}
+  selector:
+    {{- include "telegraf.selectorLabels" . | nindent 4 }}
+{{else}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "telegraf.fullname" . }}
+  labels:
+    {{- include "telegraf.labels" . | nindent 4 }}
+  {{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: 8888
+    targetPort: 8888
+    name: "health"
+  {{- range $objectKey, $objectValue := .Values.config.inputs }}
+  {{- range $key, $value := . -}}
+    {{- $tp := typeOf $value -}}
+    {{- if eq $key "http_listener" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    name: "http-listener"
+    {{- end }}
+    {{- if eq $key "http_listener_v2" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    name: "http-listener-v2"
+    {{- end }}
+    {{- if eq $key "tcp_listener" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    name: "tcp-listener"
+    {{- end }}
+    {{- if eq $key "webhooks" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    name: "webhooks"
+    {{- end }}
+  {{- end -}}
+  {{- end }}
+  {{- range $objectKey, $objectValue := .Values.config.outputs }}
+  {{- range $key, $value := . -}}
+    {{- $tp := typeOf $value -}}
+    {{- if eq $key "prometheus_client" }}
+  - port: {{ trimPrefix ":" $value.listen | int64 }}
+    targetPort: {{ trimPrefix ":" $value.listen | int64 }}
+    name: "prometheus-client"
+    {{- end }}
+  {{- end -}}
+  {{- end }}
+  selector:
+    {{- include "telegraf.selectorLabels" . | nindent 4 }}
+{{end}}
 {{- end -}}

--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -12,8 +12,8 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
-  {{- if .Values.service.loadBalancerIPTCP -}}
-  loadbalancerIP: {{ .Values.service.loadBalancerIPTCP }}
+  {{- if .Values.service.loadBalancerIPTCP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIPTCP }}
   {{- end }}
   ports:
   - port: 8888
@@ -69,8 +69,8 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
-  {{- if .Values.service.loadBalancerIPUDP -}}
-  loadbalancerIP: {{ .Values.service.loadBalancerIPUDP }}
+  {{- if .Values.service.loadBalancerIPUDP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIPUDP }}
   {{- end }}
   ports:
   {{- range $objectKey, $objectValue := .Values.config.inputs }}

--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -12,8 +12,8 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
-  {{- if .Values.service.loadBalancerIP -}}
-  loadbalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- if .Values.service.loadBalancerIPTCP -}}
+  loadbalancerIP: {{ .Values.service.loadBalancerIPTCP }}
   {{- end }}
   ports:
   - port: 8888
@@ -32,22 +32,10 @@ spec:
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
     name: "http-listener-v2"
     {{- end }}
-    {{- if eq $key "statsd" }}
-  - port: {{ trimPrefix ":" $value.service_address | int64 }}
-    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
-    protocol: "UDP"
-    name: "statsd"
-    {{- end }}
     {{- if eq $key "tcp_listener" }}
   - port: {{ trimPrefix ":" $value.service_address | int64 }}
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
     name: "tcp-listener"
-    {{- end }}
-    {{- if eq $key "udp_listener" }}
-  - port: {{ trimPrefix ":" $value.service_address | int64 }}
-    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
-    protocol: "UDP"
-    name: "udp-listener"
     {{- end }}
     {{- if eq $key "webhooks" }}
   - port: {{ trimPrefix ":" $value.service_address | int64 }}
@@ -81,8 +69,8 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
-  {{- if .Values.service.loadBalancerIP -}}
-  loadbalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- if .Values.service.loadBalancerIPUDP -}}
+  loadbalancerIP: {{ .Values.service.loadBalancerIPUDP }}
   {{- end }}
   ports:
   {{- range $objectKey, $objectValue := .Values.config.inputs }}

--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -131,10 +131,22 @@ spec:
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
     name: "http-listener-v2"
     {{- end }}
+    {{- if eq $key "statsd" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    protocol: "UDP"
+    name: "statsd"
+    {{- end }}
     {{- if eq $key "tcp_listener" }}
   - port: {{ trimPrefix ":" $value.service_address | int64 }}
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
     name: "tcp-listener"
+    {{- end }}
+    {{- if eq $key "udp_listener" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    protocol: "UDP"
+    name: "udp-listener"
     {{- end }}
     {{- if eq $key "webhooks" }}
   - port: {{ trimPrefix ":" $value.service_address | int64 }}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -65,8 +65,12 @@ tolerations: []
 
 service:
   enabled: true
-  type: ClusterIP
+  type: ClusterIP # Using a LoadBalancer will create 2 services: 1 TCP and 1 UDP
   annotations: {}
+  # Used to set the loadBalancerIP for the TCP service if type is LoadBalancer (optional)
+  # loadBalancerIPTCP: ""
+  # Used to set the loadBalancerIP for the UDP service if type is LoadBalancer (optional)
+  # loadBalancerIPUDP: ""
 
 rbac:
   # Specifies whether RBAC resources should be created


### PR DESCRIPTION
## Description
This makes the telegraf helm chart able to deploy services of the type LoadBalancer, and makes #176 possible.

This creates 2 services if the service type is load balancer, 1 to handle TCP and another to handle UDP. This is needed due to the limitation in [this kubernetes issue ](https://github.com/kubernetes/kubernetes/issues/23880). This also adds 2 load balancer specific IP values based on the recommendation in #176. 
## Checklist
- [ ] CHANGELOG.md updated <-couldn't find in repo
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

## Testing Outputs
#### Default output 
```yaml
❯ helm template telegraf-test ./ --validate                                                                                                                                                                                                                                                                                                                                                                                               ─╯
---
# Source: telegraf/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: telegraf-test
  labels:
    helm.sh/chart: telegraf-1.7.24
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
---
# Source: telegraf/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: telegraf-test
  labels:
    helm.sh/chart: telegraf-1.7.24
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
data:
  telegraf.conf: |+
    
    [agent]
      collection_jitter = "0s"
      debug = false
      flush_interval = "10s"
      flush_jitter = "0s"
      hostname = "$HOSTNAME"
      interval = "10s"
      logfile = ""
      metric_batch_size = 1000
      metric_buffer_limit = 10000
      omit_hostname = false
      precision = ""
      quiet = false
      round_interval = true
    [[processors.enum]]
      [[processors.enum.mapping]]
        dest = "status_code"
        field = "status"
        [processors.enum.mapping.value_mappings]
            critical = 3
            healthy = 1
            problem = 2
    
    
    [[outputs.influxdb]]
      database = "telegraf"
      urls = [
        "http://influxdb.monitoring.svc:8086"
      ]
    
    [[outputs.health]]
      service_address = "http://:8888"
      [[outputs.health.compares]]
        field = "buffer_size"
        lt = 5000.0
      [[outputs.health.contains]]
        field = "buffer_size"
    [[inputs.statsd]]
      allowed_pending_messages = 10000
      metric_separator = "_"
      percentile_limit = 1000
      percentiles = [
        50,
        95,
        99
      ]
      service_address = ":8125"
    [[inputs.internal]]
      collect_memstats = false
---
# Source: telegraf/templates/role.yaml
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: Role
metadata:
  name: telegraf-test
  namespace: default
  labels:
    helm.sh/chart: telegraf-1.7.24
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
rules:
  []
---
# Source: telegraf/templates/rolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: RoleBinding
metadata:
  name: telegraf-test
  labels:
    helm.sh/chart: telegraf-1.7.24
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
subjects:
  - kind: ServiceAccount
    name: telegraf-test
    namespace: default
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: telegraf-test
---
# Source: telegraf/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: telegraf-test
  labels:
    helm.sh/chart: telegraf-1.7.24
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
spec:
  type: ClusterIP
  ports:
  - port: 8888
    targetPort: 8888
    name: "health"
  - port: 8125
    targetPort: 8125
    protocol: "UDP"
    name: "statsd"
  selector:
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
---
# Source: telegraf/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: telegraf-test
  labels:
    helm.sh/chart: telegraf-1.7.24
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: telegraf
      app.kubernetes.io/instance: telegraf-test
  template:
    metadata:
      labels:
        app.kubernetes.io/name: telegraf
        app.kubernetes.io/instance: telegraf-test
      annotations:
        checksum/config: c20820ecdcab6c8dcaf6679cb746aecebb1b7e003e0e1306b9a6feb5679ff85a
    spec:
      serviceAccountName: telegraf-test
      containers:
      - name: telegraf
        image: "telegraf:1.14-alpine"
        imagePullPolicy: "IfNotPresent"
        resources:
          {}
        env:
        - name: HOSTNAME
          value: telegraf-polling-service
        volumeMounts:
        - name: config
          mountPath: /etc/telegraf
      volumes:
      - name: config
        configMap:
          name: telegraf-test
```
#### Load Balancer no ips
```yaml
❯ helm template telegraf-test ./ --validate --set service.type=LoadBalancer                                                                                                                                                                                                                                                                                                                                                               ─╯
---
# Source: telegraf/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: telegraf-test
  labels:
    helm.sh/chart: telegraf-1.7.23
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
---
# Source: telegraf/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: telegraf-test
  labels:
    helm.sh/chart: telegraf-1.7.23
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
data:
  telegraf.conf: |+
    
    [agent]
      collection_jitter = "0s"
      debug = false
      flush_interval = "10s"
      flush_jitter = "0s"
      hostname = "$HOSTNAME"
      interval = "10s"
      logfile = ""
      metric_batch_size = 1000
      metric_buffer_limit = 10000
      omit_hostname = false
      precision = ""
      quiet = false
      round_interval = true
    [[processors.enum]]
      [[processors.enum.mapping]]
        dest = "status_code"
        field = "status"
        [processors.enum.mapping.value_mappings]
            critical = 3
            healthy = 1
            problem = 2
    
    
    [[outputs.influxdb]]
      database = "telegraf"
      urls = [
        "http://influxdb.monitoring.svc:8086"
      ]
    
    [[outputs.health]]
      service_address = "http://:8888"
      [[outputs.health.compares]]
        field = "buffer_size"
        lt = 5000.0
      [[outputs.health.contains]]
        field = "buffer_size"
    [[inputs.statsd]]
      allowed_pending_messages = 10000
      metric_separator = "_"
      percentile_limit = 1000
      percentiles = [
        50,
        95,
        99
      ]
      service_address = ":8125"
    [[inputs.internal]]
      collect_memstats = false
---
# Source: telegraf/templates/role.yaml
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: Role
metadata:
  name: telegraf-test
  namespace: default
  labels:
    helm.sh/chart: telegraf-1.7.23
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
rules:
  []
---
# Source: telegraf/templates/rolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: RoleBinding
metadata:
  name: telegraf-test
  labels:
    helm.sh/chart: telegraf-1.7.23
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
subjects:
  - kind: ServiceAccount
    name: telegraf-test
    namespace: default
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: telegraf-test
---
# Source: telegraf/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: telegraf-test-tcp
  labels:
    helm.sh/chart: telegraf-1.7.23
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
spec:
  type: LoadBalancer
  ports:
  - port: 8888
    targetPort: 8888
    name: "health"
  selector:
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
---
# Source: telegraf/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: telegraf-test-udp
  labels:
    helm.sh/chart: telegraf-1.7.23
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
spec:
  type: LoadBalancer
  ports:
  - port: 8125
    targetPort: 8125
    protocol: "UDP"
    name: "statsd"
  selector:
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
---
# Source: telegraf/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: telegraf-test
  labels:
    helm.sh/chart: telegraf-1.7.23
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: telegraf
      app.kubernetes.io/instance: telegraf-test
  template:
    metadata:
      labels:
        app.kubernetes.io/name: telegraf
        app.kubernetes.io/instance: telegraf-test
      annotations:
        checksum/config: 2c7743ee151b1d3f9b910c0ec1472babf308beb262b2dd50d23ccb1d5a8ff492
    spec:
      serviceAccountName: telegraf-test
      containers:
      - name: telegraf
        image: "telegraf:1.14-alpine"
        imagePullPolicy: "IfNotPresent"
        resources:
          {}
        env:
        - name: HOSTNAME
          value: telegraf-polling-service
        volumeMounts:
        - name: config
          mountPath: /etc/telegraf
      volumes:
      - name: config
        configMap:
          name: telegraf-test
```

#### Load Balancer With IPs
```yaml
❯ helm template telegraf-test ./ --validate --set service.type=LoadBalancer --set service.loadBalancerIPTCP=192.168.1.1 --set service.loadBalancerIPUDP=192.168.1.1 --debug                                                                                                                                                                                                                                                               ─╯
install.go:172: [debug] Original chart version: ""
install.go:189: [debug] CHART PATH: /Users/awilczek/projects/helm-charts/charts/telegraf

---
# Source: telegraf/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: telegraf-test
  labels:
    helm.sh/chart: telegraf-1.7.24
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
---
# Source: telegraf/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: telegraf-test
  labels:
    helm.sh/chart: telegraf-1.7.24
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
data:
  telegraf.conf: |+
    
    [agent]
      collection_jitter = "0s"
      debug = false
      flush_interval = "10s"
      flush_jitter = "0s"
      hostname = "$HOSTNAME"
      interval = "10s"
      logfile = ""
      metric_batch_size = 1000
      metric_buffer_limit = 10000
      omit_hostname = false
      precision = ""
      quiet = false
      round_interval = true
    [[processors.enum]]
      [[processors.enum.mapping]]
        dest = "status_code"
        field = "status"
        [processors.enum.mapping.value_mappings]
            critical = 3
            healthy = 1
            problem = 2
    
    
    [[outputs.influxdb]]
      database = "telegraf"
      urls = [
        "http://influxdb.monitoring.svc:8086"
      ]
    
    [[outputs.health]]
      service_address = "http://:8888"
      [[outputs.health.compares]]
        field = "buffer_size"
        lt = 5000.0
      [[outputs.health.contains]]
        field = "buffer_size"
    [[inputs.statsd]]
      allowed_pending_messages = 10000
      metric_separator = "_"
      percentile_limit = 1000
      percentiles = [
        50,
        95,
        99
      ]
      service_address = ":8125"
    [[inputs.internal]]
      collect_memstats = false
---
# Source: telegraf/templates/role.yaml
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: Role
metadata:
  name: telegraf-test
  namespace: default
  labels:
    helm.sh/chart: telegraf-1.7.24
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
rules:
  []
---
# Source: telegraf/templates/rolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: RoleBinding
metadata:
  name: telegraf-test
  labels:
    helm.sh/chart: telegraf-1.7.24
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
subjects:
  - kind: ServiceAccount
    name: telegraf-test
    namespace: default
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: telegraf-test
---
# Source: telegraf/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: telegraf-test-tcp
  labels:
    helm.sh/chart: telegraf-1.7.24
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
spec:
  type: LoadBalancer
  loadBalancerIP: 192.168.1.1
  ports:
  - port: 8888
    targetPort: 8888
    name: "health"
  selector:
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
---
# Source: telegraf/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: telegraf-test-udp
  labels:
    helm.sh/chart: telegraf-1.7.24
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
spec:
  type: LoadBalancer
  loadBalancerIP: 192.168.1.1
  ports:
  - port: 8125
    targetPort: 8125
    protocol: "UDP"
    name: "statsd"
  selector:
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
---
# Source: telegraf/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: telegraf-test
  labels:
    helm.sh/chart: telegraf-1.7.24
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf-test
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: telegraf
      app.kubernetes.io/instance: telegraf-test
  template:
    metadata:
      labels:
        app.kubernetes.io/name: telegraf
        app.kubernetes.io/instance: telegraf-test
      annotations:
        checksum/config: c20820ecdcab6c8dcaf6679cb746aecebb1b7e003e0e1306b9a6feb5679ff85a
    spec:
      serviceAccountName: telegraf-test
      containers:
      - name: telegraf
        image: "telegraf:1.14-alpine"
        imagePullPolicy: "IfNotPresent"
        resources:
          {}
        env:
        - name: HOSTNAME
          value: telegraf-polling-service
        volumeMounts:
        - name: config
          mountPath: /etc/telegraf
      volumes:
      - name: config
        configMap:
          name: telegraf-test
```