### PR TITLE
[influxdb2] add namespace to resources

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -4,7 +4,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb/
 type: application
-version: 2.1.1
+version: 2.1.2
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com

--- a/charts/influxdb2/templates/_helpers.tpl
+++ b/charts/influxdb2/templates/_helpers.tpl
@@ -62,3 +62,10 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the namespace
+*/}}
+{{- define "influxdb.namespaceName" -}}
+{{- default .Release.Namespace .Values.namespace }}
+{{- end }}

--- a/charts/influxdb2/templates/ingress.yaml
+++ b/charts/influxdb2/templates/ingress.yaml
@@ -7,6 +7,7 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "influxdb.fullname" . }}
+  namespace: {{ include "influxdb.namespaceName" . }}
   labels:
     {{- include "influxdb.labels" . | nindent 4 }}
   annotations:

--- a/charts/influxdb2/templates/init-config.yaml
+++ b/charts/influxdb2/templates/init-config.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "influxdb.fullname" . }}-init
+  namespace: {{ include "influxdb.namespaceName" . }}
   labels:
     {{- include "influxdb.labels" . | nindent 4 }}
 data:

--- a/charts/influxdb2/templates/pdb.yaml
+++ b/charts/influxdb2/templates/pdb.yaml
@@ -7,6 +7,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "influxdb.fullname" . }}
+  namespace: {{ include "influxdb.namespaceName" . }}
   labels:
   {{- include "influxdb.labels" . | nindent 4 }}
 spec:

--- a/charts/influxdb2/templates/persistent-volume-claim.yaml
+++ b/charts/influxdb2/templates/persistent-volume-claim.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: "{{- if not (empty .Values.persistence.name) }}{{ .Values.persistence.name }}{{- else }}{{ template "influxdb.fullname" . }}{{- end }}"
+  namespace: {{ include "influxdb.namespaceName" . }}
   labels:
     {{- include "influxdb.labels" . | nindent 4 }}
   annotations:

--- a/charts/influxdb2/templates/secret.yaml
+++ b/charts/influxdb2/templates/secret.yaml
@@ -6,8 +6,9 @@ metadata:
     {{- include "influxdb.labels" . | nindent 4 }}
   {{- $name := printf "%s-auth" (include "influxdb.fullname" .) }}
   name: {{ $name }}
+  namespace: {{ include "influxdb.namespaceName" . }}
 data:
-  {{- $previous := lookup "v1" "Secret" .Release.Namespace $name }}
+  {{- $previous := lookup "v1" "Secret" (include "influxdb.namespaceName" .) $name }}
 
   {{- if $previous }}
   admin-token: {{ index $previous.data "admin-token" }}

--- a/charts/influxdb2/templates/service.yaml
+++ b/charts/influxdb2/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "influxdb.fullname" . }}
+  namespace: {{ include "influxdb.namespaceName" . }}
   labels: {{- include "influxdb.labels" . | nindent 4 }}
 {{- with .Values.service.annotations }}
   annotations:

--- a/charts/influxdb2/templates/serviceaccount.yaml
+++ b/charts/influxdb2/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "influxdb.serviceAccountName" . }}
+  namespace: {{ include "influxdb.namespaceName" . }}
   labels:
     {{- include "influxdb.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/influxdb2/templates/statefulset.yaml
+++ b/charts/influxdb2/templates/statefulset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "influxdb.fullname" . }}
+  namespace: {{ include "influxdb.namespaceName" . }}
   labels:
     {{- include "influxdb.labels" . | nindent 4 }}
 spec:

--- a/charts/influxdb2/values.yaml
+++ b/charts/influxdb2/values.yaml
@@ -17,6 +17,10 @@ podLabels: {}
 nameOverride: ""
 fullnameOverride: ""
 
+# The name of the Namespace to deploy
+# If not set, `.Release.Namespace` is used
+namespace: null
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##


### PR DESCRIPTION
This PR adds `namespace` to all Helm chart resources, which is meant to allow `helm template` to show namespace in the resources as well. The absence of which can cause some test tools, for example, kyverno-cli to fail due to missing namespace, which is a part of its best practice policies. This namespace adding structure was inspired from how promtail does it.

It was tested via `helm lint` and `helm template` to confirm the output matched the expectation

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)