### PR TITLE
[telegraf-ds] configurable docker plugin socket

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.0.31
+version: 1.0.32
 appVersion: 1.21.4
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/ci/default-values.yaml
+++ b/charts/telegraf-ds/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# Default values only, no overrides

--- a/charts/telegraf-ds/ci/docker-no-endpoint-values.yaml
+++ b/charts/telegraf-ds/ci/docker-no-endpoint-values.yaml
@@ -1,0 +1,2 @@
+config:
+  docker_endpoint: ""

--- a/charts/telegraf-ds/templates/configmap.yaml
+++ b/charts/telegraf-ds/templates/configmap.yaml
@@ -34,8 +34,10 @@ data:
     [[inputs.disk]]
     ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
 
+    {{- if .Values.config.docker_endpoint }}
     [[inputs.docker]]
-    endpoint = "unix:///var/run/docker.sock"
+    endpoint = {{ .Values.config.docker_endpoint | quote }}
+    {{- end }}
 
     [[inputs.kubernetes]]
     url = "https://$HOSTIP:10250"

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -46,8 +46,10 @@ spec:
         - name: hostfsro
           mountPath: /hostfs
           readOnly: true
+        {{- if hasPrefix "unix" .Values.config.docker_endpoint }}
         - name: docker-socket
-          mountPath: /var/run/docker.sock
+          mountPath: {{ trimPrefix "unix://" .Values.config.docker_endpoint }}
+        {{- end }}
         - name: config
           mountPath: /etc/telegraf
       {{- with .Values.nodeSelector }}
@@ -66,9 +68,12 @@ spec:
       - name: hostfsro
         hostPath:
           path: /
+      {{- if hasPrefix "unix" .Values.config.docker_endpoint }}
       - name: docker-socket
         hostPath:
-          path: /var/run/docker.sock
+          path: {{ trimPrefix "unix://" .Values.config.docker_endpoint }}
+          type: Socket
+      {{- end }}
       - name: varrunutmpro
         hostPath:
           path: /var/run/utmp

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -135,3 +135,4 @@ config:
         user_agent: "telegraf"
         insecure_skip_verify: false
   monitor_self: false
+  docker_endpoint: "unix:///var/run/docker.sock"


### PR DESCRIPTION
- `inputs.docker` endpoint can be specified with `config.docker_endpoint` value, default is `unix:///var/run/docker.sock`, empty string disables the plugin

Closes #267
Closes #320