### PR TITLE
[telegraf-ds] Add option for simple override of TOML config file contents

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.0.18
+version: 1.0.19
 appVersion: 1.16
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
@@ -10,6 +10,8 @@ keywords:
 - timeseries
 - influxdata
 home: https://www.influxdata.com/time-series-platform/telegraf/
+sources:
+  - https://github.com/influxdata/helm-charts/charts/telegraf-ds
 maintainers:
 - name: rawkode
   email: rawkode@influxdata.com

--- a/charts/telegraf-ds/templates/configmap.yaml
+++ b/charts/telegraf-ds/templates/configmap.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
 data:
+{{- if .Values.override_config.toml }}
+  telegraf.conf: |+
+    {{- .Values.override_config.toml | nindent 4 }}
+{{- else }}
   telegraf.conf: |+
     {{ template "global_tags" .Values.config.global_tags }}
     {{ template "agent" .Values.config.agent }}
@@ -37,3 +41,4 @@ data:
     url = "https://$HOSTIP:10250"
     bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
     insecure_skip_verify = true
+{{- end }}

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -65,6 +65,21 @@ serviceAccount:
 ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 # priorityClassName: system-node-critical
 
+override_config:
+  toml: ~
+  # Provide a literal TOML config
+  # toml: |+
+  #   [global_tags]
+  #     foo = "bar"
+  #   [agent]
+  #     interval = "10s"
+  #   [[inputs.mem]]
+  #   [[outputs.influxdb_v2]]
+  #     urls           = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
+  #     bucket         = "data"
+  #     organization   = "OurCompany"
+  #     token          = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
 ## Exposed telegraf configuration
 ## ref: https://docs.influxdata.com/telegraf/v1.13/administration/configuration/
 config:


### PR DESCRIPTION
This is intended as a partial fix/workaround for #221; a more complete fix will require waiting for a fix to bugs in Helm itself, which could take some time. This PR provides an "escape hatch" as where the end user can hand-write their own TOML if necessary. This was discussed as an option by @rawkode [in a comment](https://github.com/influxdata/helm-charts/issues/221#issuecomment-710766207) on the issue.

To use the escape hatch, set `config_override.toml` to a string containing the full contents of a valid Telegraf config file.

The more complete fix is at core waiting on kubernetes-sigs/yaml#45 to be fixed, and then for that fix to make its way into a new release of Helm.