### PR TITLE
Allow TLS secretName to be option for ingress to support default certs

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
 type: application
-version: 2.0.1
+version: 2.0.2
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com

--- a/charts/influxdb2/templates/ingress.yaml
+++ b/charts/influxdb2/templates/ingress.yaml
@@ -17,7 +17,9 @@ spec:
   tls:
     - hosts:
       - {{ .Values.ingress.hostname | quote }}
+      {{- if .Values.ingress.secretName }}
       secretName: {{ .Values.ingress.secretName }}
+      {{- end -}}
 {{- end }}
   rules:
   - host: {{ .Values.ingress.hostname }}

--- a/charts/influxdb2/values.yaml
+++ b/charts/influxdb2/values.yaml
@@ -92,7 +92,7 @@ ingress:
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   # ingressClassName: nginx
   tls: false
-  # secretName: my-tls-cert # only needed if tls above is true
+  # secretName: my-tls-cert # only needed if tls above is true or default certificate is not configured for Nginx
   hostname: influxdb.foobar.com
   annotations: {}
     # kubernetes.io/ingress.class: "nginx"


### PR DESCRIPTION
This PR simply allows `ingress.secretName` for the InfluxDB2 chart to be optional to support [Nginx default certificate](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/tls.md#default-ssl-certificate) functionality. Not seeing a Changelog to update or tests to run, but I bumped the Chart version, and added to the comment for secretName in values.yaml.

- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [ ] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)