### PR TITLE
fix: add startupProbe to influxdb2 chart 

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
-version: 2.0.1
+version: 2.0.2
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com

--- a/charts/influxdb2/templates/statefulset.yaml
+++ b/charts/influxdb2/templates/statefulset.yaml
@@ -100,6 +100,12 @@ spec:
             httpGet:
               path: /health
               port: http
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
           volumeMounts:
           - name: data
             mountPath: {{ .Values.persistence.mountPath }}


### PR DESCRIPTION
to avoid killing the container too soon while influx is still booting on armv8 (raspberrypi). Without this tweak I could not get influxdb2 chart running on a k3s raspberry pi cluster.