### PR TITLE
Adds flag controlling creation of default classes

### DIFF
--- a/charts/telegraf-operator/templates/secret-classes.yml
+++ b/charts/telegraf-operator/templates/secret-classes.yml
@@ -1,4 +1,4 @@
-{{- if .Values.classes.data }}
+{{- if and (.Values.classes.create) (.Values.classes.data) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/telegraf-operator/values.yaml
+++ b/charts/telegraf-operator/values.yaml
@@ -5,6 +5,7 @@ image:
   sidecarImage: "docker.io/library/telegraf:1.22"
 
 classes:
+  create: true
   secretName: "telegraf-operator-classes"
   default: "infra"
   data:


### PR DESCRIPTION
Adds a boolean flag that controls whether the secret with the default log classes will be created by telegraf-operator. Required for charts that depend on it and want to build their own secret. 

- [ ] CHANGELOG.md updated
  No, could not find it in the projects structure
- [X] Rebased/mergable
- [X] Tests pass
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)