### PR TITLE
chore: improve release process to be more forgiving

### DIFF
--- a/.github/workflows/helm-charts-release.yaml
+++ b/.github/workflows/helm-charts-release.yaml
@@ -1,9 +1,22 @@
 name: "helm-charts/release"
 
+# I'm hoping that this means we only trigger a release
+# when the push is to the master branch and a Chart.yaml was
+# modified.
+#
+# We've found that automatically releasing on push to master alone
+# causes a lot of problems, especially as we forget to encourage contributors
+# to bump the version; even reminding them isn't a great experience.
+#
+# This should allow us to have a successful build without such a change
+# and then manually update the Chart version ourselves, without build
+# failures
 on:
   push:
     branches:
       - master
+    paths:
+      - "**/Chart.yaml"
 
 jobs:
   release:


### PR DESCRIPTION
I'm hoping that this means we only trigger a release
when the push is to the master branch and a Chart.yaml was
modified.

We've found that automatically releasing on push to master alone
causes a lot of problems, especially as we forget to encourage contributors
to bump the version; even reminding them isn't a great experience.

This should allow us to have a successful build without such a change
and then manually update the Chart version ourselves, without build
failures