### PR TITLE
Sync telegraf-ds to properly format output subtables

### DIFF
--- a/charts/telegraf-ds/templates/_helpers.tpl
+++ b/charts/telegraf-ds/templates/_helpers.tpl
@@ -133,7 +133,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
         {{- range $key, $value := $config -}}
           {{- $tp := typeOf $value -}}
           {{- if eq $tp "map[string]interface {}" }}
-      [[outputs.{{ $output }}.{{ $key }}]]
+      [outputs.{{ $output }}.{{ $key }}]
             {{- range $k, $v := $value }}
               {{- $tps := typeOf $v }}
               {{- if eq $tps "string" }}
@@ -163,7 +163,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
         ]
               {{- end }}
               {{- if eq $tps "map[string]interface {}"}}
-        [[outputs.{{ $output }}.{{ $key }}.{{ $k }}]]
+        [outputs.{{ $output }}.{{ $key }}.{{ $k }}]
                 {{- range $foo, $bar := $v }}
             {{ $foo }} = {{ $bar | quote }}
                 {{- end }}


### PR DESCRIPTION
Trying to quickly resolve [Issue 498](https://github.com/influxdata/helm-charts/issues/498) by aligning telegraf-ds [with telegraf](https://github.com/influxdata/helm-charts/blob/master/charts/telegraf/templates/_helpers.tpl#L137).  Let me know if there's any further changes or validation I can provide. 

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)