### PR TITLE
[influxdbv2] deploy influx with gateway-api

### DIFF
--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -4,7 +4,7 @@ name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb/
 type: application
-version: 2.1.2
+version: 2.1.3
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com

--- a/charts/influxdb2/README.md
+++ b/charts/influxdb2/README.md
@@ -13,6 +13,7 @@ bootstrap an InfluxDB v2 StatefulSet and service on a
 - Helm v3 or later
 - Kubernetes 1.4+
 - (Optional) PersistentVolume (PV) provisioner support in the underlying infrastructure
+- (Optional) Gateway API with istio service mesh
 
 ## Install the chart
 

--- a/charts/influxdb2/templates/http-route.yaml
+++ b/charts/influxdb2/templates/http-route.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.gateway.enabled }}
+{{- $gateway:= .Values.gateway }}
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: {{ include "influxdb.fullname" . }}
+  labels:
+    {{- include "influxdb.labels" . | nindent 4 }}
+  annotations:
+{{ toYaml .Values.gateway.annotations | indent 4 }}
+  namespace: {{ .Values.namespace }}
+spec:
+  parentRefs:
+    - name: {{ $gateway.name | default "gateway-ingress" }}
+      namespace: {{ $gateway.namespace | default "istio-system" }} 
+      sectionName: {{ $gateway.sectionName | default "https" }}
+  hostnames:
+    - "{{ $gateway.url }}"
+  rules:
+    - backendRefs: 
+        - name: {{ .Values.name }}
+          namespace: {{ .Values.namespace }}
+          port: {{ .Values.service.port }}
+          weight: {{ $gateway.weight | default 100 }}
+{{- end }}

--- a/charts/influxdb2/values.yaml
+++ b/charts/influxdb2/values.yaml
@@ -186,6 +186,11 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   path: /
 
+gateway:
+  enabled: false
+  url: influxdb.foobar.com
+  annotations: {}
+
 ## Pod disruption budget configuration
 ##
 pdb:


### PR DESCRIPTION
- [influxdbv2] added httproute template to deploy influxdb with istio service mesh and expose to the internet via gateway-api.
- [influxdbv2] updated readme and the values file with the necessary values for this change.