### PR TITLE
Added metrics key to enable/disable internal metrics and minor bug fixes for influxdb2

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.0.1
+appVersion: 2.0.2
 
 name: influxdb2
 description: A Helm chart for InfluxDB v2

--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
-version: 1.0.11
+version: 1.0.12
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com

--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.0.0-rc
+appVersion: 2.0.1
 
 name: influxdb2
 description: A Helm chart for InfluxDB v2

--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -11,3 +11,4 @@ maintainers:
     email: rawkode@influxdata.com
   - name: gitirabassi
     email: giacomo@influxdata.com
+icon: https://avatars0.githubusercontent.com/u/5713248?s=200&v=4

--- a/charts/influxdb2/templates/job-setup-admin.yaml
+++ b/charts/influxdb2/templates/job-setup-admin.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: {{ template "influxdb.fullname" . }}-create-admin-user
-        image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository }}:v{{ .Chart.AppVersion }}"
         env:
           - name: INFLUXDB_PASSWORD
             valueFrom:

--- a/charts/influxdb2/templates/persistent-volume-claim.yaml
+++ b/charts/influxdb2/templates/persistent-volume-claim.yaml
@@ -5,6 +5,8 @@ metadata:
   name: "{{- if not (empty .Values.persistence.name) }}{{ .Values.persistence.name }}{{- else }}{{ template "influxdb.fullname" . }}{{- end }}"
   labels:
     {{- include "influxdb.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: "keep"
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/charts/influxdb2/templates/statefulset.yaml
+++ b/charts/influxdb2/templates/statefulset.yaml
@@ -36,6 +36,10 @@ spec:
             - name: http
               containerPort: 8086
               protocol: TCP
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{ toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /health

--- a/charts/influxdb2/templates/statefulset.yaml
+++ b/charts/influxdb2/templates/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
         {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:v{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/influxdb2/values.yaml
+++ b/charts/influxdb2/values.yaml
@@ -23,6 +23,8 @@ tolerations: []
 
 affinity: {}
 
+securityContext: {}
+
 ## Create default user through Kubernetes job
 ## Defaults indicated below
 ##

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: telegraf
 version: 1.7.32
-appVersion: 1.15
+appVersion: 1.16
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
 keywords:

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -17,3 +17,4 @@ maintainers:
     email: rawkode@influxdata.com
   - name: gitirabassi
     email: giacomo@influxdata.com
+icon: https://avatars0.githubusercontent.com/u/5713248?s=200&v=4

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.7.32
+version: 1.7.33
 appVersion: 1.16
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: telegraf
 version: 1.7.31
 appVersion: 1.15
@@ -17,4 +17,3 @@ maintainers:
     email: rawkode@influxdata.com
   - name: gitirabassi
     email: giacomo@influxdata.com
-engine: gotpl

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.7.31
+version: 1.7.32
 appVersion: 1.15
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/configmap.yaml
+++ b/charts/telegraf/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
     {{ template "processors" .Values.config.processors }}
     {{ template "aggregators" .Values.config.aggregators }}
     {{ template "outputs" .Values.config.outputs }}
+    {{- if .Values.metrics.enabled }}
     [[outputs.health]]
       service_address = "http://:8888"
       [[outputs.health.compares]]
@@ -21,3 +22,4 @@ data:
     {{ template "inputs" .Values.config.inputs -}}
     [[inputs.internal]]
       collect_memstats = false
+    {{- end }}

--- a/charts/telegraf/templates/configmap.yaml
+++ b/charts/telegraf/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
     {{ template "processors" .Values.config.processors }}
     {{ template "aggregators" .Values.config.aggregators }}
     {{ template "outputs" .Values.config.outputs }}
-    {{- if .Values.metrics.enabled }}
+    {{- if .Values.metrics.health.enabled }}
     [[outputs.health]]
       service_address = "http://:8888"
       [[outputs.health.compares]]
@@ -20,6 +20,6 @@ data:
       [[outputs.health.contains]]
         field = "buffer_size"
     {{ template "inputs" .Values.config.inputs -}}
-    [[inputs.internal]]
-      collect_memstats = false
     {{- end }}
+    [[inputs.internal]]
+      collect_memstats = {{ .Values.metrics.collect_memstats }}

--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -12,9 +12,11 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
+  {{-if .Values.metrics.enabled }}
   - port: 8888
     targetPort: 8888
     name: "health"
+  {{- end }}
   {{- range $objectKey, $objectValue := .Values.config.inputs }}
   {{- range $key, $value := . -}}
     {{- $tp := typeOf $value -}}

--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-  {{-if .Values.metrics.enabled }}
+  {{- if .Values.metrics.enabled }}
   - port: 8888
     targetPort: 8888
     name: "health"

--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-  {{- if .Values.metrics.enabled }}
+  {{- if .Values.metrics.health.enabled }}
   - port: 8888
     targetPort: 8888
     name: "health"

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repo: "telegraf"
-  tag: "1.15-alpine"
+  tag: "1.16-alpine"
   pullPolicy: IfNotPresent
 
 podAnnotations: {}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -159,6 +159,9 @@ config:
         allowed_pending_messages: 10000
         percentile_limit: 1000
 
+metrics:
+  enabled: false
+
 # Lifecycle hooks
 # hooks:
 #   postStart: ["/bin/sh", "-c", "echo Telegraf started"]

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -160,7 +160,9 @@ config:
         percentile_limit: 1000
 
 metrics:
-  enabled: false
+  health:
+    enabled: false
+  collect_memstats: false
 
 # Lifecycle hooks
 # hooks:


### PR DESCRIPTION
- [x] Bumped up the chart version
- [x] Updated `apiVersion` as Helmv2 is deprecated
- [x] Added `metrics.health.enabled` key to `values.yaml` to telegraf. This is disabled by default as it should be the user's choice to enable it.
- [x] Added `metrics.collect_memstats` key to `values.yaml` to telegraf
- [x] Updated `tag` to the latest version
- [x] Added helm resource-policy to influxdb2 pvc
- [x] Added `securityContext` to influxdb2