### PR TITLE
Update ingress to v1 from v1beta1 for Influxdb2.

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb/
 type: application
-version: 2.0.2
+version: 2.0.3
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com

--- a/charts/influxdb2/templates/ingress.yaml
+++ b/charts/influxdb2/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1

--- a/charts/influxdb2/templates/ingress.yaml
+++ b/charts/influxdb2/templates/ingress.yaml
@@ -1,30 +1,42 @@
 {{- if .Values.ingress.enabled -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ include "influxdb.fullname" . }}
   labels:
     {{- include "influxdb.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+{{ toYaml .Values.ingress.annotations | indent 4 }}
 spec:
-{{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
-{{- end -}}
 {{- if .Values.ingress.tls }}
   tls:
     - hosts:
       - {{ .Values.ingress.hostname | quote }}
       secretName: {{ .Values.ingress.secretName }}
 {{- end }}
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+{{- end }}
   rules:
   - host: {{ .Values.ingress.hostname }}
     http:
       paths:
       - path: {{ .Values.ingress.path }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+        pathType: Prefix
+{{- end }}
         backend:
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          service:
+            name: {{ include "influxdb.fullname" . }}
+            port:
+              number: 8086
+{{- else }}
           serviceName: {{ include "influxdb.fullname" . }}
-          servicePort: {{ .Values.service.portName }}
+          servicePort: 8086
+{{- end }}
 {{- end -}}

--- a/charts/influxdb2/templates/ingress.yaml
+++ b/charts/influxdb2/templates/ingress.yaml
@@ -26,11 +26,11 @@ spec:
     http:
       paths:
       - path: {{ .Values.ingress.path }}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
         pathType: Prefix
 {{- end }}
         backend:
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           service:
             name: {{ include "influxdb.fullname" . }}
             port:


### PR DESCRIPTION
Not sure if this was by design, but to get the code working I had to copy the config from `influxdbv1` to `influxdbv2` which had the v1 networking config. `influxdbv2` has `v1beta1` at least on the master branch that is. I just copied it over as is and it has worked since I did that. I am sure other folks will run into the problem if not already.

Version 1 has the new config and version 2 has the old one.