### PR TITLE
Make sidecar default resources configurable

### DIFF
--- a/charts/telegraf-operator/Chart.yaml
+++ b/charts/telegraf-operator/Chart.yaml
@@ -30,7 +30,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.3.10
+version: 1.3.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.19
+version: 1.8.20
 appVersion: 1.23.3
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
       serviceAccountName: {{ template "telegraf.serviceAccountName" . }}
       containers:
       - name: {{ .Chart.Name }}
+{{- if .Values.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.containerSecurityContext | indent 10 }}
+{{- end }}
         image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
         resources:


### PR DESCRIPTION
When default sidecar resources don't fit someone's need it's
preferable to specify a custom default value instead of adding annotations
to every pod that runs sidecar.
So this PR exposes variables to configure default sidecar resources.

This was tested by specifying custom values for default resources and deploying to k8s.
`kubectl describe pod` showed that telegraf sidecar has resources specified using `values.yaml`

