### PR TITLE
fix: [telegraf-ds] easily disable docker input

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.1.19
+version: 1.1.20
 appVersion: 1.28.3
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/templates/configmap.yaml
+++ b/charts/telegraf-ds/templates/configmap.yaml
@@ -17,9 +17,4 @@ data:
     {{ template "outputs" .Values.config.outputs }}
     {{ template "monitor_self" .Values.config.monitor_self }}
     {{ template "inputs" .Values.config.inputs }}
-
-    {{- if .Values.config.docker_endpoint }}
-    [[inputs.docker]]
-    endpoint = {{ .Values.config.docker_endpoint | quote }}
-    {{- end }}
 {{- end }}

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -159,6 +159,8 @@ config:
         url: "https://$HOSTIP:10250"
         bearer_token: "/var/run/secrets/kubernetes.io/serviceaccount/token"
         insecure_skip_verify: true
+    - docker:
+        endpoint: "unix:///var/run/docker.sock"
   outputs:
     - influxdb:
         urls:
@@ -171,4 +173,3 @@ config:
         user_agent: "telegraf"
         insecure_skip_verify: false
   monitor_self: false
-  docker_endpoint: "unix:///var/run/docker.sock"


### PR DESCRIPTION
Since in the new versions of Kubernetes, the `containerd` is the default engine, I think moving the `docker` input to the loop input definition instead of hardcoding it in templates based on a dedicated variable makes more sense.