### PR TITLE
Telegraf helm chart: Adding support for opentelemetry input in service template

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.46
+version: 1.8.47
 appVersion: 1.30.3
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -41,6 +41,11 @@ spec:
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
     name: "influxdb-v2-listener"
     {{- end }}
+    {{- if eq $key "opentelemetry" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    name: "opentelemetry"
+    {{- end }}
     {{- if eq $key "statsd" }}
   - port: {{ trimPrefix ":" $value.service_address | int64 }}
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}


### PR DESCRIPTION
Currently, if using the `opentelemetry` input plugin for telegraf, the kubernetes service is not created because this input plugin is not taken into account when setting the ports for the service.
This PR is about adding this support.

- [ ] CHANGELOG.md updated
- [X] Rebased/mergable
- [ ] Tests pass
- [X] Sign [CLA](https://influxdata.com/community/cla/) 

Example of values file:
```
resources: {}
service:
  enabled: true
config:
  agent:
    interval: "10s"
    round_interval: true
    metric_batch_size: 1000
    metric_buffer_limit: 10000
    collection_jitter: "0s"
    flush_interval: "10s"
    flush_jitter: "0s"
    precision: ""
    debug: true
    quiet: false

  inputs:
    - opentelemetry:
        service_address: ":4311" #address to receive traces
        timeout: "5s"
        metrics_schema: "prometheus-v2"
  processors:
    - starlark:
        source:
          |
            load("logging.star", "log")
            def apply(metric):
                log.info("Processing metric: {}".format(metric))
                return metric
  outputs:
    - file:
        files : ["stdout", "/tmp/metrics.out"]
```
