### PR TITLE
#227 [influxdb2] Install fails on influx setup

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
-version: 1.0.11
+version: 1.0.12
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com

--- a/charts/influxdb2/templates/job-setup-admin.yaml
+++ b/charts/influxdb2/templates/job-setup-admin.yaml
@@ -33,7 +33,10 @@ spec:
         args:
           - -c
           - |
-            influx setup -f \
+            influx org list \
+            -n {{ .Values.adminUser.organization }} \
+            -t ${INFLUXDB_TOKEN} \
+            || influx setup -f \
             --host http://{{ template "influxdb.fullname" . }}:{{ .Values.service.port }} \
             -o {{ .Values.adminUser.organization }} \
             -b {{ .Values.adminUser.bucket }} \


### PR DESCRIPTION
As described in #227, the influxdb2 helm chart will fail if influxdb2 has already been configured on the persistent volume store.

Although not fool-proof, the simplest way to overcome this failure is to execute `influx org list -n {{ .Values.adminUser.organisation }}` and only if that fails, move on to execute influx setup.

I believe this would work in all instances except where a user has deleted the configured `adminUser.organisation`

- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [ ] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)