### PR TITLE
feat: prometheus-operator hooks for telegraf

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.29
+version: 1.9.0
 appVersion: 1.27.2
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/servicemonitor.yaml
+++ b/charts/telegraf/templates/servicemonitor.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "telegraf.fullname" . }}-prometheus-exporter
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ . }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "telegraf.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  jobLabel: app.kubernetes.io/name
+  endpoints:
+    - port: prometheus-client
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      path: /metrics
+      scheme: http
+      relabelings:
+        - action: replace
+          regex: (.*)
+          replacement: $1
+          sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: instance
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "telegraf.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -172,3 +172,12 @@ pdb:
   create: true
   minAvailable: 1
   # maxUnavailable: 1
+
+## Integration with prometheus-operator
+##
+serviceMonitor:
+  enabled: false
+  namespace: ""
+  interval: 30s
+  scrapeTimeout: 5s
+  labels: {}


### PR DESCRIPTION
This adds in a simple hook for setting up a ServiceMonitor for use with Prometheus-Operator.

Configuring telegraf to expose the prometheus bits is still left as configuration for the user.