### PR TITLE
Add link to chart sources to Chart.yaml

### DIFF
--- a/charts/chronograf/Chart.yaml
+++ b/charts/chronograf/Chart.yaml
@@ -12,6 +12,8 @@ keywords:
 - influxdata
 - influxdb
 home: https://www.influxdata.com/time-series-platform/chronograf/
+sources:
+- https://github.com/influxdata/helm-charts/
 maintainers:
 - name: rawkode
   email: rawkode@influxdata.com

--- a/charts/influxdb-enterprise/Chart.yaml
+++ b/charts/influxdb-enterprise/Chart.yaml
@@ -13,6 +13,8 @@ keywords:
   - influxdata
 home: https://www.influxdata.com/time-series-platform/influxdb/
 sources:
+- https://github.com/influxdata/helm-charts/
+sources:
   - https://github.com/influxdata/influxdb
 maintainers:
   - name: rawkode

--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -10,6 +10,8 @@ keywords:
   - influxdata
 home: https://www.influxdata.com/time-series-platform/influxdb/
 sources:
+- https://github.com/influxdata/helm-charts/
+sources:
   - https://github.com/influxdata/influxdb
 maintainers:
   - name: rawkode

--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -4,6 +4,8 @@ appVersion: 2.0.0-rc
 name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
+sources:
+- https://github.com/influxdata/helm-charts/
 type: application
 version: 1.0.11
 maintainers:

--- a/charts/kapacitor/Chart.yaml
+++ b/charts/kapacitor/Chart.yaml
@@ -13,6 +13,8 @@ keywords:
 - influxdata
 home: https://www.influxdata.com/time-series-platform/kapacitor/
 sources:
+- https://github.com/influxdata/helm-charts/
+sources:
 - https://github.com/influxdata/kapacitor
 maintainers:
 - name: rawkode

--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -10,6 +10,8 @@ keywords:
 - timeseries
 - influxdata
 home: https://www.influxdata.com/time-series-platform/telegraf/
+sources:
+- https://github.com/influxdata/helm-charts/
 maintainers:
 - name: rawkode
   email: rawkode@influxdata.com

--- a/charts/telegraf-operator/Chart.yaml
+++ b/charts/telegraf-operator/Chart.yaml
@@ -19,6 +19,8 @@ maintainers:
 
 kubeVersion: ">= 1.13.0-r0"
 home: https://github.com/influxdata/telegraf-operator
+sources:
+- https://github.com/influxdata/helm-charts/
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -12,6 +12,8 @@ keywords:
   - influxdb
   - agent
 home: https://www.influxdata.com/time-series-platform/telegraf/
+sources:
+- https://github.com/influxdata/helm-charts/
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com


### PR DESCRIPTION
This PR adds the URL of this github repository under the `sources` field in each chart's `Chart.yaml` file. This field is displayed along with other chart metadata on sites like hub.helm.sh and artifacthub.io. Without such information, it's not always easy to find the source code for charts to inspect them.

This is especially important for the InfluxData charts, since in these charts the README file doesn't actually describe how to configure the chart, but instead directs the user to inspect `values.yaml`, something you can't actually do from listing sites like ArtifactHub.

- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [ ] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)