### PR TITLE
[telegraf] extend LoadBalancer service configuration

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.18
+version: 1.8.19
 appVersion: 1.22.0
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.19
-appVersion: 1.22.0
+version: 1.9.0
+appVersion: 1.22.1
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
 keywords:

--- a/charts/telegraf/ci/service-metallb-values.yaml
+++ b/charts/telegraf/ci/service-metallb-values.yaml
@@ -1,0 +1,17 @@
+service:
+  type: LoadBalancer
+  multiprotocol: false
+
+config:
+  inputs:
+    - influxdb_listener:
+        service_address: ":8086"
+    - statsd:
+        service_address: ":8125"
+  outputs:
+    - prometheus_client:
+        listen: ":9273"
+
+metrics:
+  health:
+    enabled: true

--- a/charts/telegraf/ci/service-metallb-values.yaml
+++ b/charts/telegraf/ci/service-metallb-values.yaml
@@ -6,8 +6,12 @@ config:
   inputs:
     - influxdb_listener:
         service_address: ":8086"
+    - socket_listener:
+        service_address: "tcp://:8001"
     - statsd:
         service_address: ":8125"
+    - syslog:
+        server: "tcp://:6514"
   outputs:
     - prometheus_client:
         listen: ":9273"

--- a/charts/telegraf/ci/service-nodeport-values.yaml
+++ b/charts/telegraf/ci/service-nodeport-values.yaml
@@ -1,0 +1,16 @@
+service:
+  type: NodePort
+
+config:
+  inputs:
+    - influxdb_listener:
+        service_address: ":8086"
+    - statsd:
+        service_address: ":8125"
+  outputs:
+    - prometheus_client:
+        listen: ":9273"
+
+metrics:
+  health:
+    enabled: true

--- a/charts/telegraf/templates/_service.tpl
+++ b/charts/telegraf/templates/_service.tpl
@@ -1,0 +1,105 @@
+{{/*
+Get list of service protocol groups
+*/}}
+{{- define "service.protocols" -}}
+{{- if eq .Values.service.type "LoadBalancer" }}
+  {{- if (ternary .Values.service.multiprotocol true (hasKey .Values.service "multiprotocol")) -}}
+    {{- dict "" (list "TCP" "UDP") | toYaml -}}
+  {{- else -}}
+    {{- dict "tcp" (list "TCP") "udp" (list "UDP") | toYaml -}}
+  {{- end -}}
+{{- else -}}
+  {{- dict "" (list "TCP" "UDP") | toYaml -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get service port mapping for internal input plugin
+*/}}
+{{- define "service.health" -}}
+{{- $health := include "telegraf.health" . | fromYaml }}
+{{- with $health }}
+  port: {{ trimPrefix "http://:" .service_address | int64 }}
+  targetPort: {{ trimPrefix "http://:" .service_address | int64 }}
+  name: "health"
+{{- end }}
+{{- end -}}
+
+{{/*
+Get service port mapping for input plugin
+*/}}
+{{- define "service.inputs" -}}
+{{- $key := index . 0 }}
+{{- $value := index . 1 }}
+{{- if eq $key "http_listener" }}
+  port: {{ trimPrefix ":" $value.service_address | int64 }}
+  targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+  name: "http-listener"
+{{- end }}
+{{- if eq $key "influxdb_listener" }}
+  port: {{ trimPrefix ":" $value.service_address | int64 }}
+  targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+  name: "influxdb-listener"
+{{- end }}
+{{- if eq $key "http_listener_v2" }}
+  port: {{ trimPrefix ":" $value.service_address | int64 }}
+  targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+  name: "http-listener-v2"
+{{- end }}
+{{- if eq $key "influxdb_v2_listener" }}
+  port: {{ trimPrefix ":" $value.service_address | int64 }}
+  targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+  name: "influxdb-v2-listener"
+{{- end }}
+{{- if eq $key "statsd" }}
+  port: {{ trimPrefix ":" $value.service_address | int64 }}
+  targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+  protocol: "UDP"
+  name: "statsd"
+{{- end }}
+{{- if eq $key "tcp_listener" }}
+  port: {{ trimPrefix ":" $value.service_address | int64 }}
+  targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+  name: "tcp-listener"
+{{- end }}
+{{- if eq $key "udp_listener" }}
+  port: {{ trimPrefix ":" $value.service_address | int64 }}
+  targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+  protocol: "UDP"
+  name: "udp-listener"
+{{- end }}
+{{- if eq $key "webhooks" }}
+  port: {{ trimPrefix ":" $value.service_address | int64 }}
+  targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+  name: "webhooks"
+{{- end }}
+{{- if eq $key "syslog" }}
+  {{- if regexMatch "^(tcp|udp).*" $value.server }}
+  port: {{ regexFind "[0-9]+$" $value.server  | int64 }}
+  targetPort: {{ regexFind "[0-9]+$" $value.server  | int64 }}
+  protocol: {{ upper (substr 0 3 $value.server) }}
+  name: "syslog"
+  {{- end }}
+{{- end }}
+{{- if eq $key "socket_listener" }}
+  {{- if or (hasPrefix "udp" $value.service_address) (hasPrefix "tcp" $value.service_address) }}
+  port: {{ regexFind "[0-9]+$" $value.service_address  | int64 }}
+  targetPort: {{ regexFind "[0-9]+$" $value.service_address  | int64 }}
+  protocol: {{ upper (substr 0 3 $value.service_address) }}
+  name: {{ printf "%s-%s" "socket-listener" (regexFind "[0-9]+$" $value.service_address) }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Get service port mapping for output plugin
+*/}}
+{{- define "service.outputs" -}}
+{{- $key := index . 0 }}
+{{- $value := index . 1 }}
+{{- if eq $key "prometheus_client" }}
+  port: {{ trimPrefix ":" $value.listen | int64 }}
+  targetPort: {{ trimPrefix ":" $value.listen | int64 }}
+  name: "prometheus-client"
+{{- end }}
+{{- end -}}

