### PR TITLE
Telegraf: Support list of tables in TOML generation for input plugins

### DIFF
--- a/charts/telegraf/templates/_helpers.tpl
+++ b/charts/telegraf/templates/_helpers.tpl
@@ -201,29 +201,49 @@ app.kubernetes.io/instance: {{ .Release.Name }}
       {{ $key }} = {{ $value }}
           {{- end }}
           {{- if eq $tp "[]interface {}" }}
-      {{ $key }} = [
-              {{- $numOut := len $value }}
-              {{- $numOut := sub $numOut 1 }}
+            {{- $val0 := index $value 0 -}}
+            {{- $val0tp := typeOf $val0 -}}
+            {{- if eq $val0tp "map[string]interface {}" -}}
               {{- range $b, $val := $value }}
-                {{- $i := int64 $b }}
-                {{- $tp := typeOf $val }}
-                {{- if eq $i $numOut }}
-                  {{- if eq $tp "string" }}
-        {{ $val | quote }}
-                  {{- end }}
-                  {{- if eq $tp "float64" }}
-        {{ $val | int64 }}
-                  {{- end }}
-                {{- else }}
-                  {{- if eq $tp "string" }}
-        {{ $val | quote }},
-                  {{- end}}
-                  {{- if eq $tp "float64" }}
-        {{ $val | int64 }},
-                  {{- end }}
+      [[inputs.{{- $input }}.{{- $key }}]]
+                {{- range $valkey, $valvalue := $val }}
+                    {{- $valvaluetp := typeOf $valvalue }}
+                    {{- if eq $valvaluetp "string" }}
+        {{ $valkey }} = {{ $valvalue | quote }}
+                    {{- end }}
+                    {{- if eq $valvaluetp "float64" }}
+        {{ $valkey }} = {{ $valvalue | int64 }}
+                    {{- end }}
+                    {{- if eq $valvaluetp "bool" }}
+        {{ $valkey }} = {{ $valvalue }}
+                    {{- end }}
                 {{- end }}
               {{- end }}
+            {{- else }}
+      {{ $key }} = [
+                {{- $numOut := len $value }}
+                {{- $numOut := sub $numOut 1 }}
+                {{- range $b, $val := $value }}
+                  {{- $i := int64 $b }}
+                  {{- $tp := typeOf $val }}
+                  {{- if eq $i $numOut }}
+                    {{- if eq $tp "string" }}
+          {{ $val | quote }}
+                    {{- end }}
+                    {{- if eq $tp "float64" }}
+          {{ $val | int64 }}
+                    {{- end }}
+                  {{- else }}
+                    {{- if eq $tp "string" }}
+          {{ $val | quote }},
+                    {{- end}}
+                    {{- if eq $tp "float64" }}
+          {{ $val | int64 }},
+                    {{- end }}
+                  {{- end }}
+                {{- end }}
       ]
+            {{- end }}
           {{- end }}
           {{- end }}
           {{- range $key, $value := $config -}}


### PR DESCRIPTION
Some input plugins like [postgres_extensible](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/postgresql_extensible) require a list of tables as input plugin configuration:
```toml
[[inputs.postgresql_extensible]]
   address = "host=localhost user=postgres sslmode=disable"
  [[inputs.postgresql_extensible.query]]
     sqlquery="SELECT count(*) as total_user_count FROM users"
     version=801
  [[inputs.postgresql_extensible.query]]
     sqlquery="SELECT count(*) as total_post_count FROM posts"
     version=801
```

Right now it's only possible do define a list of primitive values when generating the TOML from yaml input plugins.
So if my values are

```yaml
input:
    - postgresql_extensible:
        address: "host=localhost user=postgres sslmode=disable"
        query:
          - sqlquery: "SELECT count(*) as total_user_count FROM users"
            version: 801
          - sqlquery: "SELECT count(*) as total_post_count FROM posts"
            version: 801
```

the generated TOML is simply:

```toml
[[inputs.postgresql_extensible]]
    address = "host=localhost user=postgres sslmode=disable"
    query = [
    ]
```

The introduced changes check, because of the limited possibilities, if the first value in a list is a table/dictionary and if so, it tries to generate all values in the double-bracket form. So after my changes, the example TOMAL above is properly generated.

In the future it might be a good idea to come up with a different way of being able to pass the input config, like directly passing the TOML string, as this PR just moves the limitations to another nesting level of TOML.

- [ ] CHANGELOG.md updated
- [X] Rebased/mergable
- [ ] Tests pass
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)