### PR TITLE
Add container environment variable configuration

### DIFF
--- a/charts/influxdb-enterprise/Chart.yaml
+++ b/charts/influxdb-enterprise/Chart.yaml
@@ -19,3 +19,4 @@ maintainers:
     email: david@rawkode.com
   - name: chobbs
     email: chobbs@influxdata.com
+icon: https://avatars0.githubusercontent.com/u/5713248?s=200&v=4

--- a/charts/influxdb-enterprise/Chart.yaml
+++ b/charts/influxdb-enterprise/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 version: 0.1.14
 appVersion: 1.8.6
 engine: gotpl

--- a/charts/influxdb-enterprise/Chart.yaml
+++ b/charts/influxdb-enterprise/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.13
+version: 0.1.14
 appVersion: 1.8.6
 engine: gotpl
 

--- a/charts/influxdb-enterprise/Chart.yaml
+++ b/charts/influxdb-enterprise/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.12
+version: 0.1.13
 appVersion: 1.8.0
 engine: gotpl
 

--- a/charts/influxdb-enterprise/templates/data-statefulset.yaml
+++ b/charts/influxdb-enterprise/templates/data-statefulset.yaml
@@ -88,6 +88,10 @@ spec:
           env:
           - name: RELEASE_NAME
             value: {{ include "influxdb-enterprise.fullname" . }}
+          {{- range $key, $val := .Values.data.env }}
+          - name: {{ $key }}
+            value: {{ $val | quote }}
+          {{- end}}
           ports:
             - name: http
               containerPort: 8086

--- a/charts/influxdb-enterprise/templates/meta-statefulset.yaml
+++ b/charts/influxdb-enterprise/templates/meta-statefulset.yaml
@@ -91,6 +91,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.meta.sharedSecret.secretName }}
                   key: secret
+            {{- range $key, $val := .Values.meta.env }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end}}
           ports:
             - name: http
               containerPort: 8091

--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -11,10 +11,10 @@ license:
   # You can put your license key here for testing this chart out,
   # but we STRONGLY recommend using a license file stored in a secret
   # when you ship to production.
-  # key: ""
-  # secret:
-  #   name: influxdb-license
-  #   key: json
+  key: ""
+  secret: {}
+    # name: influxdb-license
+    # key: json
 
 # Service account to use for deployment
 # If the name is not specified default account will be used

--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -145,6 +145,9 @@ meta:
       # ca: ca.crt
       # caSecret: secret-name # only use if different from the above
     insecure: true
+  ## Additional meta container environment variables e.g.:
+  ##   INFLUXDB_META_LOGGING_ENABLED: "false"
+  env: {}
 
 
 data:
@@ -243,3 +246,6 @@ data:
       # ca: ca.crt
       # caSecret: secret-name # only use if different from the above
     insecure: true
+  ## Additional data container environment variables e.g.:
+  ##   INFLUXDB_HTTP_FLUX_ENABLED: "true"
+  env: {}

--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -54,9 +54,9 @@ bootstrap:
 # Sets the tagged version of the docker image that you want to run, will default to latest
 # The suffix is if you are pulling from influx repo, example images will be influxdb:1.8.0-meta and influxdb:1.8.0-data
 # If set to true, the suffix won't be added
-#image:
-#  tag: v1.eg.whatever
-#  ignoresuffix: true | false
+# image:
+#   tag: v1.eg.whatever
+#   ignoresuffix: true | false
 
 meta:
   replicas: 1


### PR DESCRIPTION
Allow configuration of container environment variables.

For greater flexibility and configuration of options found that are not explicitly exposed in the helm chart 

https://docs.influxdata.com/enterprise_influxdb/v1.8/administration/config-data-nodes/#data-node-configuration-settings

Our use case is for INFLUXDB_HTTP_FLUX_ENABLED