### PR TITLE
InfluxDB Enterprise version update

### DIFF
--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -45,11 +45,12 @@ jobs:
         run: |
           kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
           sleep 30 # wait for CertManager
-          kubectl apply -f ./charts/influxdb-enterprise/example-resources.yaml
+          kubectl create namespace influxdb-enterprise-test
+          kubectl apply -f ./charts/influxdb-enterprise/example-resources.yaml --namespace=influxdb-enterprise-test
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install
+        run: ct install --namespace=influxdb-enterprise-test
         env:
           INFLUXDB_ENTERPRISE_LICENSE_KEY: "${{ secrets.INFLUXDB_ENTERPRISE_LICENSE_KEY }}"
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -43,7 +43,7 @@ jobs:
       # Our Enterprise chart requires some resources created
       - name: Create Enterprise Test Resources
         run: |
-          kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.15.1/cert-manager.yaml
+          kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
           sleep 30 # wait for CertManager
           kubectl apply -f ./charts/influxdb-enterprise/example-resources.yaml
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -45,12 +45,15 @@ jobs:
         run: |
           kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
           sleep 30 # wait for CertManager
-          kubectl create namespace influxdb-enterprise-test
-          kubectl apply -f ./charts/influxdb-enterprise/example-resources.yaml --namespace=influxdb-enterprise-test
+          kubectl create namespace test-ns
+          kubectl create secret generic influxdb-license --from-literal=INFLUXDB_ENTERPRISE_LICENSE_KEY=${INFLUXDB_ENTERPRISE_LICENSE_KEY} --namespace=test-ns
+          kubectl apply -f ./charts/influxdb-enterprise/example-resources.yaml --namespace=test-ns
+        env:
+          INFLUXDB_ENTERPRISE_LICENSE_KEY: "${{ secrets.INFLUXDB_ENTERPRISE_LICENSE_KEY }}"
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install --namespace=influxdb-enterprise-test
+        run: ct install --namespace=test-ns
         env:
           INFLUXDB_ENTERPRISE_LICENSE_KEY: "${{ secrets.INFLUXDB_ENTERPRISE_LICENSE_KEY }}"
         if: steps.list-changed.outputs.changed == 'true'

