### PR TITLE
fix(templates/kubit): logic inversion on kubitSingleNamespace

### DIFF
--- a/charts/influxdb3-clustered/Chart.yaml
+++ b/charts/influxdb3-clustered/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 
-version: 0.1.1
+version: 0.1.2
 appVersion: "20240326-922145"
 name: influxdb3-clustered
 description: InfluxDB 3.0 Clustered

--- a/charts/influxdb3-clustered/templates/kubit.yml
+++ b/charts/influxdb3-clustered/templates/kubit.yml
@@ -79,7 +79,7 @@ spec:
     spec:
       containers:
       - env:
-{{- if not .Values.kubitSingleNamespace}}
+{{- if .Values.kubitSingleNamespace}}
         - name: KUBIT_WATCHED_NAMESPACE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Prior to this PR setting `Values.kubitSingleNamespace` to `false` would
cause it to watch only a single namespace, which seems to be the `kubit`
namespace itself. The reason it ends up watching the `kubit` namespace
can be seen in the deployment's namespace setting:

```
  namespace: {{if .Values.kubitSingleNamespace}}{{.Values.namespaceOverride | default .Release.Namespace}}{{else}}kubit{{end}}
```

(ie we hit the `else` branch in this logic when `kubitSingleNamespace` is false)
