### PR TITLE
Influxdb1.x port mappings, ingress resource fixes

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.12.1
+version: 4.12.2
 appVersion: 1.8.10
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/README.md
+++ b/charts/influxdb/README.md
@@ -46,78 +46,78 @@ This command removes all the Kubernetes components associated with the chart and
 
 The following table lists configurable parameters, their descriptions, and their default values stored in `values.yaml`.
 
-| Parameter | Description | Default |
-|---|---|---|
-| image.repository | Image repository url | influxdb |
-| image.tag | Image tag | 1.8.0-alpine |
-| image.pullPolicy | Image pull policy | IfNotPresent |
-| image.pullSecrets | It will store the repository's credentials to pull image | nil |
-| serviceAccount.create | It will create service account | true |
-| serviceAccount.name | Service account name | "" |
-| serviceAccount.annotations | Service account annotations | {} |
-| livenessProbe | Health check for pod | {} |
-| readinessProbe | Health check for pod | {} |
-| startupProbe | Health check for pod | {} |
-| service.type | Kubernetes service type | ClusterIP |
-| service.loadBalancerIP | A user-specified IP address for service type LoadBalancer to use as External IP (if supported) | nil |
-| service.externalIPs | A user-specified list of externalIPs to add to the service | nil |
-| service.externalTrafficPolicy | A user specified external traffic policy | nil |
-| service.nodePorts.http | Node port to expose for HTTP API if `service.type=NodePort` or `service.type=LoadBalancer` | Random port from range 30000-32767 |
-| persistence.enabled | Boolean to enable and disable persistance | true |
-| persistence.existingClaim | An existing PersistentVolumeClaim, ignored if enterprise.enabled=true | nil |
-| persistence.storageClass | If set to "-", storageClassName: "", which disables dynamic provisioning. If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.  (gp2 on AWS, standard on GKE, AWS & OpenStack |  |
-| persistence.annotations | Annotations for volumeClaimTemplates | nil |
-| persistence.accessMode | Access mode for the volume | ReadWriteOnce |
-| persistence.size | Storage size | 8Gi |
-| podAnnotations | Annotations for pod | {} |
-| podLabels | Labels for pod | {} |
-| ingress.enabled | Boolean flag to enable or disable ingress | false |
-| ingress.tls | Boolean to enable or disable tls for ingress. If enabled provide a secret in `ingress.secretName` containing TLS private key and certificate. | false |
-| ingress.secretName | Kubernetes secret containing TLS private key and certificate. It is `only` required if `ingress.tls` is enabled. | nil |
-| ingress.hostname | Hostname for the ingress | influxdb.foobar.com |
-| ingress.annotations | ingress annotations | nil |
-| schedulerName | Use an [alternate scheduler](https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/), e.g. "stork". | nil |
-| nodeSelector | Node labels for pod assignment | {} |
-| affinity | [Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for pod assignment |  {|
-| tolerations | [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) for pod assignment | [] |
-| securityContext | [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for pod | {} |
-| env | environment variables for influxdb container | {} |
-| volumes | `volumes` stanza(s) to be used in the main container | nil |
-| mountPoints | `volumeMount` stanza(s) to be used in the main container | nil |
-| extraContainers | Additional containers to be added to the pod | {} |
-| config.reporting_disabled | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#reporting-disabled-false) | false |
-| config.rpc | RPC address for backup and storage | {} |
-| config.meta | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#meta) | {} |
-| config.data | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#data) | {} |
-| config.coordinator | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#coordinator) | {} |
-| config.retention | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#retention) | {} |
-| config.shard_precreation | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#shard-precreation) | {} |
-| config.monitor | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#monitor) | {} |
-| config.http | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#http) | {} |
-| config.logging | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#logging) | {} |
-| config.subscriber | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#subscriber) | {} |
-| config.graphite | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#graphite) | {} |
-| config.collectd | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#collectd) | {} |
-| config.opentsdb | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#opentsdb) | {} |
-| config.udp | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#udp) | {} |
-| config.continous_queries | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#continuous-queries) | {} |
-| config.tls | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#tls) | {} |
-| initScripts.enabled | Boolean flag to enable and disable initscripts. If the container finds any files with the extensions .sh or .iql inside of the /docker-entrypoint-initdb.d folder, it will execute them. The order they are executed in is determined by the shell. This is usually alphabetical order. | false |
-| initScripts.scripts | Init scripts | {} |
-| backup.enabled | Enable backups, if `true` must configure one of the storage providers | `false` |
+| Parameter | Description | Default                                                              |
+|---|---|----------------------------------------------------------------------|
+| image.repository | Image repository url | influxdb                                                             |
+| image.tag | Image tag | 1.8.0-alpine                                                         |
+| image.pullPolicy | Image pull policy | IfNotPresent                                                         |
+| image.pullSecrets | It will store the repository's credentials to pull image | nil                                                                  |
+| serviceAccount.create | It will create service account | true                                                                 |
+| serviceAccount.name | Service account name | ""                                                                   |
+| serviceAccount.annotations | Service account annotations | {}                                                                   |
+| livenessProbe | Health check for pod | {}                                                                   |
+| readinessProbe | Health check for pod | {}                                                                   |
+| startupProbe | Health check for pod | {}                                                                   |
+| service.type | Kubernetes service type | ClusterIP                                                            |
+| service.loadBalancerIP | A user-specified IP address for service type LoadBalancer to use as External IP (if supported) | nil                                                                  |
+| service.externalIPs | A user-specified list of externalIPs to add to the service | nil                                                                  |
+| service.externalTrafficPolicy | A user specified external traffic policy | nil                                                                  |
+| service.nodePorts.http | Node port to expose for HTTP API if `service.type=NodePort` or `service.type=LoadBalancer` | Random port from range 30000-32767                                   |
+| persistence.enabled | Boolean to enable and disable persistance | true                                                                 |
+| persistence.existingClaim | An existing PersistentVolumeClaim, ignored if enterprise.enabled=true | nil                                                                  |
+| persistence.storageClass | If set to "-", storageClassName: "", which disables dynamic provisioning. If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.  (gp2 on AWS, standard on GKE, AWS & OpenStack |                                                                      |
+| persistence.annotations | Annotations for volumeClaimTemplates | nil                                                                  |
+| persistence.accessMode | Access mode for the volume | ReadWriteOnce                                                        |
+| persistence.size | Storage size | 8Gi                                                                  |
+| podAnnotations | Annotations for pod | {}                                                                   |
+| podLabels | Labels for pod | {}                                                                   |
+| ingress.enabled | Boolean flag to enable or disable ingress | false                                                                |
+| ingress.tls | Boolean to enable or disable tls for ingress. If enabled provide a secret in `ingress.secretName` containing TLS private key and certificate. | false                                                                |
+| ingress.secretName | Kubernetes secret containing TLS private key and certificate. It is `only` required if `ingress.tls` is enabled. | nil                                                                  |
+| ingress.hostname | Hostname for the ingress | `""`                                                  |
+| ingress.annotations | ingress annotations | nil                                                                  |
+| schedulerName | Use an [alternate scheduler](https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/), e.g. "stork". | nil                                                                  |
+| nodeSelector | Node labels for pod assignment | {}                                                                   |
+| affinity | [Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for pod assignment | {                                                                    |
+| tolerations | [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) for pod assignment | []                                                                   |
+| securityContext | [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for pod | {}                                                                   |
+| env | environment variables for influxdb container | {}                                                                   |
+| volumes | `volumes` stanza(s) to be used in the main container | nil                                                                  |
+| mountPoints | `volumeMount` stanza(s) to be used in the main container | nil                                                                  |
+| extraContainers | Additional containers to be added to the pod | {}                                                                   |
+| config.reporting_disabled | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#reporting-disabled-false) | false                                                                |
+| config.rpc | RPC address for backup and storage | `bind-address: ":8088"`                                              |
+| config.meta | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#meta) | {}                                                                   |
+| config.data | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#data) | {}                                                                   |
+| config.coordinator | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#coordinator) | {}                                                                   |
+| config.retention | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#retention) | {}                                                                   |
+| config.shard_precreation | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#shard-precreation) | {}                                                                   |
+| config.monitor | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#monitor) | {}                                                                   |
+| config.http | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#http) | `enabled: true`<br/>`bind-address: ":8086"`<br/>`flux-enabled: true` |
+| config.logging | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#logging) | {}                                                                   |
+| config.subscriber | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#subscriber) | {}                                                                   |
+| config.graphite | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#graphite) | {}                                                                   |
+| config.collectd | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#collectd) | {}                                                                   |
+| config.opentsdb | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#opentsdb) | {}                                                                   |
+| config.udp | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#udp) | {}                                                                   |
+| config.continous_queries | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#continuous-queries) | {}                                                                   |
+| config.tls | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#tls) | {}                                                                   |
+| initScripts.enabled | Boolean flag to enable and disable initscripts. If the container finds any files with the extensions .sh or .iql inside of the /docker-entrypoint-initdb.d folder, it will execute them. The order they are executed in is determined by the shell. This is usually alphabetical order. | false                                                                |
+| initScripts.scripts | Init scripts | {}                                                                   |
+| backup.enabled | Enable backups, if `true` must configure one of the storage providers | `false`                                                              |
 | backup.gcs | Google Cloud Storage config | `nil`
 | backup.azure | Azure Blob Storage config | `nil`
 | backup.s3 | Amazon S3 (or compatible) config | `nil`
-| backup.schedule | Schedule to run jobs in cron format | `0 0 * * *` |
-| backup.startingDeadlineSeconds | Deadline in seconds for starting the job if it misses its scheduled time for any reason | `nil` |
-| backup.annotations | Annotations for backup cronjob | {} |
-| backup.podAnnotations | Annotations for backup cronjob pods | {} |
-| backup.persistence.enabled | Boolean to enable and disable persistance | false |
-| backup.persistence.storageClass | If set to "-", storageClassName: "", which disables dynamic provisioning. If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.  (gp2 on AWS, standard on GKE, AWS & OpenStack |  |
-| backup.persistence.annotations | Annotations for volumeClaimTemplates | nil |
-| backup.persistence.accessMode | Access mode for the volume | ReadWriteOnce |
-| backup.persistence.size | Storage size | 8Gi |
-| backup.resources | Resources requests and limits for `backup` pods | `ephemeral-storage: 8Gi` |
+| backup.schedule | Schedule to run jobs in cron format | `0 0 * * *`                                                          |
+| backup.startingDeadlineSeconds | Deadline in seconds for starting the job if it misses its scheduled time for any reason | `nil`                                                                |
+| backup.annotations | Annotations for backup cronjob | {}                                                                   |
+| backup.podAnnotations | Annotations for backup cronjob pods | {}                                                                   |
+| backup.persistence.enabled | Boolean to enable and disable persistance | false                                                                |
+| backup.persistence.storageClass | If set to "-", storageClassName: "", which disables dynamic provisioning. If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.  (gp2 on AWS, standard on GKE, AWS & OpenStack |                                                                      |
+| backup.persistence.annotations | Annotations for volumeClaimTemplates | {}                                                                   |
+| backup.persistence.accessMode | Access mode for the volume | ReadWriteOnce                                                        |
+| backup.persistence.size | Storage size | 8Gi                                                                  |
+| backup.resources | Resources requests and limits for `backup` pods | `ephemeral-storage: 8Gi`                                             |
 
 To configure the chart, do either of the following:
 

--- a/charts/influxdb/templates/NOTES.txt
+++ b/charts/influxdb/templates/NOTES.txt
@@ -1,10 +1,10 @@
-InfluxDB can be accessed via port {{ .Values.config.http.bind_address | default 8086 }} on the following DNS name from within your cluster:
+InfluxDB can be accessed via port {{ include "influxdb.httpPortNumber" . }} on the following DNS name from within your cluster:
 
-  http://{{ include "influxdb.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.config.http.bind_address | default 8086 }}
+  http://{{ include "influxdb.fullname" . }}.{{ .Release.Namespace }}:{{ include "influxdb.httpPortNumber" . }}
 
 You can connect to the remote instance with the influx CLI. To forward the API port to localhost:8086, run the following:
 
-  kubectl port-forward --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l app={{ include "influxdb.fullname" . }} -o jsonpath='{ .items[0].metadata.name }') 8086:{{ .Values.config.http.bind_address | default 8086 }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l app={{ include "influxdb.fullname" . }} -o jsonpath='{ .items[0].metadata.name }') 8086:{{ include "influxdb.httpPortNumber" . }}
 
 You can also connect to the influx CLI from inside the container. To open a shell session in the InfluxDB pod, run the following:
 

--- a/charts/influxdb/templates/_helpers.tpl
+++ b/charts/influxdb/templates/_helpers.tpl
@@ -56,8 +56,33 @@ Create the name of the service account to use
 */}}
 {{- define "influxdb.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default (include "influxdb.fullname" .) .Values.serviceAccount.name }}
+  {{ default (include "influxdb.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
+  {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Define ports for kubernetes.
+*/}}
+{{- define "influxdb.rpcPortNumber" -}}
+  {{ default 8088 (regexReplaceAll ":([0-9]+)" (index .Values "config" "rpc" "bind-address") "${1}") }}
+{{- end -}}
+{{- define "influxdb.metaPortNumber" -}}
+  {{ default 8091 (regexReplaceAll ":([0-9]+)" (index .Values "config" "meta" "bind-address") "${1}") }}
+{{- end -}}
+{{- define "influxdb.httpPortNumber" -}}
+  {{ default 8086 (regexReplaceAll ":([0-9]+)" (index .Values "config" "http" "bind-address") "${1}") }}
+{{- end -}}
+{{- define "influxdb.graphitePortNumber" -}}
+  {{ default 2003 (regexReplaceAll ":([0-9]+)" (index .Values "config" "graphite" "bind-address") "${1}") }}
+{{- end -}}
+{{- define "influxdb.collectdPortNumber" -}}
+  {{ default 25826 (regexReplaceAll ":([0-9]+)" (index .Values "config" "collectd" "bind-address") "${1}") }}
+{{- end -}}
+{{- define "influxdb.opentsdbPortNumber" -}}
+  {{ default 4242 (regexReplaceAll ":([0-9]+)" (index .Values "config" "opentsdb" "bind-address") "${1}") }}
+{{- end -}}
+{{- define "influxdb.udpPortNumber" -}}
+  {{ default 8089 (regexReplaceAll ":([0-9]+)" (index .Values "config" "udp" "bind-address") "${1}") }}
 {{- end -}}

--- a/charts/influxdb/templates/backup-cronjob.yaml
+++ b/charts/influxdb/templates/backup-cronjob.yaml
@@ -67,7 +67,7 @@ spec:
             - '-c'
             - |
               influxd backup \
-                -host {{ include "influxdb.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.config.rpc.bind_address | default 8088 }} \
+                -host {{ include "influxdb.fullname" . }}.{{ .Release.Namespace }}.svc:{{ include "influxdb.rpcPortNumber" . }} \
                 -portable /backup/"$(date +%Y%m%d%H%M%S)"
             resources:
               {{- toYaml .Values.backup.resources | nindent 14 }}

--- a/charts/influxdb/templates/configmap.yaml
+++ b/charts/influxdb/templates/configmap.yaml
@@ -6,8 +6,8 @@ metadata:
     {{- include "influxdb.labels" . | nindent 4 }}
 data:
   influxdb.conf: |+
-    reporting-disabled = {{ .Values.config.reporting_disabled | default false }}
-    bind-address = ":{{ .Values.config.rpc.bind_address | default 8088 }}"
+    reporting-disabled = {{ .Values.config.reporting_disabled }}
+    bind-address = "{{ index .Values "config" "rpc" "bind-address"| default (printf ":%s" (include "influxdb.rpcPortNumber" . ))}}"
 
     [meta]
       dir = "/var/lib/influxdb/meta"

--- a/charts/influxdb/templates/ingress.yaml
+++ b/charts/influxdb/templates/ingress.yaml
@@ -1,42 +1,37 @@
-{{- if .Values.ingress.enabled -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ include "influxdb.fullname" . }}
   labels:
     {{- include "influxdb.labels" . | nindent 4 }}
+  {{- if .Values.ingress.annotations }}
   annotations:
-{{ toYaml .Values.ingress.annotations | indent 4 }}
+  {{ toYaml .Values.ingress.annotations | indent 4 }}
+  {{- end }}
 spec:
 {{- if .Values.ingress.tls }}
   tls:
     - hosts:
-      - {{ .Values.ingress.hostname | quote }}
+        - {{ .Values.ingress.hostname | quote }}
       secretName: {{ .Values.ingress.secretName }}
 {{- end }}
 {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
 {{- end }}
   rules:
-  - host: {{ .Values.ingress.hostname }}
-    http:
-      paths:
-      - path: {{ .Values.ingress.path }}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-        pathType: Prefix
-{{- end }}
-        backend:
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-          service:
-            name: {{ include "influxdb.fullname" . }}
-            port:
-              number: 8086
-{{- else }}
-          serviceName: {{ include "influxdb.fullname" . }}
-          servicePort: 8086
-{{- end }}
-{{- end -}}
+  {{- if .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname }}
+      http:
+  {{- else }}
+    - http:
+  {{- end }}
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "influxdb.fullname" . }}
+                port:
+                  number: {{ include "influxdb.httpPortNumber" . }}
+  {{- end }}

--- a/charts/influxdb/templates/meta-configmap.yaml
+++ b/charts/influxdb/templates/meta-configmap.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/component: meta
 data:
   influxdb-meta.conf: |+
-    reporting-disabled = {{ .Values.config.reporting_disabled | default false }}
-    bind-address = ":{{ .Values.config.meta.bind_address | default 8091 }}"
+    reporting-disabled = {{ .Values.config.reporting_disabled }}
+    bind-address = "{{ index .Values "config" "meta" "bind-address" | default (printf ":%s" (include "influxdb.metaPortNumber" .))}}"
 
     [enterprise]
       license-key = {{ .Values.enterprise.licensekey | quote }}

--- a/charts/influxdb/templates/meta-service.yaml
+++ b/charts/influxdb/templates/meta-service.yaml
@@ -17,7 +17,7 @@ spec:
   publishNotReadyAddresses: true
   ports:
     - name: meta
-      port: {{ .Values.config.meta.bind_address | default 8091 }}
+      port: {{ include "influxdb.metaPortNumber" . }}
       targetPort: meta
   selector:
     {{- include "influxdb.selectorLabels" . | nindent 4 }}

--- a/charts/influxdb/templates/meta-statefulset.yaml
+++ b/charts/influxdb/templates/meta-statefulset.yaml
@@ -38,11 +38,11 @@ spec:
 {{ toYaml .Values.enterprise.meta.resources | indent 10 }}
         ports:
         - name: udp
-          containerPort: {{ .Values.config.udp.bind_address |  default 8089 }}
+          containerPort: {{ include "influxdb.udpPortNumber" . }}
         - name: rpc
-          containerPort: {{ .Values.config.rpc.bind_address | default 8088 }}
+          containerPort: {{ include "influxdb.rpcPortNumber" . }}
         - name: meta
-          containerPort: {{ .Values.config.meta.bind_address | default 8091 }}
+          containerPort: {{ include "influxdb.metaPortNumber" . }}
         {{- if .Values.env }}
         env:
 {{ toYaml .Values.env | indent 10 }}

--- a/charts/influxdb/templates/service.yaml
+++ b/charts/influxdb/templates/service.yaml
@@ -12,34 +12,34 @@ spec:
   type: {{ .Values.service.type }}
   ports:
   - name: api
-    port: {{ .Values.config.http.bind_address | default 8086 }}
+    port: {{ include "influxdb.httpPortNumber" . }}
     targetPort: api
     {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.http))) }}
     nodePort: {{ .Values.service.nodePorts.http | int }}
     {{- end }}
   - name: rpc
-    port: {{ .Values.config.rpc.bind_address | default 8088 }}
+    port: {{ include "influxdb.rpcPortNumber" . }}
     targetPort: rpc
   {{- if .Values.config.graphite.enabled }}
   - name: graphite
-    port: {{ .Values.config.graphite.bind_address | default 2003 }}
+    port: {{ include "influxdb.graphitePortNumber" . }}
     targetPort: graphite
   {{- end }}
   {{- if .Values.config.collectd.enabled }}
   - name: collectd
-    port: {{ .Values.config.collectd.bind_address | default 25826 }}
+    port: {{ include "influxdb.collectdPortNumber" . }}
     protocol: UDP
     targetPort: collectd
   {{- end }}
   {{- if .Values.config.udp.enabled }}
   - name: udp
-    port: {{ .Values.config.udp.bind_address | default 8089 }}
+    port: {{ include "influxdb.udpPortNumber" . }}
     protocol: UDP
     targetPort: udp
   {{- end }}
   {{- if .Values.config.opentsdb.enabled }}
   - name: opentsdb
-    port: {{ .Values.config.opentsdb.bind_address | default 4242 }}
+    port: {{ include "influxdb.opentsdbPortNumber" . }}
     targetPort: opentsdb
   {{- end }}
   selector:

--- a/charts/influxdb/templates/statefulset.yaml
+++ b/charts/influxdb/templates/statefulset.yaml
@@ -62,30 +62,30 @@ spec:
         {{- end }}
         ports:
         - name: api
-          containerPort: {{ .Values.config.http.bind_address | default 8086 }}
+          containerPort: {{ include "influxdb.httpPortNumber" . }}
         {{- if .Values.config.graphite.enabled }}
         - name: graphite
-          containerPort: {{ .Values.config.graphite.bind_address | default 2003 }}
+          containerPort: {{ include "influxdb.graphitePortNumber" . }}
         {{- end }}
         {{- if .Values.config.collectd.enabled }}
         - name: collectd
-          containerPort: {{ .Values.config.collectd.bind_address |  default 25826 }}
+          containerPort: {{ include "influxdb.collectdPortNumber" . }}
           protocol: UDP
         {{- end }}
         {{- if .Values.config.udp.enabled }}
         - name: udp
-          containerPort: {{ .Values.config.udp.bind_address | default 8089 }}
+          containerPort: {{ include "influxdb.udpPortNumber" . }}
           protocol: UDP
         {{- end }}
         {{- if .Values.config.opentsdb.enabled }}
         - name: opentsdb
-          containerPort: {{ .Values.config.opentsdb.bind_address |  default 4242 }}
+          containerPort: {{ include "influxdb.opentsdbPortNumber" . }}
         {{- end }}
         - name: rpc
-          containerPort: {{ .Values.config.rpc.bind_address | default 8088 }}
+          containerPort: {{ include "influxdb.rpcPortNumber" . }}
         {{- if .Values.enterprise.enabled }}
         - name: meta
-          containerPort: {{ .Values.config.meta.bind_address | default 8091 }}
+          containerPort: {{ include "influxdb.metaPortNumber" . }}
         {{- end }}
         {{- if or .Values.env .Values.setDefaultUser.enabled }}
         env:
@@ -187,9 +187,11 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: {{ include "influxdb.fullname" . }}-data
+        {{- if .Values.persistence.annotations }}
         annotations:
         {{- range $key, $value := .Values.persistence.annotations }}
           {{ $key }}: "{{ $value }}"
+        {{- end }}
         {{- end }}
       spec:
         accessModes:

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -71,7 +71,7 @@ persistence:
   ##   GKE, AWS & OpenStack)
   ##
   # storageClass: "-"
-  annotations:
+  annotations: {}
   accessMode: ReadWriteOnce
   size: 8Gi
 
@@ -140,11 +140,10 @@ ingress:
   enabled: false
   tls: false
   # secretName: my-tls-cert # only needed if tls above is true
-  hostname: influxdb.foobar.com
-  className: null
+  hostname: ""
+  className: nginx
   annotations: {}
-    # kubernetes.io/ingress.class: "nginx"
-    # kubernetes.io/tls-acme: "true"
+    # nginx.ingress.kubernetes.io/rewrite-target: $1
   path: /
 
 
@@ -204,14 +203,18 @@ envFromSecret: {}
 ## ref: https://docs.influxdata.com/influxdb/v1.8/administration/config
 config:
   reporting_disabled: false
-  rpc: {}
+  rpc:
+    bind-address: ":8088"
   meta: {}
   data: {}
   coordinator: {}
   retention: {}
   shard_precreation: {}
   monitor: {}
-  http: {}
+  http:
+    enabled: true
+    bind-address: ":8086"
+    flux-enabled: true
   logging: {}
   subscriber: {}
   graphite: {}


### PR DESCRIPTION
- get rid of `bind_address` variable completely
- introduce new variables which extract ports from bind-address configuration property or set default value.
- ingress and other fixes (e.g. make ingress service port variable)