### PR TITLE
fix(gh-pages): update page with correct repo url

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@
 ## Add the InfluxData Helm repository
 
 ```bash
-helm repo add influxdata https://influxdata.github.io/helm-charts
+helm repo add influxdata https://helm.influxdata.com
 ```
 
 ## Install InfluxDB


### PR DESCRIPTION
Update the helm repo url to the correct location. Helm is looking for `index.yaml` which is served at https://helm.influxdata.com/index.yaml. Using the incorrect url as is currently in the instructions, the helm chart index would be served from https://helm.influxdata.com/helm-charts/index.yaml
