### PR TITLE
feat: add initcontainers, sidecars and extra k8s objects to telegraf charts

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.1.5
+version: 1.1.6
 appVersion: 1.24.3
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -29,6 +29,10 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
 {{- end }}
+{{- if .Values.initContainers }}
+      initContainers:
+{{ toYaml .Values.initContainers | indent 6 }}
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
@@ -57,15 +61,22 @@ spec:
         - name: hostfsro
           mountPath: /hostfs
           readOnly: true
-        {{- if hasPrefix "unix" .Values.config.docker_endpoint }}
-        - name: docker-socket
-          mountPath: {{ trimPrefix "unix://" .Values.config.docker_endpoint }}
+        {{- if hasPrefix "unix" .Values.config.runtime_endpoint }}
+        - name: runtime-socket
+          mountPath: {{ trimPrefix "unix://" .Values.config.runtime_endpoint }}
         {{- end }}
         - name: config
           mountPath: /etc/telegraf
         {{- if .Values.mountPoints }}
 {{ toYaml .Values.mountPoints | indent 8 }}
         {{- end }}
+        {{- if .Values.ports }}
+        ports:
+{{ toYaml .Values.ports | indent 10 }}
+        {{- end }}
+{{- if .Values.sideCars }}
+{{ toYaml .Values.sideCars | indent 6 }}
+{{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -82,10 +93,10 @@ spec:
       - name: hostfsro
         hostPath:
           path: /
-      {{- if hasPrefix "unix" .Values.config.docker_endpoint }}
-      - name: docker-socket
+      {{- if hasPrefix "unix" .Values.config.runtime_endpoint }}
+      - name: runtime-socket
         hostPath:
-          path: {{ trimPrefix "unix://" .Values.config.docker_endpoint }}
+          path: {{ trimPrefix "unix://" .Values.config.runtime_endpoint }}
           type: Socket
       {{- end }}
       - name: varrunutmpro

--- a/charts/telegraf-ds/templates/extra-objects.yaml
+++ b/charts/telegraf-ds/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -17,8 +17,16 @@ resources:
     cpu: 1
 ## Pod annotations
 podAnnotations: {}
+## override the app label
+# nameOverride: telegraf-poller
 ## Pod labels
 podLabels: {}
+## telegraf Container ports
+ports: []
+# - containerPort: 9127
+#   protocol: UDP
+#   hostPort: 9127
+#   name: statsd
 ## Configure args passed to Telegraf containers
 args: []
 ## The name of a secret in the same kubernetes namespace which contains values to
@@ -145,4 +153,13 @@ config:
         user_agent: "telegraf"
         insecure_skip_verify: false
   monitor_self: false
-  docker_endpoint: "unix:///var/run/docker.sock"
+  runtime_endpoint: "unix:///var/run/docker.sock"
+extraObjects: []
+initContainers: []
+  # - name: hello
+  #   image: library:busybox
+  #   command: ["/bin/sh", "-c", "echo 'OK'"]
+sideCars: []
+  # - name: hello
+  #   image: library:busybox
+  #   command: ["/bin/sh", "-c", "sleep 30000"]

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.23
+version: 1.8.24
 appVersion: 1.24.3
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
 {{ toYaml .Values.securityContext | indent 8 }}
 {{- end }}
       serviceAccountName: {{ template "telegraf.serviceAccountName" . }}
+{{- if .Values.initContainers }}
+      initContainers:
+{{ toYaml .Values.initContainers | indent 6 }}
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}
 {{- if .Values.containerSecurityContext }}
@@ -96,6 +100,9 @@ spec:
             path: /
             port: {{ trimPrefix "http://:" .service_address | int64 }}
         {{- end }}
+{{- if .Values.sideCars }}
+{{ toYaml .Values.sideCars | indent 6 }}
+{{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/charts/telegraf/templates/extra-objects.yaml
+++ b/charts/telegraf/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -8,6 +8,8 @@ image:
   tag: "1.24-alpine"
   pullPolicy: IfNotPresent
 podAnnotations: {}
+## override the app label
+# nameOverride: telegraf-poller
 podLabels: {}
 imagePullSecrets: []
 ## Configure args passed to Telegraf containers
@@ -172,3 +174,25 @@ pdb:
   create: true
   minAvailable: 1
   # maxUnavailable: 1
+extraObjects: []
+  # - apiVersion: autoscaling/v1
+  #   kind: HorizontalPodAutoscaler
+  #   metadata:
+  #     name: telegraf
+  #   spec:
+  #     maxReplicas: 8
+  #     minReplicas: 1
+  #     scaleTargetRef:
+  #       apiVersion: apps/v1
+  #       kind: Deployment
+  #       name: telegraf
+  #     targetCPUUtilizationPercentage: 90
+
+initContainers: []
+  # - name: hello
+  #   image: library:busybox
+  #   command: ["/bin/sh", "-c", "echo 'OK'"]
+sideCars: []
+  # - name: hello
+  #   image: library:busybox
+  #   command: ["/bin/sh", "-c", "sleep 30000"]


### PR DESCRIPTION
This PR adds multiple functioanlities to the telegraf and telegraf-ds helm charts.

For both charts:
1- init containers are added with possiblites to have multiple not only one. This [PR](https://github.com/influxdata/helm-charts/pull/479/files) also provides it but it can do only one container and it's not flexible.
2- side car containers are added
3- extra k8s objects

For telegraf-ds:
1- ports are customizable for the daemonset
2- renamed the socket instead of docker to runtime. Note I didn't change the default to containerd so I don't break an existing installations.

- [ ] CHANGELOG.md updated
- [X] Rebased/mergable
- [ ] Tests pass
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)