### PR TITLE
[telegraf] Add init container in telegraf chart

### DIFF
--- a/charts/telegraf/ci/complex-values.yaml
+++ b/charts/telegraf/ci/complex-values.yaml
@@ -120,6 +120,16 @@ config:
     - file:
         files:
           - "stdout"
+initContainer:
+  enabled: true
+  image: influxdb
+  imageTag: 1.8-alpine
+  securityContext:
+    container:
+      capabilities:
+        drop:
+          - all
+  command: ["/bin/sh", "-c", "echo 'OK'"]
 
 ## Use tpl v2 templates
 tplVersion: 2

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -29,6 +29,22 @@ spec:
 {{ toYaml .Values.securityContext | indent 8 }}
 {{- end }}
       serviceAccountName: {{ template "telegraf.serviceAccountName" . }}
+      initContainers:
+      {{- if (eq .Values.initContainer.enabled true) }}
+        - name: {{ .Chart.Name }}-init-container
+          image: {{ .Values.initContainer.image }}:{{ .Values.initContainer.imageTag }}
+          imagePullPolicy: {{ .Values.initContainer.imagePullPolicy | quote }}
+          {{- if .Values.initContainer.securityContext.container }}
+          securityContext:
+          {{ toYaml .Values.initContainer.securityContext.container | indent 12 }}
+          {{- end }}
+          {{- if .Values.initContainer.command }}
+          command:
+            {{- range $x := .Values.initContainer.command }}
+            - {{ tpl $x $ }}
+          {{- end }}
+          {{- end }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -189,3 +189,12 @@ pdb:
   create: true
   minAvailable: 1
   # maxUnavailable: 1
+
+# Init container
+initContainer:
+  enabled: false
+#  image: influxdb
+#  imageTag: 1.8-alpine
+#  securityContext:
+#    container:
+#  command: ["/bin/sh", "-c", "echo 'OK'"]


### PR DESCRIPTION
Hello, 

This pull request is made in order to add optional init container in telegraf chart.

My goal is to use it to create an influx database with specified retention policy instead of create a dedicated job to do this.

**Test performed**
Deployed in kubernetes cluster with default values, and with simple init container (echo "OK")

- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [ ] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


Thanks by advance