### PR TITLE
allow admin user creation to be skipped

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
-version: 1.0.12
+version: 1.0.13
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com

--- a/charts/influxdb2/templates/job-setup-admin.yaml
+++ b/charts/influxdb2/templates/job-setup-admin.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.adminUser.create -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -41,3 +42,4 @@ spec:
             -p ${INFLUXDB_PASSWORD} \
             -t ${INFLUXDB_TOKEN}
       restartPolicy: OnFailure
+{{- end -}}

--- a/charts/influxdb2/values.yaml
+++ b/charts/influxdb2/values.yaml
@@ -29,6 +29,7 @@ securityContext: {}
 ## Defaults indicated below
 ##
 adminUser:
+  create: true
   organization: "influxdata"
   bucket: "default"
   user: "admin"


### PR DESCRIPTION
Setting 'create' to 'true' as it's generally wanted, but now the flag
exists so it can be skipped. I tested this locally with both options to
make sure it worked, and I copied the naming from influx1's chart, but
feel free to make changes as necessary.

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [ ] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)