### PR TITLE
Make InfluxDB 2 pod annotations configurable

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
-version: 1.0.13
+version: 1.0.14
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com

--- a/charts/influxdb2/templates/job-setup-admin.yaml
+++ b/charts/influxdb2/templates/job-setup-admin.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         {{- include "influxdb.labels" . | nindent 8 }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
     spec:
       containers:
       - name: {{ template "influxdb.fullname" . }}-create-admin-user

--- a/charts/influxdb2/templates/statefulset.yaml
+++ b/charts/influxdb2/templates/statefulset.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
       {{- include "influxdb.selectorLabels" . | nindent 8 }}
+      annotations:
+      {{- toYaml .Values.podAnnotations | nindent 8 }}
     spec:
       volumes:
         - name: data

--- a/charts/influxdb2/values.yaml
+++ b/charts/influxdb2/values.yaml
@@ -2,6 +2,8 @@ image:
   repository: quay.io/influxdb/influxdb
   pullPolicy: IfNotPresent
 
+podAnnotations: {}
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
This makes it possible to specify annotations for the pods created by the `influxdb2` chart.

This is handy for things like configuring Istio sidecar injection.