### PR TITLE
Nested TOML tables should only be surrounded by a single bracket.

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.7.28
+version: 1.7.30
 appVersion: 1.15
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.7.27
+version: 1.7.28
 appVersion: 1.15
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.7.30
+version: 1.7.31
 appVersion: 1.15
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/_helpers.tpl
+++ b/charts/telegraf/templates/_helpers.tpl
@@ -164,7 +164,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
         ]
               {{- end }}
               {{- if eq $tps "map[string]interface {}"}}
-        [[outputs.{{ $output }}.{{ $key }}.{{ $k }}]]
+          [outputs.{{ $output }}.{{ $key }}.{{ $k }}]
                 {{- range $foo, $bar := $v }}
             {{ $foo }} = {{ $bar | quote }}
                 {{- end }}
@@ -253,7 +253,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
               {{- range $k, $v := $value }}
               {{- $tps := typeOf $v }}
               {{- if eq $tps "map[string]interface {}"}}
-        [[inputs.{{ $input }}.{{ $key }}.{{ $k }}]]
+          [inputs.{{ $input }}.{{ $key }}.{{ $k }}]
                 {{- range $foo, $bar := $v }}
             {{ $foo }} = {{ $bar | quote }}
                 {{- end }}

--- a/charts/telegraf/templates/_helpers.tpl
+++ b/charts/telegraf/templates/_helpers.tpl
@@ -134,7 +134,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
         {{- range $key, $value := $config -}}
           {{- $tp := typeOf $value -}}
           {{- if eq $tp "map[string]interface {}" }}
-      [[outputs.{{ $output }}.{{ $key }}]]
+      [outputs.{{ $output }}.{{ $key }}]
             {{- range $k, $v := $value }}
               {{- $tps := typeOf $v }}
               {{- if eq $tps "string" }}

--- a/charts/telegraf/templates/configmap.yaml
+++ b/charts/telegraf/templates/configmap.yaml
@@ -13,10 +13,10 @@ data:
     {{ template "outputs" .Values.config.outputs }}
     [[outputs.health]]
       service_address = "http://:8888"
-      [outputs.health.compares]
+      [[outputs.health.compares]]
         field = "buffer_size"
         lt = 5000.0
-      [outputs.health.contains]
+      [[outputs.health.contains]]
         field = "buffer_size"
     {{ template "inputs" .Values.config.inputs -}}
     [[inputs.internal]]

--- a/charts/telegraf/templates/configmap.yaml
+++ b/charts/telegraf/templates/configmap.yaml
@@ -13,10 +13,10 @@ data:
     {{ template "outputs" .Values.config.outputs }}
     [[outputs.health]]
       service_address = "http://:8888"
-      [[outputs.health.compares]]
+      [outputs.health.compares]
         field = "buffer_size"
         lt = 5000.0
-      [[outputs.health.contains]]
+      [outputs.health.contains]
         field = "buffer_size"
     {{ template "inputs" .Values.config.inputs -}}
     [[inputs.internal]]


### PR DESCRIPTION
This is similar to https://github.com/influxdata/helm-charts/pull/100 which fixed the `input` side of plugins, same change for the `output` side.