### PR TITLE
Add containerSecurityContext in telegraf deployment template

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.19
+version: 1.8.20
 appVersion: 1.23.3
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
       serviceAccountName: {{ template "telegraf.serviceAccountName" . }}
       containers:
       - name: {{ .Chart.Name }}
+{{- if .Values.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.containerSecurityContext | indent 10 }}
+{{- end }}
         image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
         resources:


### PR DESCRIPTION
- [ ] CHANGELOG.md updated <-- I'm not sure where this is?
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Hello! :wave: 

I am submitting this PR because I have been trying to deploy telegraf into a namespace with the [restricted pod security standard profile](https://kubernetes.io/docs/concepts/security/pod-security-admission/#pod-security-admission-labels-for-namespaces). As an example, the namespace looks something like this (note: this only works by default on clusters 1.23+):
```yaml
apiVersion: v1
kind: Namespace
metadata:
  annotations:
  labels:
    pod-security.kubernetes.io/enforce: restricted
    pod-security.kubernetes.io/warn: restricted
  name: test
```
There is a key in the `deployment.yaml` file already (on line 28) for `securityContext`, but this is at the **pod** level, and *not* the **container** level. To meet the requirements of the [restricted policy](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) you need to restrict attributes at both the pod and container `securityContext`. 

With the patch I am submitting here, I can add the following to the `values.yaml` file, and successfully deploy to this namespace with the restricted policy:
```yaml
securityContext:
  seccompProfile:
    type: RuntimeDefault
  runAsNonRoot: true
  runAsUser: 65534
  runAsGroup: 65534

containerSecurityContext:
  allowPrivilegeEscalation: false
  capabilities:
    drop: [ALL]
```

(this command works locally with the above values added)
```
helm upgrade --install telegraf charts/telegraf -n test
```

Let me know if there is anything I can clarify!
