### PR TITLE
Add input socket_listener port to K8s Service when it is UDP or TCP

### DIFF
--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -57,6 +57,14 @@ spec:
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
     name: "webhooks"
     {{- end }}
+    {{- if eq $key "socket_listener" }}
+    {{- if or (hasPrefix "udp" $value.service_address) (hasPrefix "tcp" $value.service_address) }}
+  - port: {{ regexFind "[0-9]+$" $value.service_address  | int64 }}
+    targetPort: {{ regexFind "[0-9]+$" $value.service_address  | int64 }}
+    protocol: {{ upper (substr 0 3 $value.service_address) }}
+    name: {{ printf "%s-%s" "socket-listener" (regexFind "[0-9]+$" $value.service_address) }}
+    {{- end }}
+    {{- end }}
   {{- end -}}
   {{- end }}
   {{- range $objectKey, $objectValue := .Values.config.outputs }}


### PR DESCRIPTION
Hello there! 👋

### Context:

While using the chart I've noticed that the UDP listener plugin has been deprecated in favor of the [socket_listener plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/socket_listener).
However configuring `socket_listener` didn't expose the port in the K8s service as I expected.

### Implementation Details:
I've based the changes in the supported protocols in the [socket_listener plugin readme file](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/socket_listener).
So basically I check if the value starts with "udp" or "tcp", if they do I add the port to the K8s service.

To support multiple entries I added the port number to the port name. 
Please check the output section to see how the service looks like after this change.

Logs with deprecation:
```
2021-04-21T14:06:30Z W! DEPRECATED: the UDP listener plugin has been deprecated in favor of the socket_listener plugin (https://github.com/influxdata/telegraf/tree/master/plugins/inputs/socket_listener)
```

values used:
```
config:
  inputs:
    - socket_listener:
        service_address: "udp://:9092"
        max_connections: 1024
        read_timeout: 30
        data_format: "influx"
    - socket_listener:
        service_address: "tcp://:9093"
        max_connections: 1024
        read_timeout: 30
        data_format: "influx"
    - socket_listener:
        service_address: "unix://foo.socket"
        max_connections: 1024
        read_timeout: 30
        data_format: "influx"
```

Output after this change is applied:
```
# Source: telegraf/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: telegraf
  labels:
    helm.sh/chart: telegraf-1.7.38
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf
spec:
  type: ClusterIP
  ports:
  - port: 9092
    targetPort: 9092
    protocol: UDP
    name: socket-listener-9092
  - port: 9093
    targetPort: 9093
    protocol: TCP
    name: socket-listener-9093
  selector:
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: telegraf
```

### Extra
⚠️ I don't have much experience with Go so the code may not be that great.

Thank you very much for your time and effort maintaining the InfluxDB ecosystem! 🙇 💐 💝 

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [ ] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)