### PR TITLE
[influxdb2] add r flag to job_setup_admin tpl, add rp to values

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
-version: 1.0.14
+version: 1.0.15
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com

--- a/charts/influxdb2/templates/job-setup-admin.yaml
+++ b/charts/influxdb2/templates/job-setup-admin.yaml
@@ -39,6 +39,7 @@ spec:
             -o {{ .Values.adminUser.organization }} \
             -b {{ .Values.adminUser.bucket }} \
             -u {{ .Values.adminUser.user }} \
+            -r {{ .Values.adminUser.retention_policy }} \
             -p ${INFLUXDB_PASSWORD} \
             -t ${INFLUXDB_TOKEN}
       restartPolicy: OnFailure

--- a/charts/influxdb2/values.yaml
+++ b/charts/influxdb2/values.yaml
@@ -33,6 +33,7 @@ adminUser:
   organization: "influxdata"
   bucket: "default"
   user: "admin"
+  retention_policy: "0s"
   ## Leave empty to generate a random password and token.
   ## Or fill any of these values to use fixed values.
   password: ""


### PR DESCRIPTION
Hi,
I propose adding -r flag, which sets retention policy of bucket, to the influx setup script in jobs_setup_admin.yaml. It helps me to remove the manual part of process, when I need to set up the same retention policy on different environments, which differs from the default one.

The default value of retention policy can live in the values.yaml and be overridden if necessary.

This was tested with helm install on my testing cluster with default value 0s and with overriding value 1440h.

- [x] CHANGELOG.md - no change log present
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA]
