### PR TITLE
fix: Add option simple to override config TOML file

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.26
+version: 1.8.27
 appVersion: 1.25.2
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/configmap.yaml
+++ b/charts/telegraf/templates/configmap.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
 data:
+{{- if .Values.override_config.toml }}
+  telegraf.conf: |+
+    {{- .Values.override_config.toml | nindent 4 }}
+{{- else }}
   telegraf.conf: |+
     {{- $tplVersion := include "detect.version" . }}
     {{ template "global_tags" .Values.config.global_tags }}
@@ -27,3 +31,4 @@ data:
     [[inputs.internal]]
       collect_memstats = {{ or .Values.metrics.internal.collect_memstats (.Values.metrics.collect_memstats | default false) }}
     {{- end }}
+{{- end }}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -112,6 +112,23 @@ serviceAccount:
 ## Exposed telegraf configuration
 ## For full list of possible values see `/docs/all-config-values.yaml` and `/docs/all-config-values.toml`
 ## ref: https://docs.influxdata.com/telegraf/v1.1/administration/configuration/
+override_config:
+  toml: ~
+  #   [[processors.starlark]]
+  #       ## The Starlark source can be set as a string in this configuration file, or
+  #       ## by referencing a file containing the script.  Only one source or script
+  #       ## should be set at once.
+
+  #       ## Source of the Starlark script.
+  #       source = '''
+  #     def apply(metric):
+  #        if metric.name == "prometheus_remote_write":
+  #             for k, v in metric.fields.items():
+  #                 metric.name = k
+  #                 metric.fields["value"] = v
+  #                 metric.fields.pop(k)
+  #        return metric
+  #     '''
 config:
   agent:
     interval: "10s"


### PR DESCRIPTION
This intend to fix issue: https://github.com/influxdata/helm-charts/issues/544
Which allow to add `starlark` script under `processor`

related: https://github.com/influxdata/helm-charts/pull/239