### PR TITLE
[influxdb] fix default user setup job

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.10.6
+version: 4.10.7
 appVersion: 1.8.10
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/post-install-set-auth.yaml
+++ b/charts/influxdb/templates/post-install-set-auth.yaml
@@ -45,5 +45,9 @@ spec:
              curl -X POST http://{{ include "influxdb.fullname" . }}:{{ .Values.config.http.bind_address | default 8086 }}/query \
              --data-urlencode \
              "q=CREATE USER \"${INFLUXDB_USER}\" WITH PASSWORD '${INFLUXDB_PASSWORD}' {{ .Values.setDefaultUser.user.privileges }}"
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
       restartPolicy: {{ .Values.setDefaultUser.restartPolicy }}
 {{- end -}}

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -105,9 +105,9 @@ setDefaultUser:
   enabled: false
 
   ## Image of the container used for job
-  ## Default: appropriate/curl:latest
+  ## Default: curlimages/curl:latest
   ##
-  image: appropriate/curl:latest
+  image: curlimages/curl:latest
 
   ## Deadline for job so it does not retry forever.
   ## Default: activeDeadline: 300


### PR DESCRIPTION
Superseded by #450 

Closes #292 : use `nodeSelector` for set-auth job
Closes #305 : use multiarch `curl` image