### PR TITLE
[influxdb-enterprise] Enable configuration of environment variables

### DIFF
--- a/charts/influxdb-enterprise/Chart.yaml
+++ b/charts/influxdb-enterprise/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.17
+version: 0.1.18
 appVersion: 1.9.6
 engine: gotpl
 

--- a/charts/influxdb-enterprise/templates/data-statefulset.yaml
+++ b/charts/influxdb-enterprise/templates/data-statefulset.yaml
@@ -88,6 +88,9 @@ spec:
           env:
           - name: RELEASE_NAME
             value: {{ include "influxdb-enterprise.fullname" . }}
+          {{- if .Values.data.env }}
+{{ toYaml .Values.data.env | indent 10 }}
+          {{- end}}
           {{- if .Values.envFromSecret }}
           envFrom:
           - secretRef:

--- a/charts/influxdb-enterprise/templates/meta-statefulset.yaml
+++ b/charts/influxdb-enterprise/templates/meta-statefulset.yaml
@@ -91,6 +91,9 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.meta.sharedSecret.secretName }}
                   key: secret
+          {{- if .Values.meta.env }}
+{{ toYaml .Values.meta.env | indent 12 }}
+          {{- end}}
           {{- if .Values.envFromSecret }}
           envFrom:
             - secretRef:

--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -158,7 +158,9 @@ meta:
       # ca: ca.crt
       # caSecret: secret-name # only use if different from the above
     insecure: true
-
+  ## Additional data container environment variables e.g.:
+  ##   INFLUXDB_HTTP_FLUX_ENABLED: "true"
+  env: {}
 
 data:
   replicas: 1
@@ -254,3 +256,6 @@ data:
     insecure: true
   flux:
     enabled: true
+  ## Additional data container environment variables e.g.:
+  ##   INFLUXDB_HTTP_FLUX_ENABLED: "true"
+  env: {}


### PR DESCRIPTION
I had to open a new PR due to a mess up. The old PR is: https://github.com/influxdata/helm-charts/pull/439

It shoule be possible to configure environment variables in enterprise chart as well. 
There is another PR related to this change (https://github.com/influxdata/helm-charts/pull/290) but didn't seem to be getting the update it was needed. 

- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

**changed files**
* update meta-statefulset.ymal
* update data-statefulset.yaml
* update values.yaml
* update Chart.yaml (chart version to v0.1.18)

**Applied test 1**
`helm lint ./influxdb-enterprise`
**Result**
```
==> Linting ./influxdb-enterprise
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

**Applied test 2**
`helm template --set data.env.INFLUXDB_ANTI_ENTROPY_ENABLED=true influxdb-enterprise ./influxdb-enterprise`
**Result : data-statefulset.yaml**
```
# Source: influxdb-enterprise/templates/data-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: influxdb-enterprise-data
  labels:
    helm.sh/chart: influxdb-enterprise-0.1.18
    app.kubernetes.io/name: influxdb-enterprise
    app.kubernetes.io/instance: influxdb-enterprise
    app.kubernetes.io/version: "1.9.6"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  podManagementPolicy: Parallel
  serviceName: influxdb-enterprise-data
  selector:
    matchLabels:
      influxdb.influxdata.com/component: data
      app.kubernetes.io/name: influxdb-enterprise
      app.kubernetes.io/instance: influxdb-enterprise
  template:
    metadata:
      labels:
        influxdb.influxdata.com/component: data
        app.kubernetes.io/name: influxdb-enterprise
        app.kubernetes.io/instance: influxdb-enterprise
    spec:
      securityContext:
        null
      serviceAccountName: default
      volumes:
      - name: influxdb-enterprise-data-data
        emptyDir: {}
      - name: config
        configMap:
          name: influxdb-enterprise-data
      - name: tls
        secret:
          secretName: influxdb-enterprise-data-tls

      containers:
        - name: influxdb-enterprise
          command:
          - "/usr/bin/perl"
          args:
          - "/etc/influxdb/entrypoint.pl"
          securityContext:
            null
          image: "influxdb:1.9.6-data"
          imagePullPolicy:
          env:
          - name: RELEASE_NAME
            value: influxdb-enterprise
          - name: INFLUXDB_ANTI_ENTROPY_ENABLED
            value: "true"
          ports:
            - name: http
              containerPort: 8086
              protocol: TCP
            - name: raft
              containerPort: 8088
              protocol: TCP
            - name: udp
              containerPort: 8089
              protocol: UDP
            - name: graphite
              containerPort: 2003
              protocol: TCP
            - name: opentsdb
              containerPort: 4242
              protocol: TCP
            - name: collectd
              containerPort: 25826
              protocol: UDP
          livenessProbe:
            httpGet:
              path: /ping
              port: http
              scheme: HTTPS
          readinessProbe:
            initialDelaySeconds: 30
            httpGet:
              path: /ping
              port: http
              scheme: HTTPS
```