### PR TITLE
fix: sync telegraf-ds to properly format output subtables

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.1.1
+version: 1.1.2
 appVersion: 1.23.3
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/templates/_helpers.tpl
+++ b/charts/telegraf-ds/templates/_helpers.tpl
@@ -133,7 +133,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
         {{- range $key, $value := $config -}}
           {{- $tp := typeOf $value -}}
           {{- if eq $tp "map[string]interface {}" }}
-      [[outputs.{{ $output }}.{{ $key }}]]
+      [outputs.{{ $output }}.{{ $key }}]
             {{- range $k, $v := $value }}
               {{- $tps := typeOf $v }}
               {{- if eq $tps "string" }}
@@ -163,7 +163,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
         ]
               {{- end }}
               {{- if eq $tps "map[string]interface {}"}}
-        [[outputs.{{ $output }}.{{ $key }}.{{ $k }}]]
+        [outputs.{{ $output }}.{{ $key }}.{{ $k }}]
                 {{- range $foo, $bar := $v }}
             {{ $foo }} = {{ $bar | quote }}
                 {{- end }}


### PR DESCRIPTION
Updates to the telegraf version are blocked due to failing CI. This resolves the CI issues.

replaces: #499
fixes: #498