### PR TITLE
Allow backup cronjobs to specify image location in values file

### DIFF
--- a/charts/influxdb/templates/backup-cronjob.yaml
+++ b/charts/influxdb/templates/backup-cronjob.yaml
@@ -66,7 +66,7 @@ spec:
           containers:
           {{- if .Values.backup.gcs }}
           - name: gsutil-cp
-            image: google/cloud-sdk:alpine
+            image: "{{ .Values.backup.gcs.image.repository }}:{{ .Values.backup.gcs.image.tag }}"
             command:
             - /bin/sh
             args:
@@ -97,7 +97,7 @@ spec:
           {{- end }}
           {{- if .Values.backup.azure }}
           - name: azure-cli
-            image: microsoft/azure-cli
+            image: "{{ .Values.backup.azure.image.repository }}:{{ .Values.backup.azure.image.tag }}"
             command:
             - /bin/sh
             args:
@@ -127,7 +127,7 @@ spec:
           {{- end }}
           {{- if .Values.backup.s3 }}
           - name: aws-cli
-            image: amazon/aws-cli
+            image: "{{ .Values.backup.s3.image.repository }}:{{ .Values.backup.s3.image.tag }}"
             command:
             - /bin/sh
             args:

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -292,15 +292,22 @@ backup:
   podAnnotations: {}
 
   ## Google Cloud Storage
-  # gcs:
+  gcs:
+    image:
+      repository: google/cloud-sdk
+      tag: alpine
   #    serviceAccountSecret: influxdb-backup-key
   #    serviceAccountSecretKey: key.json
   #    destination: gs://bucket/influxdb
 
+
   ## Azure
   ## Secret is expected to have connection string stored in `connection-string` field
   ## Existing container will be used or private one withing storage account will be created.
-  # azure:
+  azure:
+    image:
+      repository: mcr.microsoft.com/azure-cli
+      tag: latest
   #   storageAccountSecret: influxdb-backup-azure-key
   #   destination_container: influxdb-container
   #   destination_path: ""
@@ -310,7 +317,10 @@ backup:
   ## Please look at https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where
   ## for the credentials format.
   ## The bucket should already exist.
-  # s3:
+  s3:
+    image:
+      repository: amazon/aws
+      tag: latest
   #   credentialsSecret: aws-credentials-secret
   #   destination: s3://bucket/path
   #   ## Optional. Specify if you're using an alternate S3 endpoint.


### PR DESCRIPTION
Microsoft changed their container repository URL. This change updates to the new one, and it allows these images to specify container repository in the values file. Allowing users to specify a repository is important so security policies that require you to pull all images from an internal corporate repository can be followed.