### PR TITLE
influxdb2: bumped up to 2.0.0-rc

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
-version: 1.0.7
+version: 1.0.8
 maintainers:
 - name: rawkode
   email: rawkode@influxdata.com

--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.0.0-beta
+appVersion: 2.0.0-rc
 
 name: influxdb2
 description: A Helm chart for InfluxDB v2

--- a/charts/influxdb2/templates/service.yaml
+++ b/charts/influxdb2/templates/service.yaml
@@ -9,7 +9,7 @@ spec:
   type: ClusterIP
   ports:
   - port: 80
-    targetPort: 9999
+    targetPort: 8086
     protocol: TCP
     name: http
   selector:

--- a/charts/influxdb2/templates/statefulset.yaml
+++ b/charts/influxdb2/templates/statefulset.yaml
@@ -34,7 +34,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 9999
+              containerPort: 8086
               protocol: TCP
           livenessProbe:
             httpGet:


### PR DESCRIPTION
- bumped up influxdb version to 2.0.0-rc
- change default port (9999 -> 8086) ([description](https://github.com/influxdata/influxdb/releases/tag/v2.0.0-rc.0))