--- a/charts/telegraf/templates/_service.tpl
+++ b/charts/telegraf/templates/_service.tpl
@@ -19,9 +19,10 @@ Get service port mapping for internal input plugin
 {{- define "service.health" -}}
 {{- $health := include "telegraf.health" . | fromYaml }}
 {{- with $health }}
-  port: {{ trimPrefix "http://:" .service_address | int64 }}
-  targetPort: {{ trimPrefix "http://:" .service_address | int64 }}
-  name: "health"
+  {{- $port := trimPrefix "http://:" .service_address | int64 }}
+  port: {{ $port }}
+  targetPort: {{ $port }}
+  name: "health-{{ $port }}"
 {{- end }}
 {{- end -}}
 
@@ -32,61 +33,71 @@ Get service port mapping for input plugin
 {{- $key := index . 0 }}
 {{- $value := index . 1 }}
 {{- if eq $key "http_listener" }}
-  port: {{ trimPrefix ":" $value.service_address | int64 }}
-  targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
-  name: "http-listener"
+  {{- $port := trimPrefix ":" $value.service_address | int64 }}
+  port: {{ $port }}
+  targetPort: {{ $port }}
+  name: "http-listener-{{ $port }}"
 {{- end }}
 {{- if eq $key "influxdb_listener" }}
-  port: {{ trimPrefix ":" $value.service_address | int64 }}
-  targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
-  name: "influxdb-listener"
+  {{- $port := trimPrefix ":" $value.service_address | int64 }}
+  port: {{ $port }}
+  targetPort: {{ $port }}
+  name: "influxdb-listener-{{ $port }}"
 {{- end }}
 {{- if eq $key "http_listener_v2" }}
-  port: {{ trimPrefix ":" $value.service_address | int64 }}
-  targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
-  name: "http-listener-v2"
+  {{- $port := trimPrefix ":" $value.service_address | int64 }}
+  port: {{ $port }}
+  targetPort: {{ $port }}
+  name: "http-listener-v2-{{ $port }}"
 {{- end }}
 {{- if eq $key "influxdb_v2_listener" }}
