### PR TITLE
Fix probes and internal metrics configuration

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.10
-appVersion: 1.21.1
+version: 1.8.11
+appVersion: 1.21.2
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
 keywords:

--- a/charts/telegraf/ci/default-values.yaml
+++ b/charts/telegraf/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# Default values only, no overrides

--- a/charts/telegraf/ci/metrics-health-enabled-values.yaml
+++ b/charts/telegraf/ci/metrics-health-enabled-values.yaml
@@ -1,0 +1,3 @@
+metrics:
+  health:
+    enabled: true

--- a/charts/telegraf/templates/_helpers.tpl
+++ b/charts/telegraf/templates/_helpers.tpl
@@ -532,3 +532,22 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Get health configuration
+*/}}
+{{- define "telegraf.health" -}}
+{{- if .Values.metrics.health.enabled -}}
+    {{- .Values.metrics.health | toYaml -}}
+{{- else -}}
+    {{- $health := dict -}}
+    {{- range $objectKey, $objectValue := .Values.config.outputs }}
+        {{- range $key, $value := . -}}
+        {{- if eq $key "health" -}}
+            {{- $health = $value -}}
+        {{- end -}}
+        {{- end -}}
+    {{- end }}
+    {{- $health | toYaml -}}
+{{- end -}}
+{{- end -}}

--- a/charts/telegraf/templates/configmap.yaml
+++ b/charts/telegraf/templates/configmap.yaml
@@ -13,11 +13,11 @@ data:
     {{ template "outputs" .Values.config.outputs }}
     {{- if .Values.metrics.health.enabled }}
     [[outputs.health]]
-      service_address = "http://:8888"
+      service_address = "{{ .Values.metrics.health.service_address }}"
       namepass = ["internal_write"]
       [[outputs.health.compares]]
         field = "buffer_size"
-        lt = {{ .Values.metrics.health.threshold }}
+        lt = {{ .Values.metrics.health.threshold | int64 }}.0
       [[outputs.health.contains]]
         field = "buffer_size"
     {{- end }}

--- a/charts/telegraf/templates/configmap.yaml
+++ b/charts/telegraf/templates/configmap.yaml
@@ -22,5 +22,7 @@ data:
         field = "buffer_size"
     {{- end }}
     {{ template "inputs" .Values.config.inputs -}}
+    {{- if .Values.metrics.internal.enabled }}
     [[inputs.internal]]
-      collect_memstats = {{ .Values.metrics.collect_memstats }}
+      collect_memstats = {{ or .Values.metrics.internal.collect_memstats (.Values.metrics.collect_memstats | default false) }}
+    {{- end }}

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -77,20 +77,20 @@ spec:
         {{ end }}
         {{ end }}
         {{ end }}
-        {{- range $objectKey, $objectValue := .Values.config.outputs }}
-        {{- range $key, $value := . -}}
-        {{- $tp := typeOf $value -}}
-        {{- if eq $key "health" }}
+        {{- $health := include "telegraf.health" . | fromYaml }}
+        {{- with $health }}
+        startupProbe:
+          httpGet:
+            path: /
+            port: {{ trimPrefix "http://:" .service_address | int64 }}
         livenessProbe:
           httpGet:
             path: /
-            port: {{ trimPrefix "http://:" $value.service_address | int64 }}
+            port: {{ trimPrefix "http://:" .service_address | int64 }}
         readinessProbe:
           httpGet:
             path: /
-            port: {{ trimPrefix "http://:" $value.service_address | int64 }}
-        {{- end }}
-        {{- end }}
+            port: {{ trimPrefix "http://:" .service_address | int64 }}
         {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -12,9 +12,10 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-  {{- if .Values.metrics.health.enabled }}
-  - port: 8888
-    targetPort: 8888
+  {{- $health := include "telegraf.health" . | fromYaml }}
+  {{- with $health }}
+  - port: {{ trimPrefix "http://:" .service_address | int64 }}
+    targetPort: {{ trimPrefix "http://:" .service_address | int64 }}
     name: "health"
   {{- end }}
   {{- range $objectKey, $objectValue := .Values.config.inputs }}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -170,6 +170,7 @@ config:
 metrics:
   health:
     enabled: false
+    service_address: "http://:8888"
     threshold: 5000.0
   collect_memstats: false
 

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -172,7 +172,9 @@ metrics:
     enabled: false
     service_address: "http://:8888"
     threshold: 5000.0
-  collect_memstats: false
+  internal:
+    enabled: true
+    collect_memstats: false
 
 # Lifecycle hooks
 # hooks:


### PR DESCRIPTION
- closes #406 
  - adds test files for default values test and metrics health enabled
- closes #264 
  -  `internal` plugin is enabled by default for backward compatibility, can be disabled with `metrics.internal.enabled: false`
- updates Telegraf to 1.21.2
