### PR TITLE
Telegraf-DS: support configuration of tagging

### DIFF
--- a/charts/telegraf-ds/templates/configmap.yaml
+++ b/charts/telegraf-ds/templates/configmap.yaml
@@ -43,4 +43,12 @@ data:
     url = "https://$HOSTIP:10250"
     bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     insecure_skip_verify = true
+    label_include = [
+    {{- range $index, $label := .Values.config.kubernetes.label_include}}
+      {{- if $index}},{{end}} {{- $label | quote}}
+    {{- end}} ]
+    label_exclude = [
+    {{- range $index, $label := .Values.config.kubernetes.label_exclude}}
+      {{- if $index}},{{end}} {{- $label | quote}}
+    {{- end}} ]
 {{- end }}

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -146,3 +146,7 @@ config:
         insecure_skip_verify: false
   monitor_self: false
   docker_endpoint: "unix:///var/run/docker.sock"
+  kubernetes:
+    include_label: []
+    exclude_label:
+    - "*"


### PR DESCRIPTION
This exposes the ability to configure the list of labels to include/exclude as tags for the Kubernetes plugin.

Fixes #525