### PR TITLE
Use port name for backend selector in influxdb2

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb/
 type: application
-version: 2.0.3
+version: 2.0.4
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com

--- a/charts/influxdb2/templates/ingress.yaml
+++ b/charts/influxdb2/templates/ingress.yaml
@@ -37,6 +37,6 @@ spec:
               name: {{ .Values.service.portName }}
 {{- else }}
           serviceName: {{ include "influxdb.fullname" . }}
-          servicePort: 8086
+          servicePort: {{ .Values.service.portName }}
 {{- end }}
 {{- end -}}

--- a/charts/influxdb2/templates/ingress.yaml
+++ b/charts/influxdb2/templates/ingress.yaml
@@ -34,7 +34,7 @@ spec:
           service:
             name: {{ include "influxdb.fullname" . }}
             port:
-              number: 8086
+              name: {{ .Values.service.portName }}
 {{- else }}
           serviceName: {{ include "influxdb.fullname" . }}
           servicePort: 8086


### PR DESCRIPTION
In #386 the service port was hard coded to port 8086. Unfortunately, that's not necessarily the port that the service exposes. In fact, it's not even the default!
The default values.yaml config uses port 80 for the service. Since the ingress specifies the service port, not the container port, the ingress specification doesn't work as expected. 
