### PR TITLE
Add: telegraf expose service for cisco_telemetry_mdt plugin

### DIFF
--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -79,6 +79,12 @@ spec:
     name: {{ printf "%s-%s" "socket-listener" (regexFind "[0-9]+$" $value.service_address) }}
     {{- end }}
     {{- end }}
+    {{- if eq $key "cisco_telemetry_mdt" }}
+    - port: {{ trimPrefix ":" $value.service_address | int64 }}
+      targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+      protocol: "TCP"
+      name: "telemetry-listener"
+    {{- end }}
   {{- end -}}
   {{- end }}
   {{- range $objectKey, $objectValue := .Values.config.outputs }}


### PR DESCRIPTION
This MR's is for cisco_telemetry_mdt plugin support and expose missing service port.