### PR TITLE
Allow to customize healthchcks for liveness, readiness, startup probes

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.8.5
+version: 4.8.6
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/meta-statefulset.yaml
+++ b/charts/influxdb/templates/meta-statefulset.yaml
@@ -52,20 +52,20 @@ spec:
         {{- end }}
         livenessProbe:
           httpGet:
-            path: /ping
+            path: {{ .Values.livenessProbe.path | default "/ping" }}
             port: meta
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 30 }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds | default 5 }}
         readinessProbe:
           httpGet:
-            path: /ping
+            path: {{ .Values.readinessProbe.path | default "/ping" }}
             port: meta
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 5 }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds | default 1 }}
         {{- if .Values.startupProbe.enabled }}
         startupProbe:
           httpGet:
-            path: /ping
+            path: {{ .Values.startupProbe.path | default "/ping" }}
             port: meta
           failureThreshold: {{ .Values.startupProbe.failureThreshold | default 6 }}
           periodSeconds: {{ .Values.startupProbe.periodSeconds | default 5 }}

--- a/charts/influxdb/templates/statefulset.yaml
+++ b/charts/influxdb/templates/statefulset.yaml
@@ -97,14 +97,14 @@ spec:
         {{- end }}
         livenessProbe:
           httpGet:
-            path: /ping
+            path: {{ .Values.livenessProbe.path | default "/ping" }}
             port: api
             scheme: {{ .Values.livenessProbe.scheme | default "HTTP" }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 30 }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds | default 5 }}
         readinessProbe:
           httpGet:
-            path: /ping
+            path: {{ .Values.readinessProbe.path | default "/ping" }}
             port: api
             scheme: {{ .Values.readinessProbe.scheme | default "HTTP" }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 5 }}
@@ -112,7 +112,7 @@ spec:
         {{- if .Values.startupProbe.enabled }}
         startupProbe:
           httpGet:
-            path: /ping
+            path: {{ .Values.startupProbe.path | default "/ping" }}
             port: api
             scheme: {{ .Values.startupProbe.scheme | default "HTTP" }}
           failureThreshold: {{ .Values.startupProbe.failureThreshold | default 6 }}

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -19,11 +19,13 @@ serviceAccount:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 ##
 livenessProbe: {}
+  # path: "/ping"
   # initialDelaySeconds: 30
   # timeoutSeconds: 5
   # scheme: HTTP
 
 readinessProbe: {}
+  # path: "/ping"
   # initialDelaySeconds: 5
   # timeoutSeconds: 1
   # scheme: HTTP
@@ -34,6 +36,7 @@ securityContext: {}
 
 startupProbe:
   enabled: false
+  # path: "/ping"
   # failureThreshold: 6
   # periodSeconds: 5
   # scheme: HTTP


### PR DESCRIPTION
GKE ingress needs healthchecks path `/ping?verbose=true` as [10321](https://github.com/influxdata/influxdb/pull/10321) is now implemented. 
Fixes # [15165](https://github.com/helm/charts/issues/15165)
