### PR TITLE
Bugfix #472: Make default value for influxURL available and mandatory

### DIFF
--- a/charts/kapacitor/templates/deployment.yaml
+++ b/charts/kapacitor/templates/deployment.yaml
@@ -1,5 +1,3 @@
-{{- $bl := empty .Values.influxURL }}
-{{- if not $bl }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,7 +31,7 @@ spec:
         - name: KAPACITOR_HOSTNAME
           value: {{ template "kapacitor.fullname" . }}.{{ .Release.Namespace }}
         - name: KAPACITOR_INFLUXDB_0_URLS_0
-          value: {{ .Values.influxURL }}
+          value: {{ .Values.influxURL | required "Value influxURL not set!"}}
         {{- range $key, $val := .Values.envVars }}
         - name: {{ $key }}
           value: {{ $val | quote }}
@@ -112,4 +110,3 @@ spec:
         - name: sc-sideload-volume
           emptyDir: {}
       {{- end -}}
-{{- end }}

--- a/charts/kapacitor/values.yaml
+++ b/charts/kapacitor/values.yaml
@@ -10,6 +10,8 @@ image:
 # strategy:
 #   type: Recreate
 
+strategy: {}
+
 ## Specify a service type, defaults to NodePort
 ## ref: http://kubernetes.io/docs/user-guide/services/
 ##
@@ -48,6 +50,7 @@ resources:
 ## ref: https://hub.docker.com/_/kapacitor/
 ## ref: https://docs.influxdata.com/kapacitor/latest/administration/configuration/
 ##
+envVars: {}
 # Examples below
 #
 # envVars:
@@ -110,7 +113,7 @@ sidecar:
     #   cpu: 50m
     #   memory: 50Mi
   ## skipTlsVerify Set to true to skip tls verification for kube api calls
-  # skipTlsVerify: true
+  skipTlsVerify: false
   sideload:
     enabled: false
     label: kapacitor_sideload

--- a/charts/kapacitor/values.yaml
+++ b/charts/kapacitor/values.yaml
@@ -63,13 +63,15 @@ resources:
 ## Set the URL of InfluxDB instance to create subscription on
 ## ref: https://docs.influxdata.com/kapacitor/v1.1/introduction/getting_started/
 ##
-# influxURL: http://influxdb-influxdb.tick:8086
+influxURL: http://influxdb-influxdb.tick:8086
 
 ## Name of an existing Secrect used to set the environment variables for the
 ## InfluxDB user and password. The expected keys in the secret are
 ## `influxdb-user` and `influxdb-password`.
 ##
 # existingSecret: influxdb-auth
+
+existingSecret: {}
 
 ## Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
This PR fixes #472.

Tests run:
- Ran helm template with new values.yaml and the chart rendered correctly
- Ran helm without influxURL set and an error was thrown 

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)