### PR TITLE
[Kapacitor] Add way to set kapacitor strategy type

### DIFF
--- a/charts/kapacitor/Chart.yaml
+++ b/charts/kapacitor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kapacitor
-version: 1.3.2
+version: 1.3.3
 appVersion: 1.5.9
 description: InfluxDB's native data processing engine. It can process both stream
   and batch data from InfluxDB.

--- a/charts/kapacitor/README.md
+++ b/charts/kapacitor/README.md
@@ -49,6 +49,7 @@ The following table lists configurable parameters, their descriptions, and their
 | `image.repository` | image repository url | Kapacitor image | `kapacitor` |
 | `image.tag` | Kapacitor image version | `1.5.2-alpine` |
 | `image.pullPolicy` | Kapacitor image pull policy |  `IfNotPresent` |
+| `strategy` | Kapacitor deployment strategy config |  |
 | `service.type` | Kapacitor web service type  | `ClusterIP` |
 | `persistence.enabled` | Enable Kapacitor persistence using Persistent Volume Claims | `false` |
 | `persistence.storageClass` | Kapacitor Persistent Volume Storage Class | `default` |
@@ -66,7 +67,7 @@ The following table lists configurable parameters, their descriptions, and their
 | `rbac.namespaced` | Creates Role and Rolebinding instead of the default ClusterRole and ClusteRoleBindings for the Kapacitor instance  | `false` |
 | `serviceAccount.annotations` | ServiceAccount annotations | `{}` |
 | `serviceAccount.create` | Create service account | `true` |
-| `serviceAccount.name` | Service account name to use, when empty will be set to created account if `serviceAccount.create` is set else to `default` | `` |
+| `serviceAccount.name` | Service account name to use, when empty will be set to created account if `serviceAccount.create` is set else to `default` |  |
 | `sidecar.image` | Sidecar image | `kiwigrid/k8s-sidecar:0.1.116` |
 | `sidecar.imagePullPolicy` | Sidecar image pull policy | `IfNotPresent` |
 | `sidecar.resources` | Sidecar resources | `{}` |
@@ -86,7 +87,7 @@ To configure the chart, do either of the following:
   --set influxURL=http://myinflux.mytld:8086,persistence.enabled=true \
     influxdata/kapacitor
   ```
-  
+
   This command enables persistence.
 
 - Provide a YAML file that specifies parameter values while installing the chart. For example, use the following command:

--- a/charts/kapacitor/templates/deployment.yaml
+++ b/charts/kapacitor/templates/deployment.yaml
@@ -14,8 +14,6 @@ spec:
   replicas: 1
   strategy:
 {{ toYaml .Values.strategy | trim | indent 4 }}
-    {{ if eq .Values.strategy.type "Recreate" }}rollingUpdate: null{{ end }}
-{{- end }}
   selector:
     matchLabels:
       app: {{ template "kapacitor.fullname" . }}

--- a/charts/kapacitor/templates/deployment.yaml
+++ b/charts/kapacitor/templates/deployment.yaml
@@ -12,6 +12,10 @@ metadata:
     app: {{ template "kapacitor.fullname" . }}
 spec:
   replicas: 1
+  strategy:
+{{ toYaml .Values.strategy | trim | indent 4 }}
+    {{ if eq .Values.strategy.type "Recreate" }}rollingUpdate: null{{ end }}
+{{- end }}
   selector:
     matchLabels:
       app: {{ template "kapacitor.fullname" . }}

--- a/charts/kapacitor/templates/deployment.yaml
+++ b/charts/kapacitor/templates/deployment.yaml
@@ -12,8 +12,10 @@ metadata:
     app: {{ template "kapacitor.fullname" . }}
 spec:
   replicas: 1
+  {{- with .Values.strategy }}
   strategy:
-{{ toYaml .Values.strategy | trim | indent 4 }}
+{{ toYaml . | trim | indent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "kapacitor.fullname" . }}

--- a/charts/kapacitor/values.yaml
+++ b/charts/kapacitor/values.yaml
@@ -6,6 +6,10 @@ image:
   tag: "1.5.9-alpine"
   pullPolicy: "IfNotPresent"
 
+## Deployment Strategy type
+# strategy:
+#   type: Recreate
+
 ## Specify a service type, defaults to NodePort
 ## ref: http://kubernetes.io/docs/user-guide/services/
 ##


### PR DESCRIPTION
Add possibility to specify `kapacitor` deployment strategy type.

## Why?
It isn't possible to alter the kapacitor deployment strategy. In our case we don't have a RWX PVC and that causes trouble on rollouts of new versions.

---

- [ ] CHANGELOG.md updated (I can't find this file)
- [ ] Rebased/mergable
- [ ] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)