### PR TITLE
[influxdb2] Add possibility to use existing secret for admin password

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
-version: 1.0.17
+version: 1.1.0
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com

--- a/charts/influxdb2/README.md
+++ b/charts/influxdb2/README.md
@@ -52,4 +52,17 @@ Check out our [Slack channel](https://www.influxdata.com/slack) for support and 
 
 ## Fixed Auth Credentials
 
-If you need to use fixed token and/or password you can fill `adminUser.password` and `adminUser.token` on your values file to avoid using random values generation.
+If you need to use fixed token and/or password you can set the values `adminUser.password` and `adminUser.token` or you can use an existing secret, which would be a better approach.
+
+Example Secret:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: influxdb-auth
+type: Opaque
+data:
+  admin-password: ...
+  admin-token: ...
+```

--- a/charts/influxdb2/templates/NOTES.txt
+++ b/charts/influxdb2/templates/NOTES.txt
@@ -2,4 +2,17 @@ InfluxDB 2 is deployed as a StatefulSet on your cluster.
 
 You can access it by using the service name: {{ template "influxdb.fullname" . }}
 
-Admin password and token are available in the secret: {{ template "influxdb.fullname" . }}-auth
+{{- if .Values.adminUser.create }}
+
+To retrieve the password for the '{{ .Values.adminUser.user}}' user:
+
+{{- if .Values.adminUser.existingSecret }}
+
+  echo $(kubectl get secret {{ .Values.adminUser.existingSecret }} -o "jsonpath={.data['admin-password']}" --namespace {{ .Release.Namespace }} | base64 --decode)
+
+{{- else }}
+
+  echo $(kubectl get secret {{ include "influxdb.fullname" . }}-auth -o "jsonpath={.data['admin-password']}" --namespace {{ .Release.Namespace }} | base64 --decode)
+
+{{- end }}
+{{- end }}

--- a/charts/influxdb2/templates/job-setup-admin.yaml
+++ b/charts/influxdb2/templates/job-setup-admin.yaml
@@ -28,12 +28,20 @@ spec:
           - name: INFLUXDB_PASSWORD
             valueFrom:
               secretKeyRef:
+                {{- if .Values.adminUser.existingSecret }}
+                name: {{ .Values.adminUser.existingSecret -}}
+                {{ else }}
                 name: {{ template "influxdb.fullname" . }}-auth
+                {{- end }}
                 key: admin-password
           - name: INFLUXDB_TOKEN
             valueFrom:
               secretKeyRef:
+                {{- if .Values.adminUser.existingSecret }}
+                name: {{ .Values.adminUser.existingSecret -}}
+                {{ else }}
                 name: {{ template "influxdb.fullname" . }}-auth
+                {{- end }}
                 key: admin-token
         command:
           - bash

--- a/charts/influxdb2/templates/secret.yaml
+++ b/charts/influxdb2/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.adminUser.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -16,3 +17,4 @@ data:
   {{- else }}
   admin-password: {{ randAlphaNum 32 | b64enc | quote }}
   {{- end }}
+{{- end -}}

--- a/charts/influxdb2/values.yaml
+++ b/charts/influxdb2/values.yaml
@@ -41,6 +41,11 @@ adminUser:
   password: ""
   token: ""
 
+  ## The password and token are obtained from an existing secret. The expected
+  ## keys are `admin-password` and `admin-token`.
+  ## If set, the password and token values above are ignored.
+  # existingSecret: influxdb-auth
+
 ## Persist data to a persistent volume
 ##
 persistence:


### PR DESCRIPTION
I've missed the possibility to use existing secret for the admin password and the token.
For the implementation I followed the Helm Chart for InfluxDB 1.