### PR TITLE
[influxdb2] chart re-release 

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -5,7 +5,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb/
 type: application
-version: 2.0.5
+version: 2.0.6
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com


### PR DESCRIPTION
The release of the latest `influxdb2` chart failed. This PR only contains version bump to re-release it. Fixes #400.