### PR TITLE
Add cron job backup for influxdb2

### DIFF
--- a/charts/influxdb2/README.md
+++ b/charts/influxdb2/README.md
@@ -105,3 +105,28 @@ env:
         name: my-secret
         key: my-key
 ```
+
+
+## Configure the chart
+
+### Backup part
+
+The following table lists configurable parameters, their descriptions, and their default values stored in `values.yaml`.
+
+| Parameter | Description | Default |
+|---|---|---|
+| backup.enabled | Enable backups, if `true` must configure one of the storage providers | `false` |
+| backup.gcs | Google Cloud Storage config | `nil`
+| backup.azure | Azure Blob Storage config | `nil`
+| backup.s3 | Amazon S3 (or compatible) config | `nil`
+| backup.schedule | Schedule to run jobs in cron format | `0 0 * * *` |
+| backup.host | Google Cloud Storage config | `nil`
+| backup.startingDeadlineSeconds | Deadline in seconds for starting the job if it misses its scheduled time for any reason | `nil` |
+| backup.annotations | Annotations for backup cronjob | {} |
+| backup.podAnnotations | Annotations for backup cronjob pods | {} |
+| backup.persistence.enabled | Boolean to enable and disable persistance | false |
+| backup.persistence.storageClass | If set to "-", storageClassName: "", which disables dynamic provisioning. If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.  (gp2 on AWS, standard on GKE, AWS & OpenStack |  |
+| backup.persistence.annotations | Annotations for volumeClaimTemplates | nil |
+| backup.persistence.accessMode | Access mode for the volume | ReadWriteOnce |
+| backup.persistence.size | Storage size | 8Gi |
+| backup.resources | Resources requests and limits for `backup` pods | `ephemeral-storage: 8Gi` |

--- a/charts/influxdb2/templates/backup-cronjob.yaml
+++ b/charts/influxdb2/templates/backup-cronjob.yaml
@@ -1,0 +1,165 @@
+{{- if .Values.backup.enabled }}
+{{- if .Capabilities.APIVersions.Has "batch/v1" }}
+apiVersion: batch/v1
+{{- else }}
+apiVersion: batch/v1beta1
+{{- end }}
+kind: CronJob
+metadata:
+  name: {{ include "influxdb.fullname" . }}-backup
+  labels:
+    {{- include "influxdb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+  annotations:
+    {{- toYaml .Values.backup.annotations | nindent 4 }}
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  startingDeadlineSeconds: {{ .Values.backup.startingDeadlineSeconds }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          {{- if .Values.backup.podAnnotations }}
+          annotations:
+            {{ toYaml .Values.backup.podAnnotations | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "influxdb.selectorLabels" . | nindent 12 }}
+        spec:
+          restartPolicy: OnFailure
+          {{- with .Values.backup.nodeSelector }}
+          nodeSelector:
+             {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumes:
+          - name: backup
+          {{- if .Values.backup.persistence.enabled }}
+            persistentVolumeClaim:
+              claimName: {{ include "influxdb.fullname" . }}-backup
+          {{- else }}
+            emptyDir: {}
+          {{- end }}
+          {{- if .Values.backup.gcs }}
+          {{- if .Values.backup.gcs.serviceAccountSecret }}
+          - name: google-cloud-key
+            secret:
+              secretName: {{ .Values.backup.gcs.serviceAccountSecret | quote }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.backup.s3 }}
+          {{- if .Values.backup.s3.credentialsSecret }}
+          - name: aws-credentials-secret
+            secret:
+              secretName: {{ .Values.backup.s3.credentialsSecret | quote }}
+          {{- end }}
+          {{- end }}
+          serviceAccountName: {{ include "influxdb.serviceAccountName" . }}
+          initContainers:
+          - name: influxdb-backup
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            volumeMounts:
+            - name: backup
+              mountPath: /backup
+            command:
+            - /bin/sh
+            args:
+            - '-c'
+            - |
+              influx backup \
+                /backup/"$(date +%Y%m%d%H%M%S)" \
+                -t $DOCKER_INFLUXDB_INIT_ADMIN_TOKEN \
+                --host {{ .Values.backup.host }}
+            resources:
+              {{- toYaml .Values.backup.resources | nindent 14 }}
+          containers:
+          {{- if .Values.backup.gcs }}
+          - name: gsutil-cp
+            image: google/cloud-sdk:alpine
+            command:
+            - /bin/sh
+            args:
+            - '-c'
+            - '-e'
+            - |
+              if [ -n "$KEY_FILE" ]; then
+                gcloud auth activate-service-account --key-file $KEY_FILE
+              fi
+              gsutil -m cp -r /backup/* "$DST_URL"
+              rm -rf /backup/*
+            volumeMounts:
+            - name: backup
+              mountPath: /backup
+            {{- if .Values.backup.gcs.serviceAccountSecretKey}}
+            - name: google-cloud-key
+              mountPath: /var/secrets/google/
+            {{- end }}
+            env:
+              - name: DST_URL
+                value: {{ .Values.backup.gcs.destination}}
+              {{- if .Values.backup.gcs.serviceAccountSecretKey}}
+              - name: KEY_FILE
+                value: /var/secrets/google/{{ .Values.backup.gcs.serviceAccountSecretKey }}
+              {{- end }}
+            resources:
+              {{- toYaml .Values.backup.resources | nindent 14 }}
+          {{- end }}
+          {{- if .Values.backup.azure }}
+          - name: azure-cli
+            image: mcr.microsoft.com/azure-cli
+            command:
+            - /bin/sh
+            args:
+            - '-c'
+            - '-e'
+            - |
+              az storage container create --name "$DST_CONTAINER"
+              az storage blob upload-batch --destination "$DST_CONTAINER" --destination-path "$DST_PATH" --source "$SRC_URL"
+              rm -rf /backup/*
+            volumeMounts:
+            - name: backup
+              mountPath: /backup
+            env:
+              - name: SRC_URL
+                value: /backup
+              - name: DST_CONTAINER
+                value: {{ .Values.backup.azure.destination_container }}
+              - name: DST_PATH
+                value: {{ .Values.backup.azure.destination_path }}
+              - name: AZURE_STORAGE_CONNECTION_STRING
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.backup.azure.storageAccountSecret }}
+                    key: connection-string
+            resources:
+              {{- toYaml .Values.backup.resources | nindent 14 }}
+          {{- end }}
+          {{- if .Values.backup.s3 }}
+          - name: aws-cli
+            image: amazon/aws-cli
+            command:
+            - /bin/sh
+            args:
+            - '-c'
+            - '-e'
+            - |
+              aws {{- if .Values.backup.s3.endpointUrl }} --endpoint-url={{ .Values.backup.s3.endpointUrl }} {{- end }} s3 cp --recursive "$SRC_URL" "$DST_URL"
+              rm -rf /backup/*
+            volumeMounts:
+            - name: backup
+              mountPath: /backup
+            {{- if .Values.backup.s3.credentialsSecret}}
+            - name: aws-credentials-secret
+              mountPath: /var/secrets/aws/
+            {{- end }}
+            env:
+              - name: AWS_CONFIG_FILE
+                value: /var/secrets/aws/credentials
+              - name: SRC_URL
+                value: /backup
+              - name: DST_URL
+                value: {{ .Values.backup.s3.destination }}
+            resources:
+              {{- toYaml .Values.backup.resources | nindent 14 }}
+          {{- end }}
+{{- end }}

--- a/charts/influxdb2/templates/backup-pvc.yaml
+++ b/charts/influxdb2/templates/backup-pvc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.backup.enabled .Values.backup.persistence.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "influxdb.fullname" . }}-backup
+  labels:
+    {{- include "influxdb.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.backup.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.backup.persistence.size | quote }}
+{{- if .Values.backup.persistence.storageClass }}
+{{- if (eq "-" .Values.backup.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.backup.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/influxdb2/values.yaml
+++ b/charts/influxdb2/values.yaml
@@ -191,3 +191,82 @@ pdb:
   create: true
   minAvailable: 1
   # maxUnavailable: 1
+
+
+backup:
+  enabled: false
+  ## By default emptyDir is used as a transitory volume before uploading to object store.
+  ## As such, ensure that a sufficient ephemeral storage request is set to prevent node disk filling completely.
+  resources:
+    requests:
+      # memory: 512Mi
+      # cpu: 2
+      ephemeral-storage: "8Gi"
+    # limits:
+      # memory: 1Gi
+      # cpu: 4
+      # ephemeral-storage: "16Gi"
+  ## If backup destination is PVC, or want to use intermediate PVC before uploading to object store.
+  persistence:
+    enabled: false
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    # annotations:
+    accessMode: ReadWriteOnce
+    size: 8Gi
+  schedule: "0 0 * * *"
+  host: ""
+  startingDeadlineSeconds: ""
+  annotations: {}
+  podAnnotations: {}
+  nodeSelector: {}
+
+  ## Google Cloud Storage
+  # gcs:
+    # serviceAccountSecret: influxdb-backup-key
+    # serviceAccountSecretKey: key.json
+    # destination: gs://bucket/influxdb
+
+  ## Azure
+  ## Secret is expected to have connection string stored in `connection-string` field
+  ## Existing container will be used or private one withing storage account will be created.
+  # azure:
+    # storageAccountSecret: influxdb-backup-azure-key
+    # destination_container: influxdb-container
+    # destination_path: ""
+
+  ## Amazon S3 or compatible
+  ## Secret is expected to have AWS (or compatible) credentials stored in `credentials` field.
+  ## Please look at https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where
+  ## for the credentials format.
+  ## The bucket should already exist.
+  # s3:
+    # credentialsSecret: aws-credentials-secret
+    # destination: s3://bucket/path
+    ## Optional. Specify if you're using an alternate S3 endpoint.
+    # endpointUrl: ""
+
+backupRetention:
+  enabled: false
+  resources:
+    requests:
+      # memory: 512Mi
+      # cpu: 2
+    # limits:
+      # memory: 1Gi
+      # cpu: 4
+  schedule: "0 0 * * *"
+  startingDeadlineSeconds:
+  annotations: {}
+  podAnnotations: {}
+  daysToRetain: 7
+  # s3:
+  #   credentialsSecret: aws-credentials-secret
+  #   bucketName: bucket
+  #   ## Optional. Specify if you're using an alternate S3 endpoint.
+  #   # endpointUrl: ""


### PR DESCRIPTION
Add the cronjob and pvc backup for influxdb2.

Like in the influxdb template https://github.com/influxdata/helm-charts/tree/master/charts/influxdb/templates.
But with adaptation like in the  cmd https://docs.influxdata.com/influxdb/v2.3/backup-restore/backup/.