### PR TITLE
Fix ServiceAccount token mounth path

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.0.26
+version: 1.0.27
 appVersion: 1.21.1
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/templates/configmap.yaml
+++ b/charts/telegraf-ds/templates/configmap.yaml
@@ -39,6 +39,6 @@ data:
 
     [[inputs.kubernetes]]
     url = "https://$HOSTIP:10250"
-    bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
+    bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     insecure_skip_verify = true
 {{- end }}


### PR DESCRIPTION
Fix issue when a pod with telegraf-ds can't start due to absence of bearer token.

Resolves issue #310

- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [ ] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)