### PR TITLE
telegraf-ds: add support setting dnsConfig

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.0.24
+version: 1.0.25
 appVersion: 1.20.2
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -79,3 +79,7 @@ spec:
       {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
       {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml . | indent 8 }}
+      {{- end }}

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -56,6 +56,19 @@ tolerations: []
 ## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#
 ## dnsPolicy: ClusterFirstWithHostNet
 
+## If using dnsPolicy=None, set dnsConfig
+## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+## dnsConfig:
+##   nameservers:
+##     - 1.2.3.4
+##   searches:
+##     - ns1.svc.cluster-domain.example
+##     - my.dns.search.suffix
+##   options:
+##     - name: ndots
+##       value: "2"
+##     - name: edns0
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true


### PR DESCRIPTION
This allow setting `dnsConfig` when `dnsPolicy` is set to None

Signed-off-by: Seena Fallah <seenafallah@gmail.com>