### PR TITLE
Make replicaCount optional when set value to null

### DIFF
--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.replicaCount }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "telegraf.name" . }}


### PR DESCRIPTION
This pr makes the replica count optional in the telegraf Deployment object.

This is useful when you use a HorizontalPodAutoscaler that manages the replica count for you. Especially when you deploy this helm chart with ArgoCD and the auto sync functionality (https://argo-cd.readthedocs.io/en/stable/user-guide/best_practices/#leaving-room-for-imperativeness).

I've successfully tested it locally on my machine with `helm template . --set replicaCount=null`