-  port: {{ trimPrefix ":" $value.service_address | int64 }}
-  targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
-  name: "influxdb-v2-listener"
+  {{- $port := trimPrefix ":" $value.service_address | int64 }}
+  port: {{ $port }}
+  targetPort: {{ $port }}
+  name: "influxdb-v2-listener-{{ $port }}"
 {{- end }}
 {{- if eq $key "statsd" }}
-  port: {{ trimPrefix ":" $value.service_address | int64 }}
-  targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+  {{- $port := trimPrefix ":" $value.service_address | int64 }}
+  port: {{ $port }}
+  targetPort: {{ $port }}
   protocol: "UDP"
-  name: "statsd"
+  name: "statsd-{{ $port }}"
 {{- end }}
 {{- if eq $key "tcp_listener" }}
-  port: {{ trimPrefix ":" $value.service_address | int64 }}
-  targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
-  name: "tcp-listener"
+  {{- $port := trimPrefix ":" $value.service_address | int64 }}
+  port: {{ $port }}
+  targetPort: {{ $port }}
+  name: "tcp-listener-{{ $port }}"
 {{- end }}
 {{- if eq $key "udp_listener" }}
-  port: {{ trimPrefix ":" $value.service_address | int64 }}
-  targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+  {{- $port := trimPrefix ":" $value.service_address | int64 }}
+  port: {{ $port }}
+  targetPort: {{ $port }}
   protocol: "UDP"
-  name: "udp-listener"
+  name: "udp-listener-{{ $port }}"
 {{- end }}
 {{- if eq $key "webhooks" }}
-  port: {{ trimPrefix ":" $value.service_address | int64 }}
-  targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
-  name: "webhooks"
+  {{- $port := trimPrefix ":" $value.service_address | int64 }}
+  port: {{ $port }}
+  targetPort: {{ $port }}
+  name: "webhooks-{{ $port }}"
 {{- end }}
 {{- if eq $key "syslog" }}
   {{- if regexMatch "^(tcp|udp).*" $value.server }}
-  port: {{ regexFind "[0-9]+$" $value.server  | int64 }}
-  targetPort: {{ regexFind "[0-9]+$" $value.server  | int64 }}
+  {{- $port := regexFind "[0-9]+$" $value.server  | int64 }}
+  port: {{ $port }}
+  targetPort: {{ $port }}
   protocol: {{ upper (substr 0 3 $value.server) }}
-  name: "syslog"
+  name: "syslog-{{ $port }}"
   {{- end }}
 {{- end }}
 {{- if eq $key "socket_listener" }}
   {{- if or (hasPrefix "udp" $value.service_address) (hasPrefix "tcp" $value.service_address) }}
-  port: {{ regexFind "[0-9]+$" $value.service_address  | int64 }}
-  targetPort: {{ regexFind "[0-9]+$" $value.service_address  | int64 }}
+  {{- $port := regexFind "[0-9]+$" $value.service_address  | int64 }}
+  port: {{ $port }}
+  targetPort: {{ $port }}
   protocol: {{ upper (substr 0 3 $value.service_address) }}
-  name: {{ printf "%s-%s" "socket-listener" (regexFind "[0-9]+$" $value.service_address) }}
+  name: "socket-listener-{{ $port }}"
   {{- end }}
 {{- end }}
 {{- end -}}
@@ -98,8 +109,9 @@ Get service port mapping for output plugin
 {{- $key := index . 0 }}
 {{- $value := index . 1 }}
 {{- if eq $key "prometheus_client" }}
-  port: {{ trimPrefix ":" $value.listen | int64 }}
-  targetPort: {{ trimPrefix ":" $value.listen | int64 }}
-  name: "prometheus-client"
+  {{- $port := trimPrefix ":" $value.listen | int64 }}
+  port: {{ $port }}
+  targetPort: {{ $port }}
+  name: "prometheus-client-{{ $port }}"
 {{- end }}
 {{- end -}}

