### PR TITLE
[influxdb] fix ingress className set to string nil

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.9.13
+version: 4.9.14
 appVersion: 1.8.4
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -169,7 +169,7 @@ ingress:
   tls: false
   # secretName: my-tls-cert # only needed if tls above is true
   hostname: influxdb.foobar.com
-  className: nil
+  className: ""
   annotations: {}
     # kubernetes.io/ingress.class: "nginx"
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
Due to a recent change, a default installation will cause ingress className to be set to the string 'nil'. This PR fixes that to be empty string.

```
kind: Ingress
apiVersion: extensions/v1beta1
...
spec:
  ingressClassName: nil
```

Signed-off-by: Dennis Zhang <dennis.zhang.nrg@gmail.com>

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)