### PR TITLE
[telegraf] Add envFromSecret to pass sensitive data into environment

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: telegraf
 version: 1.8.0
-appVersion: 1.18.0
+appVersion: 1.18.3
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
 keywords:

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.7.38
+version: 1.8.0
 appVersion: 1.18.0
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -41,6 +41,11 @@ spec:
         {{- end }}
         env:
 {{ toYaml .Values.env | indent 8 }}
+{{- if .Values.envFromSecret }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.envFromSecret . }}
+{{- end }}
         volumeMounts:
         - name: config
           mountPath: /etc/telegraf

--- a/charts/telegraf/templates/role.yaml
+++ b/charts/telegraf/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.clusterWide }}
 kind: ClusterRole
 {{- else }}

--- a/charts/telegraf/templates/rolebinding.yaml
+++ b/charts/telegraf/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.clusterWide }}
 kind: ClusterRoleBinding
 {{- else }}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -18,6 +18,14 @@ imagePullSecrets: []
 ## Configure args passed to Telegraf containers
 args: []
 
+
+# The name of a secret in the same kubernetes namespace which contains values to
+# be added to the environment (must be manually created)
+# This can be useful for auth tokens, etc.
+
+# envFromSecret: "telegraf-tokens"
+
+
 env:
   - name: HOSTNAME
     value: "telegraf-polling-service"


### PR DESCRIPTION
Add ability to pass sensitive environment variables to telegraf environment.
Specific use case might be passing `$INFLUX_TOKEN` or any other API token:

Example `values.yaml` will look like this:
```
...
envFromSecret: "telegraf-tokens"
env:
  - name: HOSTNAME
    value: "telegraf-polling-service"
  - name: INFLUX_ORG
    value: influxdata
  - name: INFLUX_HOST
    value: https://example.com
...
config:
  agent:
...
    hostname: "$HOSTNAME"
    omit_hostname: false
  outputs:
    - influxdb_v2:
        urls:
          - "${INFLUX_HOST}"
        token: "${INFLUX_TOKEN}"
        organization = "${INFLUX_ORG}"
...
```