### PR TITLE
Get the KAPACITOR_SLACK_URL from a secret

### DIFF
--- a/charts/kapacitor/Chart.yaml
+++ b/charts/kapacitor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kapacitor
-version: 1.4.2
+version: 1.4.3
 appVersion: 1.6.3
 description: InfluxDB's native data processing engine. It can process both stream
   and batch data from InfluxDB.

--- a/charts/kapacitor/README.md
+++ b/charts/kapacitor/README.md
@@ -62,7 +62,7 @@ The following table lists configurable parameters, their descriptions, and their
 | `resources.limits.cpu` | Kapacitor cpu limit | `2` |
 | `envVars` | Environment variables to set initial Kapacitor configuration (https://hub.docker.com/_/kapacitor/) | `{}` |
 | `influxURL` | InfluxDB url used to interact with Kapacitor (also can be set with ```envVars.KAPACITOR_INFLUXDB_0_URLS_0```) | `http://influxdb-influxdb.tick:8086` |
-| `existingSecret` | Name of an existing Secrect used to set the environment variables for the InfluxDB user and password. The expected keys in the secret are `influxdb-user` and `influxdb-password`. |
+| `existingSecret` | Name of an existing Secrect used to set certain environment variables with sensitive data, like the InfluxDB credentials and the Slack event handler URL. The following keys are accepted in the secret `influxdb-user`, `influxdb-password` and `kapacitor-slack-url` (optional). |
 | `rbac.create` | Create and use RBAC resources | `true` |
 | `rbac.namespaced` | Creates Role and Rolebinding instead of the default ClusterRole and ClusteRoleBindings for the Kapacitor instance  | `false` |
 | `serviceAccount.annotations` | ServiceAccount annotations | `{}` |

--- a/charts/kapacitor/templates/deployment.yaml
+++ b/charts/kapacitor/templates/deployment.yaml
@@ -49,6 +49,12 @@ spec:
             secretKeyRef:
               key: influxdb-password
               name: {{ .Values.existingSecret }}
+        - name: KAPACITOR_SLACK_URL
+          valueFrom:
+            secretKeyRef:
+              key: kapacitor-slack-url
+              name: {{ .Values.existingSecret }}
+              optional: true
         {{- end }}
         ports:
         - containerPort: 9092

--- a/charts/kapacitor/values.yaml
+++ b/charts/kapacitor/values.yaml
@@ -65,11 +65,11 @@ resources:
 ##
 # influxURL: http://influxdb-influxdb.tick:8086
 
-## Name of an existing Secrect used to set the environment variables for the
-## InfluxDB user and password. The expected keys in the secret are
-## `influxdb-user` and `influxdb-password`.
+## Name of an existing Secrect used to set certain environment variables with sensitive data,
+## like the InfluxDB credentials and the Slack event handler URL. The following keys are accepted
+## in the secret `influxdb-user`, `influxdb-password` and `kapacitor-slack-url` (optional).
 ##
-# existingSecret: influxdb-auth
+# existingSecret: kapacitor
 
 ## Role based access control
 rbac:


### PR DESCRIPTION
- Avoid publishing publicly the Slack handler URL in the values.yaml. Obtain that from the Kapacitor `existingSecret` instead.