### PR TITLE
Add updateStrategy to Telegraf Deployment.

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.35
+version: 1.8.36
 appVersion: 1.28.2
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -10,6 +10,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "telegraf.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- with .Values.updateStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -58,6 +58,14 @@ tolerations: []
 #   value: "value"
 #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
+## Configure the updateStrategy used to replace Telegraf Pods
+## See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/
+updateStrategy: {}
+#  type: RollingUpdate|Recreate
+#  rollingUpdate:
+#    maxUnavailable: 1
+#    maxSurge: 1
+
 service:
   enabled: true
   type: ClusterIP


### PR DESCRIPTION
This makes it possible to configure the updateStrategy for the Telegraf Deployment. 

In our use case and clusters we have `podAntiAffinity` configured for the Telegraf Deployment and to avoid pods being stuck in state `Pending` we also want to set `updateStrategy.type: Recreate`.

I've manually tried this change with:
```
updateStrategy: {}
```
```
updateStrategy:
  type: RollingUpdate
  rollingUpdate:
    maxUnavailable: 1
    maxSurge: 1
```
```
updateStrategy:
  type: Recreate
```
Which all correctly set the `strategy` on the Deployment.

- [ ] CHANGELOG.md updated -> Doesn't seem to exist anymore?
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)