### PR TITLE
fix: Adding options for additional rules in RBAC

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.1.7
+version: 1.1.8
 appVersion: 1.25.1
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/templates/role.yaml
+++ b/charts/telegraf-ds/templates/role.yaml
@@ -14,6 +14,9 @@ rules:
   - apiGroups: [""]
     resources: ["nodes/proxy", "nodes/stats"]
     verbs: ["get", "list", "watch"]
+{{- if .Values.rbac.additionalRules }}
+{{ .Values.rbac.additionalRules | toYaml | indent 2 }}
+{{- end }}
 ---
 # Define global role with the default system:aggregate-to-view cluster role and the two rules we just created
 kind: ClusterRole

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -86,6 +86,7 @@ tolerations: []
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
+  additionalRules: []
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true


### PR DESCRIPTION
Signed-off-by: Philippe Burgisser <philippe@burgisser.ch>

When enabling kubernetes and kubernetes_inventory, telegraf was complaining that it couldn't get information from nodes and persistentvolumes. I thought that adding additional rules could cover missing rules when necessary.