### PR TITLE
[chronograf][ingress] use networking.k8s.io/v1

### DIFF
--- a/charts/chronograf/templates/ingress.yaml
+++ b/charts/chronograf/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "chronograf.fullname" . }}
@@ -22,7 +22,10 @@ spec:
     http:
       paths:
       - path: {{ .Values.ingress.path }}
+        pathType: ImplementationSpecific
         backend:
-          serviceName: {{ template "chronograf.fullname" . }}
-          servicePort: 80
+          service:
+            name: {{ template "chronograf.fullname" . }}
+            port:
+              number: 80
 {{- end -}}


### PR DESCRIPTION
`networking.k8s.io/v1beta1` is deprecated in `v1.19.0`. And removed in `v1.22.0`. Thus my change.

**Tests**

Before my change:

```
➜ helm template chronograf --set=ingress.enabled=true | pluto detect -owide --target-versions k8s=v1.19.0 -
NAME                      NAMESPACE   KIND      VERSION                     REPLACEMENT            DEPRECATED   DEPRECATED IN   REMOVED   REMOVED IN
RELEASE-NAME-chronograf   <UNKNOWN>   Ingress   networking.k8s.io/v1beta1   networking.k8s.io/v1   true         v1.19.0         false     v1.22.0
```

After my change:

```
➜ helm template chronograf --set=ingress.enabled=true | pluto detect -owide --target-versions k8s=v1.19.0 -
There were no resources found with known deprecated apiVersions.
```

Some more tests:

```
➜ helm lint chronograf --debug --namespace test --set=ingress.enabled=true
==> Linting chronograf
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

```
➜ helm upgrade test-release chronograf --debug --install --dry-run --namespace test --set=ingress.enabled=true
history.go:56: [debug] getting history for release test-release
Release "test-release" does not exist. Installing it now.
install.go:173: [debug] Original chart version: ""
install.go:190: [debug] CHART PATH: /Users/tomislater/github/moje/forks/helm-charts-1/charts/chronograf

NAME: test-release
LAST DEPLOYED: Tue Jun 15 11:05:26 2021
NAMESPACE: test
STATUS: pending-install
REVISION: 1
TEST SUITE: None
USER-SUPPLIED VALUES:
ingress:
  enabled: true

COMPUTED VALUES:
affinity: {}
env:
  HOST_PAGE_DISABLED: true
envFromSecret: ""
image:
  pullPolicy: IfNotPresent
  repository: chronograf
  tag: 1.8.8
influxdb: {}
ingress:
  annotations: {}
  enabled: true
  hostname: chronograf.foobar.com
  path: /
  tls: false
nodeSelector: {}
oauth:
  enabled: false
  generic:
    api_key: ""
    api_url: ""
    auth_url: ""
    enabled: false
    public_url: ""
    scopes: ""
    token_url: ""
  github:
    enabled: false
    gh_orgs: ""
  google:
    domains: ""
    enabled: false
    public_url: ""
  heroku:
    enabled: false
    he_orgs: ""
persistence:
  accessMode: ReadWriteOnce
  enabled: false
  size: 8Gi
resources:
  limits:
    cpu: 2
    memory: 2Gi
  requests:
    cpu: 0.1
    memory: 256Mi
service:
  replicas: 1
  type: ClusterIP
tolerations: []
updateStrategy:
  type: RollingUpdate

HOOKS:
MANIFEST:
---
# Source: chronograf/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: test-release-chronograf
  labels:
    app: test-release-chronograf
    chart: "chronograf-1.1.24"
    release: "test-release"
    heritage: "Helm"
spec:
  type: ClusterIP
  ports:
  - port: 80
    targetPort: 8888
  selector:
    app: test-release-chronograf
---
# Source: chronograf/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test-release-chronograf
  labels:
    app: test-release-chronograf
    chart: "chronograf-1.1.24"
    release: "test-release"
    heritage: "Helm"
spec:
  replicas: 1
  strategy:
    type: RollingUpdate
  selector:
    matchLabels:
      app: test-release-chronograf
  template:
    metadata:
      labels:
        app: test-release-chronograf
    spec:
      containers:
      - name: chronograf
        image: "chronograf:1.8.8"
        imagePullPolicy: IfNotPresent
        env:
        - name: "HOST_PAGE_DISABLED"
          value: "true"
        ports:
        - containerPort: 8888
          name: api
        livenessProbe:
          httpGet:
            path: /ping
            port: api
        readinessProbe:
          httpGet:
            path: /ping
            port: api
        volumeMounts:
        - name: data
          mountPath: /var/lib/chronograf
        resources:
          limits:
            cpu: 2
            memory: 2Gi
          requests:
            cpu: 0.1
            memory: 256Mi
      volumes:
        - name: data
          emptyDir: {}
---
# Source: chronograf/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: test-release-chronograf
  labels:
    app: test-release-chronograf
    chart: "chronograf-1.1.24"
    release: "test-release"
    heritage: "Helm"
  annotations:
    {}
spec:
  rules:
  - host: chronograf.foobar.com
    http:
      paths:
      - path: /
        pathType: ImplementationSpecific
        backend:
          service:
            name: test-release-chronograf
            port:
              number: 80

NOTES:
Chronograf can be accessed via port 80 on the following DNS name from within your cluster:

  http://test-release-chronograf.test

You can easily connect to the remote instance from your browser. Forward the webserver port to localhost:8888:

  kubectl port-forward --namespace test $(kubectl get pods --namespace test -l app=test-release-chronograf -o jsonpath='{ .items[0].metadata.name }') 8888

You can also connect to the container running Chronograf. To open a shell session in the pod run the following:

  kubectl exec -i -t --namespace test $(kubectl get pods --namespace test -l app=test-release-chronograf -o jsonpath='{.items[0].metadata.name}') /bin/sh

To view the logs for the Chronograf pod run the following:

  kubectl logs -f --namespace test $(kubectl get pods --namespace test -l app=test-release-chronograf -o jsonpath='{ .items[0].metadata.name }')

Chronograf will be available at the URL:

  http://chronograf.foobar.com
```

- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [ ] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/)