### PR TITLE
[telegraf-ds] add pod labels, annotations and env from secret support

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.0.34
-appVersion: 1.22.0
+version: 1.1.0
+appVersion: 1.22.1
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
 keywords:

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -14,10 +14,16 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "telegraf.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.podLabels }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
       annotations:
         # Include a hash of the configmap in the pod template
         # This means that if the configmap changes, the deployment will be rolled
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "telegraf.serviceAccountName" . }}
 {{- if .Values.priorityClassName }}
@@ -39,6 +45,11 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
 {{ toYaml .Values.env | indent 8 }}
+        {{- if .Values.envFromSecret }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.envFromSecret }}
+{{- end }}
         volumeMounts:
         - name: varrunutmpro
           mountPath: /var/run/utmp

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -17,9 +17,21 @@ resources:
     memory: 2Gi
     cpu: 1
 
+## Pod annotations
+podAnnotations: {}
+
+## Pod labels
+podLabels: {}
+
 ## Configure args passed to Telegraf containers
 args: []
 
+## The name of a secret in the same kubernetes namespace which contains values to
+## be added to the environment (must be manually created)
+## This can be useful for auth tokens, etc.
+# envFromSecret: "telegraf-tokens"
+
+## Environment
 env:
   # This pulls HOSTNAME from the node, not the pod.
   - name: HOSTNAME
@@ -44,7 +56,7 @@ env:
   - name: "HOST_MOUNT_PREFIX"
     value: "/hostfs"
 
-## Add custom volumes and mountPoints
+## Add custom volumes and mounts
 # volumes:
 # - name: telegraf-output-influxdb2
 #   configMap:


### PR DESCRIPTION
This PR adds labels, annotations and env from secret support. It's copied from `telegraf` chart.
- enables expose secret key as env  -> Closes #63 
- annotations are used to specify apparmor profile -> Closes #284 