### PR TITLE
influxdb2 - persist bolt-path in volume. use docker hub.

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
-version: 1.1.0
+version: 1.2.0
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com

--- a/charts/influxdb2/templates/statefulset.yaml
+++ b/charts/influxdb2/templates/statefulset.yaml
@@ -32,12 +32,14 @@ spec:
         {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:v{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - influxd
             - --engine-path
             - {{ .Values.persistence.mountPath }}
+            - --bolt-path
+            - {{ .Values.persistence.mountPath }}/influxd.bolt
           ports:
             - name: {{ .Values.service.portName }}
               containerPort: 8086

--- a/charts/influxdb2/values.yaml
+++ b/charts/influxdb2/values.yaml
@@ -1,5 +1,6 @@
 image:
-  repository: quay.io/influxdb/influxdb
+  repository: influxdb
+  # tag:
   pullPolicy: IfNotPresent
 
 podAnnotations: {}
@@ -64,7 +65,7 @@ persistence:
   # storageClass: "-"
   accessMode: ReadWriteOnce
   size: 50Gi
-  mountPath: /root/.influxdbv2
+  mountPath: /var/lib/influxdbv2
 
 service:
   type: ClusterIP


### PR DESCRIPTION
# Summary

closes #293 

- use docker hub rather than quay.io
- ensure that boltdb is also persisted in the Volume if mouthPath is set
