### PR TITLE
Always deploy job-setup-admin pod on a linux node

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
-version: 1.1.0
+version: 1.1.1
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com

--- a/charts/influxdb2/templates/job-setup-admin.yaml
+++ b/charts/influxdb2/templates/job-setup-admin.yaml
@@ -56,6 +56,8 @@ spec:
             -r {{ .Values.adminUser.retention_policy }} \
             -p ${INFLUXDB_PASSWORD} \
             -t ${INFLUXDB_TOKEN}
+      nodeSelector:
+        kubernetes.io/os: linux
       restartPolicy: OnFailure
       {{- if .Values.securityContext.runAsGroup }}
       securityContext:


### PR DESCRIPTION
Hybrid clusters with windows and linux nodes would potentially
deploy the pod on a windows worker. Using a nodeSelector for the
admin setup job fixes this.

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

related to #256