### PR TITLE
Add missing permissions for telegraf ClusterRole

### DIFF
--- a/charts/telegraf-ds/templates/role.yaml
+++ b/charts/telegraf-ds/templates/role.yaml
@@ -12,7 +12,7 @@ rules:
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["nodes/proxy", "nodes/stats"]
+    resources: ["nodes", "nodes/proxy", "nodes/stats", "persistentvolumes"]
     verbs: ["get", "list", "watch"]
 ---
 # Define global role with the default system:aggregate-to-view cluster role and the two rules we just created


### PR DESCRIPTION
The telegraf-ds chart with `inputs.kube_inventory` logs the following errors:

```
E! [inputs.kube_inventory] Error in plugin: persistentvolumes is forbidden: User "system:serviceaccount:telegraf:telegraf-telegraf-ds" cannot list resource "persistentvolumes" in API group "" at the cluster scope
E! [inputs.kube_inventory] Error in plugin: nodes is forbidden: User "system:serviceaccount:telegraf:telegraf-telegraf-ds" cannot list resource "nodes" in API group "" at the cluster scope
```

This PR adds the missing permissions to the `influx-stats-viewer` ClusterRole.

- [x] Tested on: EKS v1.25.9
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
