### PR TITLE
fix: use explicit path to container registry

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.30
+version: 1.8.31
 appVersion: 1.27.3
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -4,7 +4,7 @@
 
 replicaCount: 1
 image:
-  repo: "telegraf"
+  repo: "docker.io/library/telegraf"
   tag: "1.27-alpine"
   pullPolicy: IfNotPresent
 podAnnotations: {}


### PR DESCRIPTION
This helps avoid a bad actor changing your default registries to force fetching unexpected images.

My auditors prefer explicit container paths so that there is no mystery where the objects are fetch from.