### PR TITLE
Removed duplicated HOSTIP

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.1.16
+version: 1.1.18
 appVersion: 1.28.1
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -40,10 +40,6 @@ spec:
 {{ toYaml .Values.args | indent 8 }}
         {{- end }}
         env:
-        - name: HOSTIP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
 {{ toYaml .Values.env | indent 8 }}
         {{- if .Values.envFromSecret }}
         envFrom:


### PR DESCRIPTION
When telegraf-ds helm chart is deployed the HOSTIP env arg is duplicated in the daemonset.