### PR TITLE
[telegraf] Add support for sidecar and init containers

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.4
+version: 1.9.0
 appVersion: 1.19.0
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
 {{ toYaml .Values.securityContext | indent 8 }}
 {{- end }}
       serviceAccountName: {{ template "telegraf.serviceAccountName" . }}
+      {{- with.Values.initContainers }}
+      initContainers:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
@@ -92,6 +96,9 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+      {{- with .Values.extraContainers }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -71,6 +71,16 @@ tolerations: []
 #   value: "value"
 #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
+# Init containers for the pod
+initContainers: []
+# - name: ubuntu
+#   image: ubuntu
+
+# Extra sidecar containers for the pod
+extraContainers: []
+# - name: ubuntu
+#   image: ubuntu
+
 service:
   enabled: true
   type: ClusterIP


### PR DESCRIPTION
Add ability to add sidecar and init containers for Telegraf. Tested on my own deployment.