### PR TITLE
[telegraf] allow variables in nameOverride and podLabel

### DIFF
--- a/charts/telegraf/templates/_helpers.tpl
+++ b/charts/telegraf/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "telegraf.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- tpl (default .Chart.Name .Values.nameOverride) . | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -12,8 +12,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "telegraf.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- if tpl .Values.fullnameOverride . -}}
+{{- tpl .Values.fullnameOverride . | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app.kubernetes.io/name: {{ include "telegraf.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
 {{- with .Values.podLabels }}
-{{ toYaml . | indent 8 }}
+{{ tpl (toYaml .) . | indent 8 }}
 {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}


### PR DESCRIPTION
## Change
Allow variables in `nameOverride`, `fullnameOverride` and `podLabels`.
This will help us use custom templated values instead of hard coding them.

e.g

today we use:
```
fullnameOverride: prod-eu-central-1-telegraf
```
we want to be able to use:
```
fullnameOverride: {{ .Release.Namespace }}-telegraf
```

## TODO
- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [ ] Tests pass
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


