### PR TITLE
Adds persistence.existingClaim value to Chronograf chart

### DIFF
--- a/charts/chronograf/Chart.yaml
+++ b/charts/chronograf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: chronograf
-version: 1.1.22
+version: 1.1.23
 appVersion: 1.8.9.1
 description: Open-source web application written in Go and React.js that provides
   the tools to visualize your monitoring data and easily create alerting and automation

--- a/charts/chronograf/Chart.yaml
+++ b/charts/chronograf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: chronograf
-version: 1.1.19
+version: 1.1.20
 appVersion: 1.8.8
 description: Open-source web application written in Go and React.js that provides
   the tools to visualize your monitoring data and easily create alerting and automation

--- a/charts/chronograf/Chart.yaml
+++ b/charts/chronograf/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: chronograf
-version: 1.1.20
-appVersion: 1.8.8
+version: 1.1.22
+appVersion: 1.8.9.1
 description: Open-source web application written in Go and React.js that provides
   the tools to visualize your monitoring data and easily create alerting and automation
   rules.

--- a/charts/chronograf/README.md
+++ b/charts/chronograf/README.md
@@ -55,6 +55,7 @@ The following table lists configurable parameters, their descriptions, and their
 | `persistence.storageClass`   | Storage class of backing PVC                                                                              | `nil` (uses alpha storage class annotation) |
 | `persistence.accessModes`    | Use volume as ReadOnly or ReadWrite                                                                       | `[ReadWriteOnce]`                           |
 | `persistence.size`           | Size of data volume                                                                                       | `8Gi`                                       |
+| `persistence.existingClaim`  | Use an existing PVC to persist data                                                                       | `nil`                                       |
 | `resources.requests.memory`  | Memory used for resource requests                                                                         | `256Mi`                                     |
 | `resources.requests.cpu`     | CPU used for resource requests                                                                            | `0.1`                                       |
 | `resources.limits.memory`    | Maximum memory that can be used for resource requests                                                     | `2Gi`                                       |

--- a/charts/chronograf/templates/deployment.yaml
+++ b/charts/chronograf/templates/deployment.yaml
@@ -200,7 +200,7 @@ spec:
         - name: data
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ template "chronograf.fullname" . }}
+            claimName: {{ .Values.persistence.existingClaim | default (include "chronograf.fullname" .) }}
         {{ else }}
           emptyDir: {}
         {{ end }}

--- a/charts/chronograf/templates/deployment.yaml
+++ b/charts/chronograf/templates/deployment.yaml
@@ -200,7 +200,7 @@ spec:
         - name: data
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ .Values.persistence.existingClaim | default (include "chronograf.fullname" .) }}
+            claimName: {{ .Values.persistence.existingClaim | default (template "chronograf.fullname" .) }}
         {{ else }}
           emptyDir: {}
         {{ end }}

--- a/charts/chronograf/templates/deployment.yaml
+++ b/charts/chronograf/templates/deployment.yaml
@@ -200,7 +200,7 @@ spec:
         - name: data
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ .Values.persistence.existingClaim | default (template "chronograf.fullname" .) }}
+            claimName: {{ .Values.persistence.existingClaim | default (include "chronograf.fullname" .) }}
         {{ else }}
           emptyDir: {}
         {{ end }}

--- a/charts/chronograf/values.yaml
+++ b/charts/chronograf/values.yaml
@@ -28,6 +28,7 @@ persistence:
   # storageClass: "-"
   accessMode: ReadWriteOnce
   size: 8Gi
+  # existingClaim: ""
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -43,14 +44,16 @@ resources:
 ## Node labels for pod assignment
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
 #
-nodeSelector: {}
+nodeSelector:
+  {}
 
- ## Tolerations for pod assignment
+  ## Tolerations for pod assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
-tolerations: []
+tolerations:
+  []
 
- ## Affinity for pod assignment
+  ## Affinity for pod assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ##
 affinity: {}
@@ -63,7 +66,8 @@ ingress:
   enabled: false
   tls: false
   hostname: chronograf.foobar.com
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: "nginx"
     # secretName: my-tls-cert
     # kubernetes.io/tls-acme: "true"
@@ -122,7 +126,6 @@ env:
 ## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
 ## This can be useful for auth tokens, etc
 envFromSecret: ""
-
 # volumes:
 # - name: chronograf-output-influxdb2
 #   configMap:


### PR DESCRIPTION
In order to accommodate PersistentVolumeClaims that have already been created, I've added in the `persistence.existingClaim` value in [the same way that Grafana does it](https://github.com/grafana/helm-charts/blob/74624247a5676bd8d2c5460c47bd984aaad35712/charts/grafana/templates/_pod.tpl#L417).

This should allow users to use other storage methods (NFS in my case) to store Chrongraf configuration data.

I have tested this locally via `helm install...`