### PR TITLE
Enterprise Helm Chart README Refactor

### DIFF
--- a/charts/influxdb-enterprise/Chart.yaml
+++ b/charts/influxdb-enterprise/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.21
+version: 0.1.22
 appVersion: 1.10.0
 engine: gotpl
 

--- a/charts/influxdb-enterprise/README.md
+++ b/charts/influxdb-enterprise/README.md
@@ -11,12 +11,73 @@ helm upgrade --install influxdb influxdata/influxdb-enterprise --namespace monit
 
 ## Introduction
 
-This chart bootstraps an InfluxDB Enterprise cluster, with a StatefulSet for both the meta and data nodes.
+[InfluxDB Enterprise](https://www.influxdata.com/products/influxdb-enterprise/) includes features designed for production workloads, including high availability and horizontal scaling. InfluxDB Enterprise requires an InfluxDB Enterprise license. This chart bootstraps an InfluxDB Enterprise cluster, with a StatefulSet for both the meta and data nodes.
 
 ## Prerequisites
 
 - Kubernetes 1.4+
 - PV provisioner support in the underlying infrastructure (optional)
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+helm upgrade --install my-release influxdata/influxdb-enterprise
+```
+
+The command deploys InfluxDB Enterprise on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+helm uninstall my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configure the InfluxDB Enterprise chart
+
+To enable InfluxDB Enterprise, set the following keys and values in a values file provided to Helm.
+
+| Key | Description | Recommended value |
+| --- | --- | --- |
+| `livenessProbe.initalDelaySeconds` | Used to allow enough time to join meta nodes to a cluster | `3600` |
+| `image.tag` | Set to a `data` image. See https://hub.docker.com/_/influxdb for details | `data` |
+| `service.ClusterIP` | Use a headless service for StatefulSets | `"None"` |
+| `env.name[_HOSTNAME]` | Used to provide a unique `name.service` for InfluxDB. See [values.yaml]() for an example | `valueFrom.fieldRef.fieldPath: metadata.name` |
+| `enterprise.enabled` | Create StatefulSets for use with `influx-data` and `influx-meta` images | `true` |
+| `enterprise.licensekey` | License for InfluxDB Enterprise |  |
+| `enterprise.clusterSize` | Replicas for `influx` StatefulSet | Dependent on license |
+| `enterprise.meta.image.tag` | Set to an `meta` image. See https://hub.docker.com/_/influxdb for details | `meta` |
+| `enterprise.meta.clusterSize` | Replicas for `influxdb-meta` StatefulSet. | `3` |
+| `enterprise.meta.resources` | Resources requests and limits for meta `influxdb-meta` pods | See `values.yaml` |
+
+#### Join pods to InfluxDB Enterprise cluster
+
+Meta and data pods must be joined using the command `influxd-ctl` found on meta pods.
+We recommend running `influxd-ctl` on one and only one meta pod and joining meta pods together before data pods. For each meta pod, run `influxd-ctl`.
+
+In the following examples, we use the pod names `influxdb-meta-0` and `influxdb-0` and the service name `influxdb`.
+
+For example, using the default settings, your script should look something like this:
+
+```shell script
+kubectl exec influxdb-meta-0 influxd-ctl add-meta influxdb-meta-0.influxdb-meta:8091
+```
+
+From the same meta pod, for each data pod, run `influxd-ctl`. With default settings, your script should look something like this:
+
+```shell script
+kubectl exec influxdb-meta-0 influxd-ctl add-data influxdb-0.influxdb:8088
+```
+
+When using `influxd-ctl`, use the appropriate DNS name for your pods, following the naming scheme of `pod.service`.
+
 
 ### Secrets
 
@@ -58,6 +119,8 @@ meta:
   sharedSecret:
     secretName: shared-secret
 ```
+
+
 
 #### Authentication (Optional)
 
@@ -113,25 +176,3 @@ bootstrap:
   ddldml:
     configMap: ddl-dml
 ```
-
-## Installing the Chart
-
-To install the chart with the release name `my-release`:
-
-```bash
-helm upgrade --install my-release influxdata/influxdb-enterprise
-```
-
-The command deploys InfluxDB Enterprise on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
-
-> **Tip**: List all releases using `helm list`
-
-## Uninstalling the Chart
-
-To uninstall/delete the `my-release` deployment:
-
-```bash
-helm uninstall my-release
-```
-
-The command removes all the Kubernetes components associated with the chart and deletes the release.

--- a/charts/influxdb-enterprise/README.md
+++ b/charts/influxdb-enterprise/README.md
@@ -120,8 +120,6 @@ meta:
     secretName: shared-secret
 ```
 
-
-
 #### Authentication (Optional)
 
 If you want to configure authentication for your data nodes, you must provide the following within your `values.yaml`:

--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.12.0
+version: 4.12.1
 appVersion: 1.8.10
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/README.md
+++ b/charts/influxdb/README.md
@@ -4,7 +4,7 @@
 
 The InfluxDB Helm chart uses the [Helm](https://helm.sh) package manager to bootstrap an InfluxDB StatefulSet and service on a [Kubernetes](http://kubernetes.io) cluster.
 
-> **Note:** ### If you're using the InfluxDB Enterprise Helm chart, check out [InfluxDB Enterprise Helm chart](#influxdb-enterprise-helm-chart).
+> **Note:** ### If you're using the InfluxDB Enterprise Helm chart, check out [InfluxDB Enterprise Helm chart](https://github.com/influxdata/helm-charts/tree/master/charts/influxdb-enterprise).
 
 ## Prerequisites
 
@@ -140,48 +140,6 @@ To configure the chart, do either of the following:
   > **Tip**: Use the default [values.yaml](values.yaml).
 
 For information about running InfluxDB in Docker, see the [full image documentation](https://hub.docker.com/_/influxdb/).
-
-### InfluxDB Enterprise Helm chart
-
-[InfluxDB Enterprise](https://www.influxdata.com/products/influxdb-enterprise/) includes features designed for production workloads, including high availability and horizontal scaling. InfluxDB Enterprise requires an InfluxDB Enterprise license.
-
-#### Configure the InfluxDB Enterprise chart
-
-To enable InfluxDB Enterprise, set the following keys and values in a values file provided to Helm.
-
-| Key | Description | Recommended value |
-| --- | --- | --- |
-| `livenessProbe.initalDelaySeconds` | Used to allow enough time to join meta nodes to a cluster | `3600` |
-| `image.tag` | Set to a `data` image. See https://hub.docker.com/_/influxdb for details | `data` |
-| `service.ClusterIP` | Use a headless service for StatefulSets | `"None"` |
-| `env.name[_HOSTNAME]` | Used to provide a unique `name.service` for InfluxDB. See [values.yaml]() for an example | `valueFrom.fieldRef.fieldPath: metadata.name` |
-| `enterprise.enabled` | Create StatefulSets for use with `influx-data` and `influx-meta` images | `true` |
-| `enterprise.licensekey` | License for InfluxDB Enterprise |  |
-| `enterprise.clusterSize` | Replicas for `influx` StatefulSet | Dependent on license |
-| `enterprise.meta.image.tag` | Set to an `meta` image. See https://hub.docker.com/_/influxdb for details | `meta` |
-| `enterprise.meta.clusterSize` | Replicas for `influxdb-meta` StatefulSet. | `3` |
-| `enterprise.meta.resources` | Resources requests and limits for meta `influxdb-meta` pods | See `values.yaml` |
-
-#### Join pods to InfluxDB Enterprise cluster
-
-Meta and data pods must be joined using the command `influxd-ctl` found on meta pods.
-We recommend running `influxd-ctl` on one and only one meta pod and joining meta pods together before data pods. For each meta pod, run `influxd-ctl`.
-
-In the following examples, we use the pod names `influxdb-meta-0` and `influxdb-0` and the service name `influxdb`.
-
-For example, using the default settings, your script should look something like this:
-
-```shell script
-kubectl exec influxdb-meta-0 influxd-ctl add-meta influxdb-meta-0.influxdb-meta:8091
-```
-
-From the same meta pod, for each data pod, run `influxd-ctl`. With default settings, your script should look something like this:
-
-```shell script
-kubectl exec influxdb-meta-0 influxd-ctl add-data influxdb-0.influxdb:8088
-```
-
-When using `influxd-ctl`, use the appropriate DNS name for your pods, following the naming scheme of `pod.service`.
 
 ## Persistence
 

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -17,14 +17,6 @@ args: []
 # This can be useful for auth tokens, etc.
 
 # envFromSecret: "telegraf-tokens"
-
-# The name of a secret in the same kubernetes namespace which contains values to
-# be added to the environment (must be manually created)
-# This can be useful for auth tokens, etc.
-
-# envFromSecret: "telegraf-tokens"
-
-
 env:
   - name: HOSTNAME
     value: "telegraf-polling-service"

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -17,6 +17,14 @@ args: []
 # This can be useful for auth tokens, etc.
 
 # envFromSecret: "telegraf-tokens"
+
+# The name of a secret in the same kubernetes namespace which contains values to
+# be added to the environment (must be manually created)
+# This can be useful for auth tokens, etc.
+
+# envFromSecret: "telegraf-tokens"
+
+
 env:
   - name: HOSTNAME
     value: "telegraf-polling-service"


### PR DESCRIPTION
Per issue #519 this PR removes configuration options that are specific to InfluxDB _Enterprise_ and moves them to the Enterprise chart. 