### PR TITLE
[telegraf] render percentiles as floats

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.9
+version: 1.8.10
 appVersion: 1.21.1
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/_helpers.tpl
+++ b/charts/telegraf/templates/_helpers.tpl
@@ -207,39 +207,24 @@ app.kubernetes.io/instance: {{ .Release.Name }}
               {{- range $b, $val := $value }}
                 {{- $i := int64 $b }}
                 {{- $tp := typeOf $val }}
-                {{- if eq $i $numOut }}
-                  {{- if eq $tp "string" }}
+                {{- if eq $tp "string" }}
         {{ $val | quote }}
-                  {{- end }}
-                  {{- if eq $tp "float64" }}
-                    {{- if eq $key "percentiles" }}
-                      {{- $xval := float64 (int64 $val) }}
-                      {{- if eq $val $xval }}
+                {{- end }}
+                {{- if eq $tp "float64" }}
+                  {{- if eq $key "percentiles" }}
+                    {{- $xval := float64 (int64 $val) }}
+                    {{- if eq $val $xval }}
         {{ $val | int64 }}.0
-                      {{- else }}
+                    {{- else }}
         {{ $val | float64 }}
-                      {{- end }}
-                    {{- else }}
+                    {{- end }}
+                  {{- else }}
         {{ $val | int64 }}
-                    {{- end }}
-                  {{- end }}
-                {{- else }}
-                  {{- if eq $tp "string" }}
-        {{ $val | quote }},
-                  {{- end}}
-                  {{- if eq $tp "float64" }}
-                    {{- if eq $key "percentiles" }}
-                      {{- $xval := float64 (int64 $val) }}
-                      {{- if eq $val $xval }}
-        {{ $val | int64 }}.0,
-                      {{- else }}
-        {{ $val | float64 }},
-                      {{- end }}
-                    {{- else }}
-        {{ $val | int64 }},
-                    {{- end }}
                   {{- end }}
                 {{- end }}
+                {{- if ne $i $numOut -}}
+        ,
+                {{- end -}}
               {{- end }}
       ]
           {{- end }}

--- a/charts/telegraf/templates/_helpers.tpl
+++ b/charts/telegraf/templates/_helpers.tpl
@@ -212,14 +212,32 @@ app.kubernetes.io/instance: {{ .Release.Name }}
         {{ $val | quote }}
                   {{- end }}
                   {{- if eq $tp "float64" }}
+                    {{- if eq $key "percentiles" }}
+                      {{- $xval := float64 (int64 $val) }}
+                      {{- if eq $val $xval }}
+        {{ $val | int64 }}.0
+                      {{- else }}
+        {{ $val | float64 }}
+                      {{- end }}
+                    {{- else }}
         {{ $val | int64 }}
+                    {{- end }}
                   {{- end }}
                 {{- else }}
                   {{- if eq $tp "string" }}
         {{ $val | quote }},
                   {{- end}}
                   {{- if eq $tp "float64" }}
+                    {{- if eq $key "percentiles" }}
+                      {{- $xval := float64 (int64 $val) }}
+                      {{- if eq $val $xval }}
+        {{ $val | int64 }}.0,
+                      {{- else }}
+        {{ $val | float64 }},
+                      {{- end }}
+                    {{- else }}
         {{ $val | int64 }},
+                    {{- end }}
                   {{- end }}
                 {{- end }}
               {{- end }}


### PR DESCRIPTION
Fixes #382 

- Renders `percentiles` (plugins `statsd`, `ping`) as floats (with trailing `.0` for input values without decimals, it's harmless).
- Also updates Telegraf version to 1.20.4

values:
```
config:
  inputs:
    - statsd:
        service_address: ":8125"
        percentiles:
          - 50
          - 95
          - 99
          - 99.5
        metric_separator: "_"
        allowed_pending_messages: 10000
        percentile_limit: 1000
```

output:
```
    [[inputs.statsd]]
      allowed_pending_messages = 10000
      metric_separator = "_"
      percentile_limit = 1000
      percentiles = [
        50.0,
        95.0,
        99.0,
        99.5
      ]
      service_address = ":8125"
```