### PR TITLE
Expose Cisco Model-Driven Telemetry (MDT) input plugin in service.yaml

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.26
+version: 1.8.27
 appVersion: 1.25.2
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -79,6 +79,12 @@ spec:
     name: {{ printf "%s-%s" "socket-listener" (regexFind "[0-9]+$" $value.service_address) }}
     {{- end }}
     {{- end }}
+    {{- if eq $key "cisco_telemetry_mdt" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    protocol: "TCP"
+    name: "cisco-telemetry-mdt"
+    {{- end }}
   {{- end -}}
   {{- end }}
   {{- range $objectKey, $objectValue := .Values.config.outputs }}


### PR DESCRIPTION
Automatically expose Cisco Model-Driven Telemetry (MDT) port as defined in config.inputs.

```
config:
  inputs:
    - cisco_telemetry_mdt:
         service_address: ".57000"
```

```
- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [ ] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
```