### PR TITLE
[telegraf-ds] add imagePullSecrets support

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.1.27
+version: 1.1.28
 appVersion: 1.30.2
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -25,6 +25,10 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "telegraf.serviceAccountName" . }}
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -6,6 +6,7 @@ image:
   repo: "telegraf"
   tag: "1.30-alpine"
   pullPolicy: IfNotPresent
+imagePullSecrets: []
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 resources:


### PR DESCRIPTION
Add support for `imagePullSecrets` in `telegraf-ds`. With the DockerHub pull rate limiting it's important that users are able to provide auth creds for DockerHub.

There is a previous MR: https://github.com/influxdata/helm-charts/pull/558, but it is quite old and out of date.