### PR TITLE
[influxdb] Remove folders from PVC after uploading

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.8.9
+version: 4.8.10
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/backup-cronjob.yaml
+++ b/charts/influxdb/templates/backup-cronjob.yaml
@@ -76,6 +76,7 @@ spec:
                 gcloud auth activate-service-account --key-file $KEY_FILE
               fi
               gsutil -m cp -r /backup/* "$DST_URL"
+              rm -rf /backup/*
             volumeMounts:
             - name: backup
               mountPath: /backup
@@ -103,6 +104,7 @@ spec:
             - |
               az storage container create --name "$DST_CONTAINER"
               az storage blob upload-batch --destination "$DST_CONTAINER" --destination-path "$DST_PATH" --source "$SRC_URL"
+              rm -rf /backup/*
             volumeMounts:
             - name: backup
               mountPath: /backup
@@ -130,6 +132,7 @@ spec:
             - '-c'
             - |
               aws {{- if .Values.backup.s3.endpointUrl }} --endpoint-url={{ .Values.backup.s3.endpointUrl }} {{- end }} s3 cp --recursive "$SRC_URL" "$DST_URL"
+              rm -rf /backup/*
             volumeMounts:
             - name: backup
               mountPath: /backup

--- a/charts/influxdb/templates/backup-cronjob.yaml
+++ b/charts/influxdb/templates/backup-cronjob.yaml
@@ -71,6 +71,7 @@ spec:
             - /bin/sh
             args:
             - '-c'
+            - '-e'
             - |
               if [ -n "$KEY_FILE" ]; then
                 gcloud auth activate-service-account --key-file $KEY_FILE
@@ -101,6 +102,7 @@ spec:
             - /bin/sh
             args:
             - '-c'
+            - '-e'
             - |
               az storage container create --name "$DST_CONTAINER"
               az storage blob upload-batch --destination "$DST_CONTAINER" --destination-path "$DST_PATH" --source "$SRC_URL"
@@ -130,6 +132,7 @@ spec:
             - /bin/sh
             args:
             - '-c'
+            - '-e'
             - |
               aws {{- if .Values.backup.s3.endpointUrl }} --endpoint-url={{ .Values.backup.s3.endpointUrl }} {{- end }} s3 cp --recursive "$SRC_URL" "$DST_URL"
               rm -rf /backup/*


### PR DESCRIPTION
Fixes influxdata/helm-charts#240
When a PVC is used before the data upload then it fills up quickly after some backups because always a new timestamped folder is created.
This PR fixes the problem by removing all folders located under `/backup/*`after uploading them.