### PR TITLE
Add support for influxdb-listener since http-listener is deprecated

### DIFF
--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -23,6 +23,11 @@ spec:
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
     name: "http-listener"
     {{- end }}
+    {{- if eq $key "influxdb_listener" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    name: "influxdb-listener"
+    {{- end }}
     {{- if eq $key "http_listener_v2" }}
   - port: {{ trimPrefix ":" $value.service_address | int64 }}
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}


### PR DESCRIPTION
per https://docs.influxdata.com/telegraf/v1.15/plugins/#http_listener being deprecated, adding support for influx-listener. 