### PR TITLE
refactor: Deduplicate env var

### DIFF
--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -33,13 +33,6 @@ env:
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
-  # In test clusters where hostnames are resolved in /etc/hosts on each node,
-  # the HOSTNAME is not resolvable from inside containers
-  # So inject the host IP as well
-  - name: HOSTIP
-    valueFrom:
-      fieldRef:
-        fieldPath: status.hostIP
   # Mount the host filesystem and set the appropriate env variables.
   # ref: https://github.com/influxdata/telegraf/blob/master/docs/FAQ.md
   # HOST_PROC is required by the cpu, disk, diskio, kernel and processes input plugins


### PR DESCRIPTION
Hi there, telegraf-ds's daemonset has the duplicated env var HOSTIP. 