### PR TITLE
feat(statefulset): set securityContext at containerlevel

### DIFF
--- a/charts/influxdb/templates/statefulset.yaml
+++ b/charts/influxdb/templates/statefulset.yaml
@@ -60,6 +60,10 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         {{- end }}
+        {{- if .Values.securityContext }}
+        securityContext:
+{{ toYaml .Values.securityContext | indent 10 }}
+        {{- end }}
         ports:
         - name: api
           containerPort: {{ include "influxdb.httpPortNumber" . }}


### PR DESCRIPTION
I would like to run my influxdb instance with non-root IDs. Unfortunately I can't set them on container level. With this PR the securityContext should also be set to container level.