### PR TITLE
Influxdb2 - Add startup probe to prevent killing slow container

### DIFF
--- a/charts/influxdb2/templates/statefulset.yaml
+++ b/charts/influxdb2/templates/statefulset.yaml
@@ -100,6 +100,12 @@ spec:
             httpGet:
               path: /health
               port: http
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
           volumeMounts:
           - name: data
             mountPath: {{ .Values.persistence.mountPath }}


### PR DESCRIPTION
Slow-starting containers (typically the first time an image is pulled) can get killed pretty easily by the readiness & liveness probes