--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -1,8 +1,14 @@
 {{- if .Values.service.enabled -}}
+{{- $protocols := fromYaml (include "service.protocols" .) -}}
+{{- $outer := . -}}
+{{- range $i, $key := keys $protocols | sortAlpha -}}
+{{- $ps := get $protocols $key -}}
+{{- $nameExt := ternary "" (printf "-%s" $key) (empty $key) -}}
+{{- with $outer }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "telegraf.fullname" . }}
+  name: {{ include "telegraf.fullname" . }}{{ $nameExt }}
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
   {{- if .Values.service.annotations }}
@@ -11,86 +17,46 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
-  {{- $health := include "telegraf.health" . | fromYaml }}
-  {{- with $health }}
-  - port: {{ trimPrefix "http://:" .service_address | int64 }}
-    targetPort: {{ trimPrefix "http://:" .service_address | int64 }}
-    name: "health"
+  {{- if .Values.metrics.health.enabled }}
+    {{- $entry := fromYaml (include "service.health" .) -}}
+    {{- if not (empty $entry) -}}
+      {{- $protocol := default "TCP" $entry.protocol -}}
+      {{- if has $protocol $ps -}}
+        {{ toYaml (list $entry) | nindent 2 }}
+      {{- end -}}
+    {{- end -}}
   {{- end }}
   {{- range $objectKey, $objectValue := .Values.config.inputs }}
-  {{- range $key, $value := . -}}
-    {{- $tp := typeOf $value -}}
-    {{- if eq $key "http_listener" }}
-  - port: {{ trimPrefix ":" $value.service_address | int64 }}
-    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
-    name: "http-listener"
-    {{- end }}
-    {{- if eq $key "influxdb_listener" }}
-  - port: {{ trimPrefix ":" $value.service_address | int64 }}
-    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
-    name: "influxdb-listener"
-    {{- end }}
-    {{- if eq $key "http_listener_v2" }}
-  - port: {{ trimPrefix ":" $value.service_address | int64 }}
-    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
-    name: "http-listener-v2"
-    {{- end }}
-    {{- if eq $key "influxdb_v2_listener" }}
-  - port: {{ trimPrefix ":" $value.service_address | int64 }}
-    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
-    name: "influxdb-v2-listener"
-    {{- end }}
-    {{- if eq $key "statsd" }}
-  - port: {{ trimPrefix ":" $value.service_address | int64 }}
-    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
-    protocol: "UDP"
-    name: "statsd"
-    {{- end }}
-    {{- if eq $key "tcp_listener" }}
-  - port: {{ trimPrefix ":" $value.service_address | int64 }}
-    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
-    name: "tcp-listener"
-    {{- end }}
-    {{- if eq $key "udp_listener" }}
-  - port: {{ trimPrefix ":" $value.service_address | int64 }}
-    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
-    protocol: "UDP"
-    name: "udp-listener"
-    {{- end }}
-    {{- if eq $key "webhooks" }}
-  - port: {{ trimPrefix ":" $value.service_address | int64 }}
-    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
-    name: "webhooks"
-    {{- end }}
-    {{- if eq $key "syslog" }}
-      {{- if regexMatch "^(tcp|udp).*" $value.server }}
-  - port: {{ regexFind "[0-9]+$" $value.server  | int64 }}
-    targetPort: {{ regexFind "[0-9]+$" $value.server  | int64 }}
-    protocol: {{ upper (substr 0 3 $value.server) }}
-    name: "syslog"
-      {{- end }}
-    {{- end }}
-    {{- if eq $key "socket_listener" }}
-    {{- if or (hasPrefix "udp" $value.service_address) (hasPrefix "tcp" $value.service_address) }}
-  - port: {{ regexFind "[0-9]+$" $value.service_address  | int64 }}
-    targetPort: {{ regexFind "[0-9]+$" $value.service_address  | int64 }}
-    protocol: {{ upper (substr 0 3 $value.service_address) }}
-    name: {{ printf "%s-%s" "socket-listener" (regexFind "[0-9]+$" $value.service_address) }}
-    {{- end }}
-    {{- end }}
+  {{- range $key, $value := . }}
+    {{- $entry := fromYaml (include "service.inputs" (list $key $value)) -}}
+    {{- if not (empty $entry) -}}
+      {{- $protocol := default "TCP" $entry.protocol -}}
+      {{- if has $protocol $ps -}}
+        {{ toYaml (list $entry) | nindent 2 }}
+      {{- end -}}
+    {{- end -}}
   {{- end -}}
   {{- end }}
   {{- range $objectKey, $objectValue := .Values.config.outputs }}
   {{- range $key, $value := . -}}
