### PR TITLE
New telegraf configs features added to the configmap template

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.7.38
+version: 1.7.39
 appVersion: 1.18.0
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/configmap.yaml
+++ b/charts/telegraf/templates/configmap.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
 data:
-{{- if .Values.override_config }}
+{{- if .Values.config_toml }}
   telegraf.conf: |+
-    {{- .Values.override_config.toml | nindent 4 }}
+    {{- .Values.config_toml | nindent 4 }}
 {{- else }}
   telegraf.conf: |+
     {{ template "global_tags" .Values.config.global_tags }}

--- a/charts/telegraf/templates/configmap.yaml
+++ b/charts/telegraf/templates/configmap.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
 data:
+{{- if .Values.override_config }}
+  telegraf.conf: |+
+    {{- .Values.override_config.toml | nindent 4 }}
+{{- else }}
   telegraf.conf: |+
     {{ template "global_tags" .Values.config.global_tags }}
     {{ template "agent" .Values.config.agent }}
@@ -23,3 +27,8 @@ data:
     {{ template "inputs" .Values.config.inputs -}}
     [[inputs.internal]]
       collect_memstats = {{ .Values.metrics.collect_memstats }}
+{{- end }}
+{{- if .Values.query_script }}
+  query.sh: |+
+    {{- .Values.query_script.shell | nindent 4 }}
+{{- end }}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -122,7 +122,7 @@ serviceAccount:
 override_config:
   # toml: ~
   # Provide a literal TOML config
-  
+
 config:
   agent:
     interval: "10s"

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -119,6 +119,10 @@ serviceAccount:
 ## Exposed telegraf configuration
 ## For full list of possible values see `/docs/all-config-values.yaml` and `/docs/all-config-values.toml`
 ## ref: https://docs.influxdata.com/telegraf/v1.1/administration/configuration/
+override_config:
+  # toml: ~
+  # Provide a literal TOML config
+  
 config:
   agent:
     interval: "10s"
@@ -158,6 +162,10 @@ config:
         metric_separator: "_"
         allowed_pending_messages: 10000
         percentile_limit: 1000
+
+query_script:
+  # shell: ~
+  # Provide a literal Shell script
 
 metrics:
   health:

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -119,9 +119,9 @@ serviceAccount:
 ## Exposed telegraf configuration
 ## For full list of possible values see `/docs/all-config-values.yaml` and `/docs/all-config-values.toml`
 ## ref: https://docs.influxdata.com/telegraf/v1.1/administration/configuration/
-override_config:
+config_toml:
   # toml: ~
-  # Provide a literal TOML config
+  # Provide a literal TOML config that replaces all other config options
 
 config:
   agent:


### PR DESCRIPTION
- Allows to provide a literal TOML config.
- Allows to provide a query.sh file from a literal BASH script to be used by the telegraf exec plugin.

Example:

```
  override_config:
    toml: |+
      [global_tags]
  
      [agent]
        interval = "10s"
        round_interval = true
        metric_batch_size = 1000
        metric_buffer_limit = 10000
        collection_jitter = "0s"
        flush_interval = "10s"
        flush_jitter = "0s"
        precision = ""
        hostname = ""
        omit_hostname = false
  
      [[outputs.influxdb]]
        urls = ["http://aci-monitor-influxdb.monitor:8086"]
        database = "telegraf"
        username = "telegraf"
            password = "telegraf"
      
      [[inputs.exec]]
        name_override = "ACI_APIC"
        commands = ["sh /etc/telegraf/query.sh /api/class/infraWiNode.json"]
        timeout = "10s"
        data_format = "json"
      
        json_query = "imdata"
        tag_keys = ["infraWiNode_attributes_nodeName", "infraWiNode_attributes_addr"]
        json_string_fields = ["*health", "*apicMode", "*adminSt", "*operSt", "*failoverStatus"]
      
        [inputs.exec.tags]
           apic = "${APIC_ADDRESS}"

  query_script:
    shell: |+
      #!/bin/bash
      #
      # Pipe bash arguments to variables
      operation=$1
      
      # Create cookie filename
      #cookiefilename=apic_cookie
      
      # APIC Login and store session cookie to /tmp
      curl -s -k -d "<aaaUser name=${APIC_USER} pwd=${APIC_PASSWORD}/>" -c /tmp/cookiefile -X POST https://${APIC_ADDRESS}/api/mo/aaaLogin.xml > /dev/null
      
      # APIC Query Operation using the session cookie
      curl -s -k -X GET https://${APIC_ADDRESS}$operation -b /tmp/cookiefile
      
      # APIC Logout
      curl -s -k -d "<aaaUser name=${APIC_USER}/>" -X POST https://${APIC_ADDRESS}/api/mo/aaaLogout.json -b /tmp/cookiefile > /dev/null
      
      # Remove session cookie
      # rm -f /tmp/cookiefile


```
