### PR TITLE
add service account configuration for influxdb deployment

### DIFF
--- a/charts/influxdb-enterprise/Chart.yaml
+++ b/charts/influxdb-enterprise/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.11
+version: 0.1.12
 appVersion: 1.8.0
 engine: gotpl
 

--- a/charts/influxdb-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb-enterprise/templates/_helpers.tpl
@@ -51,8 +51,16 @@ app.kubernetes.io/name: {{ include "influxdb-enterprise.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
-
-
+{{/*
+Create the name of the service account
+*/}}
+{{- define "influxdb-enterprise.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "influxdb-enterprise.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
 
 {{- define "influxdb-enterprise.image" -}}
 {{- $dataTagName := (printf "%s-%s" .chart.AppVersion .podtype) -}}

--- a/charts/influxdb-enterprise/templates/bootstrap-job.yaml
+++ b/charts/influxdb-enterprise/templates/bootstrap-job.yaml
@@ -23,6 +23,7 @@ spec:
           name: {{ .Values.bootstrap.ddldml.configMap }}
       {{ end }}
       restartPolicy: OnFailure
+      serviceAccountName: {{ template "influxdb-enterprise.serviceAccountName" . }}
       # Consider this a middleware of setup components.
       # Each is executed in-order until all of theme complete successfully.
       # This means that each command must be idempotent.

--- a/charts/influxdb-enterprise/templates/data-statefulset.yaml
+++ b/charts/influxdb-enterprise/templates/data-statefulset.yaml
@@ -28,6 +28,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.data.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ template "influxdb-enterprise.serviceAccountName" . }}
       volumes:
       {{ if not .Values.data.persistence.enabled }}
       - name: {{ include "influxdb-enterprise.fullname" . }}-data-data

--- a/charts/influxdb-enterprise/templates/meta-statefulset.yaml
+++ b/charts/influxdb-enterprise/templates/meta-statefulset.yaml
@@ -28,6 +28,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.meta.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ template "influxdb-enterprise.serviceAccountName" . }}
       volumes:
       {{ if not .Values.meta.persistence.enabled }}
       - name: {{ include "influxdb-enterprise.fullname" . }}-meta-data

--- a/charts/influxdb-enterprise/templates/serviceaccount.yaml
+++ b/charts/influxdb-enterprise/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "influxdb-enterprise.labels" . | nindent 4 }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: {{ template "influxdb-enterprise.serviceAccountName" . }}
+{{- end }}

--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -16,6 +16,13 @@ license:
   #   name: license
   #   key: json
 
+# Service account to use for deployment
+# If the name is not specified default account will be used
+serviceAccount:
+  create: false
+  name: ''
+  annotations: {}
+
 # A secret with keys "username" and "password" is required
 # This bootstrap configuration allows you to configure
 # some parts of the InfluxDB system at install time.


### PR DESCRIPTION
PR adds configuration for service account used by InfluxDB deployment. This feature is required in some environments where service account extends basic security model such as AWS EKS or OpenShift Enterprise platform. Feature allows user to create new account directly from deployment or use already pre-created one.