### PR TITLE
Telegraf-DS: parametrize the pod's SecurityContext

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.0.27
+version: 1.0.28
 appVersion: 1.21.1
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -83,3 +83,5 @@ spec:
       dnsConfig:
 {{ toYaml . | indent 8 }}
       {{- end }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -83,5 +83,7 @@ spec:
       dnsConfig:
 {{ toYaml . | indent 8 }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-{{ toYaml .Values.podSecurityContext | indent 8 }}
+{{ toYaml . | indent 8 }}
+      {{- end }}

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -84,6 +84,9 @@ serviceAccount:
 ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 # priorityClassName: system-node-critical
 
+# Specify the pod's SecurityContext, including the OS user and group to run the pod
+podSecurityContext: {}
+
 override_config:
   toml: ~
   # Provide a literal TOML config


### PR DESCRIPTION
This PR exposes the Telegraf pod's SecurityContext as a user-configured value, allowing the user to provide the `runAsUser`/`runAsGroup` parameters in the Telegraf-DS chart. (The SecurityContext is already exposed in similar way in the Telegraf and Telegraf-Operator charts.) Since Telegraf 1.20.3, providing a non-default `runAsGroup` value is crucial to being able to use the Docker input plugin (see [Docker: Run Telegraf as non-root](https://www.influxdata.com/blog/docker-run-telegraf-as-non-root/)).

I tested the fix by running `helm template` and examining the output.

- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)