--- a/charts/influxdb-enterprise/README.md
+++ b/charts/influxdb-enterprise/README.md
@@ -45,6 +45,25 @@ license:
     key: json
 ```
 
+Since InfluxDB Enterprise can grab the license key from environment variable `INFLUXDB_ENTERPRISE_LICENSE_KEY`,
+you can also leave `license` entry empty, save the key to a secret
+and then refer to the secret in `envFromSecret`.
+
+```yaml
+license: {}
+  # You can put your license key here for testing this chart out,
+  # but we STRONGLY recommend using a license file stored in a secret
+  # when you ship to production.
+  # key: "your license key"
+  # secret:
+  #  name: license
+  #  key: json
+
+...
+
+envFromSecret: influxdb-license
+```
+
 #### Shared Secret
 
 The meta cluster requires a shared internal secret to secure communication. This must be provided by specifying a secret name in the `values.yaml` file.

--- a/charts/influxdb-enterprise/ci/env-values.yaml
+++ b/charts/influxdb-enterprise/ci/env-values.yaml
@@ -1,0 +1,255 @@
+# Default values for influxdb-enterprise.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+nameOverride: ""
+fullnameOverride: ""
+imagePullSecrets: []
+
+daemonset:
+  enabled: true
+  hostNetworking: true
+
+# License-key and license-path are mutually exclusive. Use only one and leave the other blank.
+license: {}
+  # You can put your license key here for testing this chart out,
+  # but we STRONGLY recommend using a license file stored in a secret
+  # when you ship to production.
+  # key: ""
+  # secret:
+  #   name: influxdb-license
+  #   key: json
+
+# Service account to use for deployment
+# If the name is not specified default account will be used
+serviceAccount:
+  create: false
+  name: ''
+  annotations: {}
+
+## The name of a secret in the same kubernetes namespace which contain values
+## to be added to the environment.
+## This can be used, for example, to set the INFLUXDB_ENTERPRISE_LICENSE_KEY
+## or INFLUXDB_ENTERPRISE_LICENSE_PATH environment variable.
+envFromSecret: influxdb-license
+
+# A secret with keys "username" and "password" is required
+# This bootstrap configuration allows you to configure
+# some parts of the InfluxDB system at install time.
+#
+# This job ONLY runs once, after the first `helm upgrade --install`
+# or `helm install`
+#
+# This job WILL NOT run on upgrades
+#
+bootstrap:
+  # This section allows you to enable authentication'
+  # of the data nodes, which will create a username
+  # and password for your "admin" account.
+  # A secret should be provided, which will have the keys
+  # "username" and "password" available.
+  auth:
+    secretName: influxdb-auth
+  # This section allows you to use DDL and DML to define
+  # databases, retention policies, and inject some data.
+  # When using the configMap setting, the keys "ddl" and "dml"
+  # must exist, even if one of them is empty.
+  # DDL is executed before DML, to enforce databases and retention policies
+  # to exist.
+  ddldml: {}
+    # configMap: influxdb-ddl-dml
+    # resources: {}
+
+
+# Sets the tagged version of the docker image that you want to run, will default to latest
+# The suffix is if you are pulling from influx repo, example images will be influxdb:1.8.0-meta and influxdb:1.8.0-data
+# If set to true, the suffix won't be added
+# image:
+#  tag: v1.eg.whatever
+#  ignoresuffix: true | false
+
+meta:
+  replicas: 1
+  image: {}
+    # override: true
+    # pullPolicy: IfNotPresent
+    # repository: influxdb
+  # nodeSelector: {}
+  # tolerations: []
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 1
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: influxdb.influxdata.com/component
+              operator: In
+              values:
+              - meta
+          topologyKey: kubernetes.io/hostname
+  # podAnnotations: {}
+  #
+  # podSecurityContext: {}
+  #   fsGroup: 2000
+  #
+  # This allows you to run the pods as a non-privileged user, set to the uid
+  # securityContext: {}
+  #   runAsUser: 2000
+  #   runAsGroup: 2000
+  #  capabilities:
+  #    drop:
+  #    - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  #
+  # These are the commands that will be run before influxdb is started
+  # preruncmds:
+  #   - cmd: ls -l
+  #     description: We want to see what's in the directory
+  #   - cmd: stat $HOME/somefile
+  #     description: And we run a second command
+  # This secret needs a key called "secret" and it should be a long random string
+  # Please see docs for shared-internal-secret:
+  # https://docs.influxdata.com/enterprise_influxdb/v1.8/administration/config-data-nodes/#meta-internal-shared-secret
+  sharedSecret:
+    secretName: influxdb-shared-secret
+  #
+  ## Persist data to a persistent volume
+  ##
+  persistence:
+    enabled: false
+    ## A manually managed Persistent Volume and Claim
+    ## Requires persistence.enabled: true
+    ## If defined, PVC must be created manually before volume will be bound
+    # existingClaim:
+    ## influxdb data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    # annotations:
+    # accessMode: ReadWriteOnce
+    # size: 8Gi
+  # Pick one
+  podDisruptionBudget:
+    # maxUnavailable: 2
+    minAvailable: 2
+  https:
+    # If you need to debug the data nodes registration with the meta nodes, we recommend
+    # that you comment out the active curl command in the data-configmap and uncomment the following
+    # line, which has -v / debugging enabled.
+    enabled: true
+    # The `useCertManager` option, when set to true, will
+    # automatically create the certificate resources for you.
+    # You do not need to set the secret.name when using this flag.
+    useCertManager: true
+    secret:
+      name: influxdb-tls
+      # crt: tls.crt
+      # key: tls.key
+      # ca: ca.crt
+      # caSecret: secret-name # only use if different from the above
+    insecure: true
+
+
+data:
+  replicas: 1
+  image: {}
+    # override: true
+    # pullPolicy: IfNotPresent
+    # repository: influxdb
+  # nodeSelector: {}
+  # tolerations: []
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 1
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: influxdb.influxdata.com/component
+              operator: In
+              values:
+              - data
+          topologyKey: kubernetes.io/hostname
+  # podAnnotations: {}
+  #
+  # podSecurityContext: {}
+  #   fsGroup: 2000
+  #
+  # This allows you to run the pods as a non-privileged user, set to the uid
+  # securityContext: {}
+  #   runAsUser: 2000
+  #   runAsGroup: 2000
+  #  capabilities:
+  #    drop:
+  #    - ALL
+  #  capabilities:
+  #    drop:
+  #    - ALL
+  #
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  #
+  # These are the commands that will be run before influxdb is started
+  # preruncmds:
+  #   - cmd: ls -l
+  #     description: We want to see what's in the directory
+  #   - cmd: stat $HOME/somefile
+  #     description: And we run a second command
+  #
+  ## Persist data to a persistent volume
+  ##
+  ## Specify a service type
+  ## NodePort is default
+  ## ref: http://kubernetes.io/docs/user-guide/services/
+  ##
+  service:
+    ## Specify a service type
+    ## ClusterIP is default
+    ## ref: http://kubernetes.io/docs/user-guide/services/
+    ## Add annotations to service
+    # annotations: {}
+    type: ClusterIP
+    # loadBalancerIP: ""
+    # externalIPs: []
+    # externalTrafficPolicy: ""
+  persistence:
+    enabled: false
+    ## A manually managed Persistent Volume and Claim
+    ## Requires persistence.enabled: true
+    ## If defined, PVC must be created manually before volume will be bound
+    # existingClaim:
+    ## influxdb data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    # annotations:
+    # accessMode: ReadWriteOnce
+    # size: 8Gi
+  https:
+    # If you need to debug the data nodes registration with the meta nodes, we recommend
+    # that you comment out the active curl command in the data-configmap and uncomment the following
+    # line, which has -v / debugging enabled.
+    enabled: true
+    # The `useCertManager` option, when set to true, will
+    # automatically create the certificate resources for you.
+    # You do not need to set the secret.name when using this flag.
+    useCertManager: true
+    secret:
+      name: influxdb-tls
+      # crt: tls.crt
+      # key: tls.key
+      # ca: ca.crt
+      # caSecret: secret-name # only use if different from the above
+    insecure: true

--- a/charts/influxdb-enterprise/templates/certmanager-issuer.yaml
+++ b/charts/influxdb-enterprise/templates/certmanager-issuer.yaml
@@ -1,5 +1,5 @@
 {{- if or .Values.data.https.useCertManager .Values.meta.https.useCertManager -}}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "influxdb-enterprise.fullname" . }}

--- a/charts/influxdb-enterprise/templates/data-certmanager.yaml
+++ b/charts/influxdb-enterprise/templates/data-certmanager.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.data.https.enabled .Values.data.https.useCertManager -}}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "influxdb-enterprise.fullname" . }}-data

--- a/charts/influxdb-enterprise/templates/data-configmap.yaml
+++ b/charts/influxdb-enterprise/templates/data-configmap.yaml
@@ -27,7 +27,7 @@ data:
       {{ if .Values.license.key }}
       # license-key and license-path are mutually exclusive, use only one and leave the other blank
       license-key = "{{ .Values.license.key }}" #✨ mutually exclusive with license-path
-      {{ else }}
+      {{ else if .Values.license.secret }}
       # license-key and license-path are mutually exclusive, use only one and leave the other blank
       license-path = "/var/run/secrets/influxdb/license.json"
       {{ end }}

--- a/charts/influxdb-enterprise/templates/data-statefulset.yaml
+++ b/charts/influxdb-enterprise/templates/data-statefulset.yaml
@@ -88,6 +88,11 @@ spec:
           env:
           - name: RELEASE_NAME
             value: {{ include "influxdb-enterprise.fullname" . }}
+          {{- if .Values.envFromSecret }}
+          envFrom:
+          - secretRef:
+              name: {{ .Values.envFromSecret }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8086

--- a/charts/influxdb-enterprise/templates/meta-certmanager.yaml
+++ b/charts/influxdb-enterprise/templates/meta-certmanager.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.meta.https.enabled .Values.meta.https.useCertManager -}}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "influxdb-enterprise.fullname" . }}-meta

--- a/charts/influxdb-enterprise/templates/meta-configmap.yaml
+++ b/charts/influxdb-enterprise/templates/meta-configmap.yaml
@@ -14,7 +14,7 @@ data:
       {{ if .Values.license.key }}
       # license-key and license-path are mutually exclusive, use only one and leave the other blank
       license-key = "{{ .Values.license.key }}" #✨ mutually exclusive with license-path
-      {{ else }}
+      {{ else if .Values.license.secret }}
       # license-key and license-path are mutually exclusive, use only one and leave the other blank
       license-path = "/var/run/secrets/influxdb/license.json"
       {{ end }}

--- a/charts/influxdb-enterprise/templates/meta-statefulset.yaml
+++ b/charts/influxdb-enterprise/templates/meta-statefulset.yaml
@@ -91,6 +91,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.meta.sharedSecret.secretName }}
                   key: secret
+          {{- if .Values.envFromSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.envFromSecret }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8091

--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -31,7 +31,7 @@ serviceAccount:
 ## to be added to the environment.
 ## This can be used, for example, to set the INFLUXDB_ENTERPRISE_LICENSE_KEY
 ## or INFLUXDB_ENTERPRISE_LICENSE_PATH environment variable.
-envFromSecret: {}
+# envFromSecret: influxdb-license
 
 # A secret with keys "username" and "password" is required
 # This bootstrap configuration allows you to configure

--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -6,6 +6,10 @@ nameOverride: ""
 fullnameOverride: ""
 imagePullSecrets: []
 
+daemonset:
+  enabled: true
+  hostNetworking: true
+
 # License-key and license-path are mutually exclusive. Use only one and leave the other blank.
 license: {}
   # You can put your license key here for testing this chart out,

--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -27,6 +27,12 @@ serviceAccount:
   name: ''
   annotations: {}
 
+## The name of a secret in the same kubernetes namespace which contain values
+## to be added to the environment.
+## This can be used, for example, to set the INFLUXDB_ENTERPRISE_LICENSE_KEY
+## or INFLUXDB_ENTERPRISE_LICENSE_PATH environment variable.
+envFromSecret: {}
+
 # A secret with keys "username" and "password" is required
 # This bootstrap configuration allows you to configure
 # some parts of the InfluxDB system at install time.

--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 imagePullSecrets: []
 
 # License-key and license-path are mutually exclusive. Use only one and leave the other blank.
-license:
+license: {}
   # You can put your license key here for testing this chart out,
   # but we STRONGLY recommend using a license file stored in a secret
   # when you ship to production.


### PR DESCRIPTION
This should fix `nil pointer evaluating interface {}.xxx` error in PR #368. In addition to that
- updates certificate manager to `v1` from `v1alpha2` to get rid of deprecation warnings and definite removal in the near future
- uses common namespace (_how come it worked without it?_)
- fixes DNS lookup
- allows license (key or file) to be passed via env variables retrieved from secret (feature copied from `influxdb` chart)
  - custom values for CI tests uses that to safely pass license key)