### PR TITLE
Added configmap and deployment annotations capabilities

### DIFF
--- a/charts/telegraf/templates/configmap.yaml
+++ b/charts/telegraf/templates/configmap.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "telegraf.fullname" . }}
+  {{- if .Values.configmapAnnotations }}
+  annotations:
+  {{ toYaml .Values.configmapAnnotations | indent 4 }}
+  {{- end }}
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
 data:

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "telegraf.fullname" . }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+  {{ toYaml .Values.configmapAnnotations | indent 4 }}
+  {{- end }}
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
 spec:

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -9,6 +9,8 @@ image:
   pullPolicy: IfNotPresent
 podAnnotations: {}
 podLabels: {}
+deploymentAnnotations: {}
+configmapAnnotations: {}
 imagePullSecrets: []
 ## Configure args passed to Telegraf containers
 args: []


### PR DESCRIPTION
Added ability to specify annotations in deployment and configmap.
The motivation to do so is to allow reloader to match & search resources valid for reloading, and I suspect there are further use-cases.

Did not add to service resource as it is already enabled using service.annotaions, as well as PDB, Role and RoleBinding resources for which it isn't as relevant.