### PR TITLE
Update telegraf-operator to use image tag instead of Chart Version if specified

### DIFF
--- a/charts/telegraf-operator/templates/deployment.yaml
+++ b/charts/telegraf-operator/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "--telegraf-default-class={{ .Values.classes.default }}"

--- a/charts/telegraf-operator/values.yaml
+++ b/charts/telegraf-operator/values.yaml
@@ -1,6 +1,7 @@
 replicaCount: 3
 image:
   repository: quay.io/influxdb/telegraf-operator
+  tag: 1.2.0
   pullPolicy: IfNotPresent
   sidecarImage: "docker.io/library/telegraf:1.14.4"
 


### PR DESCRIPTION
Updated the telegraf-operator charts(https://github.com/influxdata/helm-charts/tree/master/charts/telegraf-operator) to use an image tag. Telegraf-operator is used as a dependent chart in many cases, this will allow users to specify image tag for telegraf-operator.