### PR TITLE
Fix ingress capability check in influxdb

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.10.1
+version: 4.10.2
 appVersion: 1.8.6
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/ingress.yaml
+++ b/charts/influxdb/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
@@ -26,11 +26,11 @@ spec:
     http:
       paths:
       - path: {{ .Values.ingress.path }}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
         pathType: Prefix
 {{- end }}
         backend:
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           service:
             name: {{ include "influxdb.fullname" . }}
             port:


### PR DESCRIPTION
Ensure that the Ingress object is present in networking.k8s.io/v1, before rendering that version of the object.

Some versions of k8s (ie. 1.16), have the v1 api, but it does not include the Ingress, which causes the install to fail, when the ingress is enabled.

The helm documentation states that it is possible to check for an objects presence in an api group:
https://helm.sh/docs/chart_template_guide/builtin_objects/