### PR TITLE
use pod anti-affinity to support HA deployment by default

### DIFF
--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -59,7 +59,18 @@ meta:
     # repository: influxdb
   # nodeSelector: {}
   # tolerations: []
-  # affinity: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 1
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: influxdb.influxdata.com/component
+              operator: In
+              values:
+              - meta
+          topologyKey: kubernetes.io/hostname
   # podAnnotations: {}
   #
   # podSecurityContext: {}
@@ -137,7 +148,18 @@ data:
     # repository: influxdb
   # nodeSelector: {}
   # tolerations: []
-  # affinity: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 1
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: influxdb.influxdata.com/component
+              operator: In
+              values:
+              - data
+          topologyKey: kubernetes.io/hostname
   # podAnnotations: {}
   #
   # podSecurityContext: {}


### PR DESCRIPTION
Enterprise deployments should run in HA setup. This PR adds sensible default configuration that try to deploy data and meta containers on different workers in K8s cluster if possible by default.