### PR TITLE
Make readiness and liveness checks configurable

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
-version: 1.0.16
+version: 1.1.1
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com

--- a/charts/influxdb2/templates/statefulset.yaml
+++ b/charts/influxdb2/templates/statefulset.yaml
@@ -48,12 +48,20 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
-              path: /health
-              port: http
+              path: {{.Values.statefulset.livenessprobe.path}}
+              port: {{.Values.statefulset.livenessprobe.port}}
+            timeoutSeconds: {{.Values.statefulset.livenessprobe.timeoutSeconds}}
+            periodSeconds: {{.Values.statefulset.livenessprobe.periodSeconds}}
+            successThreshold: {{.Values.statefulset.livenessprobe.successThreshold}}
+            failureThreshold: {{.Values.statefulset.livenessprobe.failureThreshold}}
           readinessProbe:
             httpGet:
-              path: /health
-              port: http
+              path: {{.Values.statefulset.readinessprobe.path}}
+              port: {{.Values.statefulset.readinessprobe.port}}
+            timeoutSeconds: {{.Values.statefulset.readinessprobe.timeoutSeconds}}
+            periodSeconds: {{.Values.statefulset.readinessprobe.periodSeconds}}
+            successThreshold: {{.Values.statefulset.readinessprobe.successThreshold}}
+            failureThreshold: {{.Values.statefulset.readinessprobe.failureThreshold}}
           volumeMounts:
           - name: data
             mountPath: {{ .Values.persistence.mountPath }}

--- a/charts/influxdb2/templates/statefulset.yaml
+++ b/charts/influxdb2/templates/statefulset.yaml
@@ -48,16 +48,16 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
-              path: {{.Values.statefulset.livenessprobe.path}}
-              port: {{.Values.statefulset.livenessprobe.port}}
+              path: /health
+              port: http
             timeoutSeconds: {{.Values.statefulset.livenessprobe.timeoutSeconds}}
             periodSeconds: {{.Values.statefulset.livenessprobe.periodSeconds}}
             successThreshold: {{.Values.statefulset.livenessprobe.successThreshold}}
             failureThreshold: {{.Values.statefulset.livenessprobe.failureThreshold}}
           readinessProbe:
             httpGet:
-              path: {{.Values.statefulset.readinessprobe.path}}
-              port: {{.Values.statefulset.readinessprobe.port}}
+              path: /health
+              port: http
             timeoutSeconds: {{.Values.statefulset.readinessprobe.timeoutSeconds}}
             periodSeconds: {{.Values.statefulset.readinessprobe.periodSeconds}}
             successThreshold: {{.Values.statefulset.readinessprobe.successThreshold}}

--- a/charts/influxdb2/values.yaml
+++ b/charts/influxdb2/values.yaml
@@ -61,6 +61,22 @@ persistence:
   size: 50Gi
   mountPath: /root/.influxdbv2
 
+statefulset:
+  livenessprobe:
+    path: /health
+    port: http
+    timeoutSeconds: 1
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 3
+  readinessprobe:
+    path: /health
+    port: http
+    timeoutSeconds: 1
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 3
+
 service:
   type: ClusterIP
   port: 80

--- a/charts/influxdb2/values.yaml
+++ b/charts/influxdb2/values.yaml
@@ -63,15 +63,11 @@ persistence:
 
 statefulset:
   livenessprobe:
-    path: /health
-    port: http
     timeoutSeconds: 1
     periodSeconds: 10
     successThreshold: 1
     failureThreshold: 3
   readinessprobe:
-    path: /health
-    port: http
     timeoutSeconds: 1
     periodSeconds: 10
     successThreshold: 1


### PR DESCRIPTION
The choosen defaults for readiness/liveness checks may trigger unnecessary container restarts, because timeouts may be too low. 

I simply introduced a readiness/liveness config options and used the in the statefulset.yaml. 

I tested my changes by locally installing the chart and checking if the values were set correctly.

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)