### PR TITLE
Hack to at least start influxDB2 on Openshift with the restricted-v2 SCC

### DIFF
--- a/charts/influxdb2/templates/statefulset.yaml
+++ b/charts/influxdb2/templates/statefulset.yaml
@@ -44,6 +44,10 @@ spec:
         {{- if .Values.volumes }}
           {{- toYaml .Values.volumes | nindent 8 }}
         {{- end }}
+        {{- if .Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints" }}
+        - name: etc
+          emptyDir: {}
+        {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}
@@ -150,6 +154,10 @@ spec:
           {{- end }}
           {{- if .Values.mountPoints }}
             {{- toYaml .Values.mountPoints | nindent 10 }}
+          {{- end }}
+          {{- if .Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints" }}
+          - name: etc
+            mountPath: /etc/influxdb2
           {{- end }}
           resources:
             {{ .Values.resources | toYaml | nindent 12 | trim }}


### PR DESCRIPTION
Hack to get around https://github.com/influxdata/helm-charts/issues/550

Still some errors in the log, but influxdb2 stops crashlooping

> $ oc logs test-influxdb2-0 
chmod: changing permissions of '/var/lib/influxdb2': Operation not permitted
chmod: changing permissions of '/var/lib/influxdb2': Operation not permitted
chmod: changing permissions of '/etc/influxdb2': Operation not permitted
2023-04-14T16:38:10.446321154Z	info	found existing boltdb file, skipping setup wrapper	{"system": "docker", "bolt_path": "/var/lib/influxdb2/influxd.bolt"}
ts=2023-04-14T16:38:10.533747Z lvl=info msg="Welcome to InfluxDB" log_id=0hC9xBPG000 version=v2.6.1 commit=9dcf880fe0 build_date=2022-12-29T15:53:07Z log_level=info
ts=2023-04-14T16:38:10.533772Z lvl=warn msg="nats-port argument is deprecated and unused" log_id=0hC9xBPG000
ts=2023-04-14T16:38:10.542661Z lvl=info msg="Resources opened" log_id=0hC9xBPG000 service=bolt path=/var/lib/influxdb2/influxd.bolt
ts=2023-04-14T16:38:10.542742Z lvl=info msg="Resources opened" log_id=0hC9xBPG000 service=sqlite path=/var/lib/influxdb2/influxd.sqlite
ts=2023-04-14T16:38:10.553266Z lvl=info msg="Checking InfluxDB metadata for prior version." log_id=0hC9xBPG000 bolt_path=/var/lib/influxdb2/influxd.bolt
ts=2023-04-14T16:38:10.553361Z lvl=info msg="Using data dir" log_id=0hC9xBPG000 service=storage-engine service=store path=/var/lib/influxdb2/data
ts=2023-04-14T16:38:10.553377Z lvl=info msg="Compaction settings" log_id=0hC9xBPG000 service=storage-engine service=store max_concurrent_compactions=8 throughput_bytes_per_second=50331648 throughput_bytes_per_second_burst=50331648
ts=2023-04-14T16:38:10.553383Z lvl=info msg="Open store (start)" log_id=0hC9xBPG000 service=storage-engine service=store op_name=tsdb_open op_event=start
ts=2023-04-14T16:38:10.553412Z lvl=info msg="Open store (end)" log_id=0hC9xBPG000 service=storage-engine service=store op_name=tsdb_open op_event=end op_elapsed=0.030ms
ts=2023-04-14T16:38:10.553434Z lvl=info msg="Starting retention policy enforcement service" log_id=0hC9xBPG000 service=retention check_interval=30m
ts=2023-04-14T16:38:10.553442Z lvl=info msg="Starting precreation service" log_id=0hC9xBPG000 service=shard-precreation check_interval=10m advance_period=30m
ts=2023-04-14T16:38:10.554631Z lvl=info msg="Starting query controller" log_id=0hC9xBPG000 service=storage-reads concurrency_quota=1024 initial_memory_bytes_quota_per_query=9223372036854775807 memory_bytes_quota_per_query=9223372036854775807 max_memory_bytes=0 queue_size=1024
ts=2023-04-14T16:38:10.559086Z lvl=info msg="Configuring InfluxQL statement executor (zeros indicate unlimited)." log_id=0hC9xBPG000 max_select_point=0 max_select_series=0 max_select_buckets=0
ts=2023-04-14T16:38:10.574218Z lvl=info msg=Starting log_id=0hC9xBPG000 service=telemetry interval=8h
ts=2023-04-14T16:38:10.574672Z lvl=info msg=Listening log_id=0hC9xBPG000 service=tcp-listener transport=http addr=:8086 port=8086
