### PR TITLE
[telegraf] Fix: Cannot define inputs without health check

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.7.33
+version: 1.7.34
 appVersion: 1.16
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
@@ -12,6 +12,9 @@ keywords:
   - influxdb
   - agent
 home: https://www.influxdata.com/time-series-platform/telegraf/
+sources:
+  - https://github.com/influxdata/helm-charts/tree/master/charts/telegraf
+  - https://github.com/influxdata/helm-charts/
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com

--- a/charts/telegraf/templates/configmap.yaml
+++ b/charts/telegraf/templates/configmap.yaml
@@ -19,7 +19,7 @@ data:
         lt = 5000.0
       [[outputs.health.contains]]
         field = "buffer_size"
-    {{ template "inputs" .Values.config.inputs -}}
     {{- end }}
+    {{ template "inputs" .Values.config.inputs -}}
     [[inputs.internal]]
       collect_memstats = {{ .Values.metrics.collect_memstats }}


### PR DESCRIPTION
In the current implementation, a misplaced `{{- end }}` in the chart causes the `{{ template "inputs" .Values.config.inputs -}}` call to be inside the `{{- if .Values.metrics.health.enabled }}` conditional block.

This fixes that.