### PR TITLE
influxdb: support v1 ingress

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.10.0
+version: 4.10.1
 appVersion: 1.8.6
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/ingress.yaml
+++ b/charts/influxdb/templates/ingress.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.ingress.enabled -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ include "influxdb.fullname" . }}
@@ -22,7 +26,17 @@ spec:
     http:
       paths:
       - path: {{ .Values.ingress.path }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+        pathType: Prefix
+{{- end }}
         backend:
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          service:
+            name: {{ include "influxdb.fullname" . }}
+            port:
+              number: 8086
+{{- else }}
           serviceName: {{ include "influxdb.fullname" . }}
           servicePort: 8086
+{{- end }}
 {{- end -}}


### PR DESCRIPTION
InfluxDB's Helm chart was lacking v1 ingress support, which makes it impossible to deploy on Kubernetes 1.22. This PR makes helm auto-detect if v1 ingress is possible.