### PR TITLE
[influxdb-enterprise] add annotations to data.service

### DIFF
--- a/charts/influxdb-enterprise/Chart.yaml
+++ b/charts/influxdb-enterprise/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.15
+version: 0.1.16
 appVersion: 1.9.6
 engine: gotpl
 

--- a/charts/influxdb-enterprise/templates/data-service.yaml
+++ b/charts/influxdb-enterprise/templates/data-service.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+{{- if .Values.data.service.annotations }}
+  annotations:
+{{ toYaml .Values.data.service.annotations | indent 4 }}
+{{- end }}
   name: {{ template "influxdb-enterprise.fullname" . }}-data
   labels:
     influxdb.influxdata.com/component: data

--- a/charts/influxdb-enterprise/templates/meta-service.yaml
+++ b/charts/influxdb-enterprise/templates/meta-service.yaml
@@ -1,6 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
+{{- if .Values.meta.service.annotations }}
+  annotations:
+{{ toYaml .Values.meta.service.annotations | indent 4 }}
   name: {{ template "influxdb-enterprise.fullname" . }}-meta
   labels:
     influxdb.influxdata.com/component: meta

--- a/charts/influxdb-enterprise/templates/meta-service.yaml
+++ b/charts/influxdb-enterprise/templates/meta-service.yaml
@@ -4,6 +4,7 @@ metadata:
 {{- if .Values.meta.service.annotations }}
   annotations:
 {{ toYaml .Values.meta.service.annotations | indent 4 }}
+{{- end }}
   name: {{ template "influxdb-enterprise.fullname" . }}-meta
   labels:
     influxdb.influxdata.com/component: meta

--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -112,8 +112,11 @@ meta:
   sharedSecret:
     secretName: influxdb-shared-secret
   #
+  service:
+    ## Add annotations to service
+    # annotations: {}
+  #
   ## Persist data to a persistent volume
-  ##
   persistence:
     enabled: false
     ## A manually managed Persistent Volume and Claim
@@ -200,22 +203,18 @@ data:
   #   - cmd: stat $HOME/somefile
   #     description: And we run a second command
   #
-  ## Persist data to a persistent volume
-  ##
-  ## Specify a service type
-  ## NodePort is default
-  ## ref: http://kubernetes.io/docs/user-guide/services/
-  ##
   service:
     ## Specify a service type
     ## ClusterIP is default
     ## ref: http://kubernetes.io/docs/user-guide/services/
-    ## Add annotations to service
-    # annotations: {}
     type: ClusterIP
     # loadBalancerIP: ""
     # externalIPs: []
     # externalTrafficPolicy: ""
+    ## Add annotations to service
+    # annotations: {}
+  #
+  ## Persist data to a persistent volume
   persistence:
     enabled: false
     ## A manually managed Persistent Volume and Claim

--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -113,8 +113,12 @@ meta:
     secretName: influxdb-shared-secret
   #
   service:
+    ## Specify a service type
+    ## ClusterIP is default
+    ## ref: http://kubernetes.io/docs/user-guide/services/
+    type: ClusterIP
     ## Add annotations to service
-    annotations: {}
+    # annotations: {}
   #
   ## Persist data to a persistent volume
   persistence:
@@ -212,7 +216,7 @@ data:
     # externalIPs: []
     # externalTrafficPolicy: ""
     ## Add annotations to service
-    annotations: {}
+    # annotations: {}
   #
   ## Persist data to a persistent volume
   persistence:

--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -114,7 +114,7 @@ meta:
   #
   service:
     ## Add annotations to service
-    # annotations: {}
+    annotations: {}
   #
   ## Persist data to a persistent volume
   persistence:
@@ -212,7 +212,7 @@ data:
     # externalIPs: []
     # externalTrafficPolicy: ""
     ## Add annotations to service
-    # annotations: {}
+    annotations: {}
   #
   ## Persist data to a persistent volume
   persistence:


### PR DESCRIPTION
- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

It should be possible to ingest data to influxdb via cloud internal load balancer.

> To set an internal load balancer, add one of the following annotations to the Service depending on the cloud Service provider you're using. 

(ref. [https://kubernetes.io/docs](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer))

**Example: Azure**

```
annotations: 
        service.beta.kubernetes.io/azure-load-balancer-internal: "true"
```

**Applied tests:**

```
helm lint ./influxdb-enterprise
```
resulted to:

```
==> Linting ./influxdb-enterprise
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

```
helm template --set data.service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-internal=true influxdb-enterprise ./influxdb-enterprise
```
resulted to (extract):
```
# Source: influxdb-enterprise/templates/data-service.yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    service.beta.kubernetes.io/azure-load-balancer-internal: true
  name: influxdb-enterprise-data
  labels:
    influxdb.influxdata.com/component: data
    helm.sh/chart: influxdb-enterprise-0.1.15
    app.kubernetes.io/name: influxdb-enterprise
    app.kubernetes.io/instance: influxdb-enterprise
    app.kubernetes.io/version: "1.9.6"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  clusterIP: None
  publishNotReadyAddresses: true
  ports:
  - port: 8086
    protocol: TCP
    name: http
  - port: 8088
    protocol: TCP
    name: rpc
  - port: 2003
    protocol: TCP
    name: graphite
  - port: 4242
    protocol: TCP
    name: opentsdb
  - port: 25826
    protocol: UDP
    name: collectd
  - port: 8089
    protocol: UDP
    name: udp
  selector:
    influxdb.influxdata.com/component: data
    app.kubernetes.io/name: influxdb-enterprise
    app.kubernetes.io/instance: influxdb-enterprise

```