### PR TITLE
Fix default value for ingress class name

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.9.13
+version: 4.9.14
 appVersion: 1.8.4
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -169,7 +169,7 @@ ingress:
   tls: false
   # secretName: my-tls-cert # only needed if tls above is true
   hostname: influxdb.foobar.com
-  className: nil
+  className: null
   annotations: {}
     # kubernetes.io/ingress.class: "nginx"
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
Helm does not seem to evaluate `nil` as false, but it does with `null`. This fixes #277, introduced by #272 / 108378f.