### PR TITLE
feat: hpa with cpu + mem util scaling options

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.42
+version: 1.8.43
 appVersion: 1.29.5
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled}}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "telegraf.name" . }}

--- a/charts/telegraf/templates/horizontalpodautoscaler.yaml
+++ b/charts/telegraf/templates/horizontalpodautoscaler.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "telegraf.fullname" . }}
+  labels:
+    {{- include "telegraf.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "telegraf.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  {{- if .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml .Values.autoscaling.behavior | nindent 4 }}
+  {{- end }}
+  metrics:
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -180,3 +180,11 @@ pdb:
   create: true
   minAvailable: 1
   # maxUnavailable: 1
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+  behavior: {}


### PR DESCRIPTION
We would like to scale the number of replicas based on usage which is a slight pain currently as it's not possible to disable the `deployment.spec.replicas` field if we were to roll our own HPA resource. There's also a pre-existing issue: https://github.com/influxdata/helm-charts/issues/624.

```
$ helm version
version.BuildInfo{Version:"v3.14.2", GitCommit:"c309b6f0ff63856811846ce18f3bdc93d2b4d54b", GitTreeState:"clean", GoVersion:"go1.22.0"}
```

Setting `autoscaling.enabled: true` templates the following `Deployment` and `HPA` resources:
```
$ cat values.yaml | grep autoscaling -A10
autoscaling:
  enabled: true
  minReplicas: 1
  maxReplicas: 5
  targetCPUUtilizationPercentage: 80
  targetMemoryUtilizationPercentage: 80
  behavior: {}

$ helm template ./ -s templates/deployment.yaml
---
# Source: telegraf/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-telegraf
  labels:
    helm.sh/chart: telegraf-1.8.43
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: release-name
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: telegraf
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        app.kubernetes.io/name: telegraf
        app.kubernetes.io/instance: release-name
      annotations:
        checksum/config: 11e7bc3db613c177911535018f65051a22f67ef0cf419dc2f19448d2a629282f
    spec:
      serviceAccountName: release-name-telegraf
      containers:
      - name: telegraf
        image: "docker.io/library/telegraf:1.29-alpine"
        imagePullPolicy: "IfNotPresent"
        resources:
          {}
        env:
        - name: HOSTNAME
          value: telegraf-polling-service
        volumeMounts:
        - name: config
          mountPath: /etc/telegraf
      volumes:
      - name: config
        configMap:
          name: release-name-telegraf

$ helm template ./ -s templates/horizontalpodautoscaler.yaml
---
# Source: telegraf/templates/horizontalpodautoscaler.yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: release-name-telegraf
  labels:
    helm.sh/chart: telegraf-1.8.43
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: release-name
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: release-name-telegraf
  minReplicas: 1
  maxReplicas: 5
  metrics:
    - type: Resource
      resource:
        name: memory
        target:
          type: Utilization
          averageUtilization: 80
    - type: Resource
      resource:
        name: cpu
        target:
          type: Utilization
          averageUtilization: 80
```

Setting `autoscaling.enabled: false` templates the following `Deployment`  resource:
```
$ cat values.yaml | grep autoscaling -A10
autoscaling:
  enabled: false
  minReplicas: 1
  maxReplicas: 5
  targetCPUUtilizationPercentage: 80
  targetMemoryUtilizationPercentage: 80
  behavior: {}

helm template ./ -s templates/deployment.yaml
---
# Source: telegraf/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-telegraf
  labels:
    helm.sh/chart: telegraf-1.8.43
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: telegraf
    app.kubernetes.io/instance: release-name
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: telegraf
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        app.kubernetes.io/name: telegraf
        app.kubernetes.io/instance: release-name
      annotations:
        checksum/config: 11e7bc3db613c177911535018f65051a22f67ef0cf419dc2f19448d2a629282f
    spec:
      serviceAccountName: release-name-telegraf
      containers:
      - name: telegraf
        image: "docker.io/library/telegraf:1.29-alpine"
        imagePullPolicy: "IfNotPresent"
        resources:
          {}
        env:
        - name: HOSTNAME
          value: telegraf-polling-service
        volumeMounts:
        - name: config
          mountPath: /etc/telegraf
      volumes:
      - name: config
        configMap:
          name: release-name-telegraf

$ helm template ./ -s templates/horizontalpodautoscaler.yaml
Error: could not find template templates/horizontalpodautoscaler.yaml in chart
```