### PR TITLE
[telegraf-ds] support annotations on serviceaccount

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.0.28
+version: 1.0.29
 appVersion: 1.21.1
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/templates/serviceaccount.yaml
+++ b/charts/telegraf-ds/templates/serviceaccount.yaml
@@ -5,4 +5,8 @@ metadata:
   name: {{ include "telegraf.serviceAccountName" . }}
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -79,6 +79,8 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   # name:
+  # Annotations for the ServiceAccount
+  annotations: {}
 
 ## Specify priorityClassName
 ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/


### PR DESCRIPTION
Adds support for annotations in the ServiceAccount.

Facilitates easier installation of the chart into EKS clusters, when using IRSA (IAM roles for service accounts).

With annotations:

```
$ helm template charts/telegraf-ds -s templates/serviceaccount.yaml  \
    --set "serviceAccount.annotations.foo=bar" \
    --set "serviceAccount.annotations.bar=baz"
---
# Source: telegraf-ds/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: RELEASE-NAME-telegraf-ds
  labels:
    helm.sh/chart: telegraf-ds-1.0.29
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf-ds
    app.kubernetes.io/instance: RELEASE-NAME
  annotations:
    bar: baz
    foo: bar
```

Without annotations:

```
$ helm template charts/telegraf-ds -s templates/serviceaccount.yaml
---
# Source: telegraf-ds/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: RELEASE-NAME-telegraf-ds
  labels:
    helm.sh/chart: telegraf-ds-1.0.29
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf-ds
    app.kubernetes.io/instance: RELEASE-NAME
```

- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
