### PR TITLE
Fix telegraf-ds mounts

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: telegraf-ds
 version: 1.0.23
-appVersion: 1.19
+appVersion: "1.19"
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
 keywords:

--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.0.22
+version: 1.0.23
 appVersion: 1.19
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -43,11 +43,8 @@ spec:
         - name: varrunutmpro
           mountPath: /var/run/utmp
           readOnly: true
-        - name: sysro
-          mountPath: /rootfs/sys
-          readOnly: true
-        - name: procro
-          mountPath: /rootfs/proc
+        - name: hostfsro
+          mountPath: /hostfs
           readOnly: true
         - name: docker-socket
           mountPath: /var/run/docker.sock
@@ -66,15 +63,12 @@ spec:
 {{ toYaml . | indent 8 }}
       {{- end }}
       volumes:
-      - name: sysro
+      - name: hostfsro
         hostPath:
-          path: /sys
+          path: /
       - name: docker-socket
         hostPath:
           path: /var/run/docker.sock
-      - name: procro
-        hostPath:
-          path: /proc
       - name: varrunutmpro
         hostPath:
           path: /var/run/utmp

--- a/charts/telegraf-ds/templates/role.yaml
+++ b/charts/telegraf-ds/templates/role.yaml
@@ -3,7 +3,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: influx:stats:viewer
+  name: influx-stats-viewer
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
     rbac.authorization.k8s.io/aggregate-view-telegraf-stats: "true"

--- a/charts/telegraf-ds/templates/rolebinding.yaml
+++ b/charts/telegraf-ds/templates/rolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: influx:telegraf:viewer
+  name: influx-telegraf-viewer
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
 subjects:

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -33,10 +33,16 @@ env:
     valueFrom:
       fieldRef:
         fieldPath: status.hostIP
+  # Mount the host filesystem and set the appropriate env variables.
+  # ref: https://github.com/influxdata/telegraf/blob/master/docs/FAQ.md
+  # HOST_PROC is required by the cpu, disk, diskio, kernel and processes input plugins
   - name: "HOST_PROC"
-    value: "/rootfs/proc"
+    value: "/hostfs/proc"
+  # HOST_SYS is required by the diskio plugin
   - name: "HOST_SYS"
-    value: "/rootfs/sys"
+    value: "/hostfs/sys"
+  - name: "HOST_MOUNT_PREFIX"
+    value: "/hostfs"
 
 ## Tolerations for pod assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/


### PR DESCRIPTION
 Currently the Helm chart mounts `/proc` on `/rootfs/proc` but even after setting `HOST_PROC=/rootfs/proc` a `cat` on `/proc/self/mounts` or a `df` inside the container shows information for the container and not for the host.

Mounting the host filesystem following [this FAQ](https://github.com/influxdata/telegraf/blob/master/docs/FAQ.md#q-how-can-i-monitor-the-docker-engine-host-from-within-a-container) fixes it.