### PR TITLE
fix(influxdb2): update version and fix path

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
-appVersion: 2.0.6
+appVersion: 2.1.1
 
 name: influxdb2
 description: A Helm chart for InfluxDB v2
-home: https://www.influxdata.com/products/influxdb-overview/influxdb-2-0/
+home: https://www.influxdata.com/products/influxdb/
 type: application
-version: 2.0.1
+version: 2.0.2
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com

--- a/charts/influxdb2/values.yaml
+++ b/charts/influxdb2/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: influxdb
-  tag: 2.0.6-alpine
+  tag: 2.1.1-alpine
   pullPolicy: IfNotPresent
 
 podAnnotations: {}

--- a/charts/influxdb2/values.yaml
+++ b/charts/influxdb2/values.yaml
@@ -76,7 +76,7 @@ persistence:
   # storageClass: "-"
   accessMode: ReadWriteOnce
   size: 50Gi
-  mountPath: /var/lib/influxdbv2
+  mountPath: /var/lib/influxdb2
 
 service:
   type: ClusterIP


### PR DESCRIPTION
- updates version to 2.1.1
- fixes mountPath to match influxdb2 image filesystem and description (the image contains and [description](https://registry.hub.docker.com/_/influxdb/) describes path `/var/lib/influxdb2`). Together with https://github.com/influxdata/influxdata-docker/pull/549 should end confusion in #350.

- [x] Rebased/mergeable
- [x] Tests pass
