### PR TITLE
[telegraf] Create a script to be used by telegraf exec input plugin

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.7.38
+version: 1.7.39
 appVersion: 1.18.0
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/configmap.yaml
+++ b/charts/telegraf/templates/configmap.yaml
@@ -23,3 +23,7 @@ data:
     {{ template "inputs" .Values.config.inputs -}}
     [[inputs.internal]]
       collect_memstats = {{ .Values.metrics.collect_memstats }}
+{{- if .Values.query_script.shell }}
+  query.sh: |+
+    {{- .Values.query_script.shell | nindent 4 }}
+{{- end }}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -159,6 +159,11 @@ config:
         allowed_pending_messages: 10000
         percentile_limit: 1000
 
+## Optionally create a script to be used by telegraf exec input plugin
+query_script:
+  shell:
+    # Provide a literal shell script
+
 metrics:
   health:
     enabled: false


### PR DESCRIPTION
Optionally create a script to be used by telegraf exec input plugin.

The main purpose is to allow the same script to be reused by more than one [[inputs.exec]] for different query parameters based on bash arguments. In addition, it also allows the user to enter a set of commands to be performed by the [[inputs.exec]] in a more fashion way.