### PR TITLE
fix: bump resource limits for init job

### DIFF
--- a/charts/influxdb-enterprise/templates/bootstrap-job.yaml
+++ b/charts/influxdb-enterprise/templates/bootstrap-job.yaml
@@ -61,10 +61,10 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
       {{ end }}
       {{- if .Values.bootstrap.ddldml.configMap }}
       - name: ddl
@@ -151,8 +151,8 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
 {{ end }}


### PR DESCRIPTION
Resource limits on init job might fail deployment of InfluxDB cluster. Main offender is hardcoded 10MB RAM limit on final container which is too tight and in some circumstances results in endless loop of attempts to start the container. Since this is single point of failure and job runs only once I would like to propose removal of these limits completely. Second option would be to use the `{{- toYaml .Values.bootstrap.ddldml.resources | nindent 10 }}` for final container as well.

### Event log with OOM error
(combined from similar events): Failed to create pod sandbox: rpc error: code = Unknown desc = container create failed: time="2020-10-21T16:25:24Z" level=warning msg="signal: killed" time="2020-10-21T16:25:24Z" level=error msg="container_linux.go:349: starting container process caused \"process_linux.go:365: sending config to init process caused \\\"write init-p: broken pipe\\\"\"" container_linux.go:349: starting container process caused "process_linux.go:365: sending config to init process caused \"write init-p: broken pipe\""
