### PR TITLE
[telegraf-ds] minor fixes

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.0.30
-appVersion: 1.21.1
+version: 1.0.31
+appVersion: 1.21.4
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
 keywords:

--- a/charts/telegraf-ds/README.md
+++ b/charts/telegraf-ds/README.md
@@ -46,7 +46,7 @@ The default configuration parameters are listed in `values.yaml`. To change the 
 
 ```console
 helm upgrade --install my-release \
-  --set config.outputs.influxdb.url=http://foo.bar:8086 \
+  --set outputs.influxdb.urls=["http://foo.bar:8086"] \
     influxdata/telegraf-ds
 ```
 

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -15,8 +15,8 @@ spec:
         app.kubernetes.io/name: {{ include "telegraf.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
-        # Include a hash of the configmap in the pod template
-        # This means that if the configmap changes, the deployment will be rolled
+        # Include a hash of the configmap in the pod template
+        # This means that if the configmap changes, the deployment will be rolled
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "telegraf.serviceAccountName" . }}

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -75,7 +75,7 @@ spec:
       - name: config
         configMap:
           name:  {{ include "telegraf.fullname" . }}
-      hostNetwork: {{ default .Values.hostNetwork  false }}
+      hostNetwork: {{ default false .Values.hostNetwork }}
       {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
       {{- end }}


### PR DESCRIPTION
`daemonset` template:
- removed non-printable unicode character
Closes #289 
- fixed `hostNetwork` default
`README.dm`:
- fixed example of usage intruction
Closes #316 
