### PR TITLE
Adding support for influxdb_listener since http_listener is deprecated

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.7.23
+version: 1.7.24
 appVersion: 1.14
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -23,6 +23,11 @@ spec:
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
     name: "http-listener"
     {{- end }}
+    {{- if eq $key "influxdb_listener" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    name: "influxdb-listener"
+    {{- end }}
     {{- if eq $key "http_listener_v2" }}
   - port: {{ trimPrefix ":" $value.service_address | int64 }}
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}


### PR DESCRIPTION
Tested locally on a kube cluster. Let me know if there's anything else I need to address in PR 
- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [n/a] Tests pass
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)