### PR TITLE
release: update for `telegraf-operator@v1.3.11`

### DIFF
--- a/charts/telegraf-operator/Chart.yaml
+++ b/charts/telegraf-operator/Chart.yaml
@@ -34,4 +34,4 @@ version: 1.3.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: v1.3.10
+appVersion: v1.3.11

--- a/charts/telegraf-operator/Chart.yaml
+++ b/charts/telegraf-operator/Chart.yaml
@@ -30,7 +30,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.3.11
+version: 1.3.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.


### PR DESCRIPTION
New [`telegraf-operator`](https://github.com/influxdata/telegraf-operator/releases/tag/v1.3.11) release, follow up here.
