### PR TITLE
fix(telegraf): configmap rendering error

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.16
+version: 1.8.17
 appVersion: 1.21.4
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/configmap.yaml
+++ b/charts/telegraf/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "telegraf.labels" . | nindent 4 }}
 data:
   telegraf.conf: |+
-    {{- $tplVersion := include "detect.version" . -}}
+    {{- $tplVersion := include "detect.version" . }}
     {{ template "global_tags" .Values.config.global_tags }}
     {{ template "agent" .Values.config.agent }}
     {{ template "processors" (list $tplVersion .Values.config.processors) }}


### PR DESCRIPTION
Hello,

Since https://github.com/influxdata/helm-charts/pull/441 in my usage I have the current values:
```yaml
---
config:
  global_tags:
    foo: bar
```

And when `helm template testing .`, I've got:
```yaml
Error: YAML parse error on telegraf/templates/configmap.yaml: error converting YAML to JSON: yaml: line 11: did not find expected comment or line break
```