### PR TITLE
feat(telegraf-operator): add optional --require-annotations-for-secret flag

### DIFF
--- a/charts/telegraf-operator/Chart.yaml
+++ b/charts/telegraf-operator/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.3
+version: 1.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/telegraf-operator/templates/deployment.yaml
+++ b/charts/telegraf-operator/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - --telegraf-classes-directory=/etc/telegraf-operator
             - --enable-default-internal-plugin
             - "--telegraf-image={{ .Values.image.sidecarImage }}"
-            {{- if .Values.requireAnnotationsForSecret }}
+            {{- if eq .Values.requireAnnotationsForSecret true }}
             - "--require-annotations-for-secret"
             {{- end }}
           env:

--- a/charts/telegraf-operator/templates/deployment.yaml
+++ b/charts/telegraf-operator/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
             - --telegraf-classes-directory=/etc/telegraf-operator
             - --enable-default-internal-plugin
             - "--telegraf-image={{ .Values.image.sidecarImage }}"
+            {{- if .Values.requireAnnotationsForSecret }}
+            - "--require-annotations-for-secret"
+            {{- end }}
           env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/charts/telegraf-operator/values.yaml
+++ b/charts/telegraf-operator/values.yaml
@@ -45,3 +45,4 @@ resources:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+requireAnnotationsForSecret: false


### PR DESCRIPTION
Adds support for `--require-annotations-for-secret` introduced in influxdata/telegraf-operator#42 that allows enforcing checking of annotation for secret used for storing telegraf configuration.

Not enabled by default as this flag should not be enabled on any existing deployment of `telegraf-operator` since secrets created prior to influxdata/telegraf-operator#42 will not have the annotation set.
