### PR TITLE
feat(influxdb-enterprise): allow to customize meta service properties

### DIFF
--- a/charts/influxdb-enterprise/Chart.yaml
+++ b/charts/influxdb-enterprise/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.18
+version: 0.1.19
 appVersion: 1.9.6
 engine: gotpl
 

--- a/charts/influxdb-enterprise/templates/data-service.yaml
+++ b/charts/influxdb-enterprise/templates/data-service.yaml
@@ -19,6 +19,9 @@ spec:
   - port: 8086
     protocol: TCP
     name: http
+{{- if .Values.data.service.nodePort }}
+    nodePort: {{ .Values.data.service.nodePort }}
+{{- end }}
   - port: 8088
     protocol: TCP
     name: rpc

--- a/charts/influxdb-enterprise/templates/meta-service.yaml
+++ b/charts/influxdb-enterprise/templates/meta-service.yaml
@@ -25,3 +25,13 @@ spec:
   selector:
     influxdb.influxdata.com/component: meta
     {{- include "influxdb-enterprise.selectorLabels" . | nindent 4 }}
+{{- if .Values.meta.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.meta.service.loadBalancerIP }}
+{{- end }}
+{{- if .Values.meta.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.meta.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.meta.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.meta.service.externalTrafficPolicy }}
+{{- end }}

--- a/charts/influxdb-enterprise/templates/meta-service.yaml
+++ b/charts/influxdb-enterprise/templates/meta-service.yaml
@@ -10,8 +10,10 @@ metadata:
     influxdb.influxdata.com/component: meta
     {{- include "influxdb-enterprise.labels" . | nindent 4 }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.meta.service.type }}
+{{- if (eq "ClusterIP" .Values.meta.service.type) }}
   clusterIP: None
+{{- end }}
   publishNotReadyAddresses: true
   ports:
   - port: 8089

--- a/charts/influxdb-enterprise/templates/meta-service.yaml
+++ b/charts/influxdb-enterprise/templates/meta-service.yaml
@@ -22,6 +22,9 @@ spec:
   - port: 8091
     protocol: TCP
     name: http
+{{- if .Values.meta.service.nodePort }}
+    nodePort: {{ .Values.meta.service.nodePort }}
+{{- end }}
   selector:
     influxdb.influxdata.com/component: meta
     {{- include "influxdb-enterprise.selectorLabels" . | nindent 4 }}

--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -120,6 +120,7 @@ meta:
     # loadBalancerIP: ""
     # externalIPs: []
     # externalTrafficPolicy: ""
+    # nodePort: 30086
     ## Add annotations to service
     # annotations: {}
   #
@@ -220,6 +221,7 @@ data:
     # loadBalancerIP: ""
     # externalIPs: []
     # externalTrafficPolicy: ""
+    # nodePort: 30091
     ## Add annotations to service
     # annotations: {}
   #

--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -117,6 +117,9 @@ meta:
     ## ClusterIP is default
     ## ref: http://kubernetes.io/docs/user-guide/services/
     type: ClusterIP
+    # loadBalancerIP: ""
+    # externalIPs: []
+    # externalTrafficPolicy: ""
     ## Add annotations to service
     # annotations: {}
   #


### PR DESCRIPTION
This PR allows customizing influxdb-enterprise meta service the same way as it is already possible for the data service. I.e.
`meta.service.type` can change the k8s service type and a few other other attributes can be specified when using `LoadBalancer` service type. 

Additionally `meta.service.nodePort` and `data.service.nodePort` can further specify fixed (main) HTTP node ports when `NodePort` service type is used.

These changes make it easy for me to customize `influxdb-enterprise` helm chart locally for development, by changing data/meta services to `NodePort` and assigning a specific `nodePort`.
```
helm upgrade --install influxdb influxdata/influxdb-enterprise --namespace default \
  --set-string envFromSecret=influxdb-license \
  --set-string data.service.type=NodePort \
  --set-string meta.service.type=NodePort \
  --set data.service.nodePort=30086 \
  --set meta.service.nodePort=30091  
```