-    {{- $tp := typeOf $value -}}
-    {{- if eq $key "prometheus_client" }}
-  - port: {{ trimPrefix ":" $value.listen | int64 }}
-    targetPort: {{ trimPrefix ":" $value.listen | int64 }}
-    name: "prometheus-client"
-    {{- end }}
+    {{- $entry := fromYaml (include "service.outputs" (list $key $value)) -}}
+    {{- if not (empty $entry) -}}
+      {{- $protocol := default "TCP" $entry.protocol -}}
+      {{- if has $protocol $ps -}}
+        {{ toYaml (list $entry) | nindent 2 }}
+      {{- end -}}
+    {{- end -}}
   {{- end -}}
   {{- end }}
   selector:
     {{- include "telegraf.selectorLabels" . | nindent 4 }}
+{{- end }}
+{{- if and (gt (len $protocols) 1) (lt $i (len $protocols)) }}
+---
+{{- end }}
+{{- end -}}
 {{- end -}}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -72,8 +72,15 @@ tolerations: []
 #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
 service:
+  # Specifies whether service should be created
   enabled: true
+  # Service type
   type: ClusterIP
+  # Static IP address for LoadBalancer service type
+  # loadBalancerIP: 10.10.10.10
+  # Specify whether LoadBalancer service type should be multiprotocol or separate services for TCP and UDP are created. True by default when not set.
+  # multiprotocol: true
+  # Annotations for the Service
   annotations: {}
 
 rbac:


### PR DESCRIPTION
This PR 

- adds more options to configure LoadBalancer service type.

`service.loadBalancerIP` - allows to set static IP [Closes #334] 
`service.multiprotocol` - controls whether single service with mixed protocols is used or separate services for TCP and UDP are created

Does the same as #194 but with less template code duplicates.

- fixes ports entry name clash when multiple plugins of the same type are used (like #458 but for all plugins) by including port as the name suffix

---

Example (`LoadBalancer` with split services for TCP and UDP):
```yaml
service:
  type: LoadBalancer
  multiprotocol: false

config:
  inputs:
    - influxdb_listener:
        service_address: ":8086"
    - statsd:
        service_address: ":8125"
  outputs:
    - prometheus_client:
        listen: ":9273"

metrics:
  health:
    enabled: true
```
` helm template --release-name my-telegraf -f charts/telegraf/ci/service-metallb-values.yaml charts/telegraf`

Services
```yaml
---
# Source: telegraf/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: RELEASE-NAME-telegraf-tcp
  labels:
    helm.sh/chart: telegraf-1.8.18
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: RELEASE-NAME
spec:
  type: LoadBalancer
  ports:
  - name: health-8888
    port: 8888
    targetPort: 8888
  - name: influxdb-listener-8086
    port: 8086
    targetPort: 8086
  - name: prometheus-client-9273
    port: 9273
    targetPort: 9273
  selector:
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: RELEASE-NAME
---
# Source: telegraf/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: RELEASE-NAME-telegraf-udp
  labels:
    helm.sh/chart: telegraf-1.8.18
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: RELEASE-NAME
spec:
  type: LoadBalancer
  ports:
  - name: statsd-8125
    port: 8125
    protocol: UDP
    targetPort: 8125
  selector:
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: RELEASE-NAME
```