### PR TITLE
fix: image override error when passing list

### DIFF
--- a/charts/influxdb3-clustered/Chart.yaml
+++ b/charts/influxdb3-clustered/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 
-version: 0.1.4
+version: 0.1.5
 appVersion: "20240717-1117630"
 name: influxdb3-clustered
 description: InfluxDB 3.0 Clustered

--- a/charts/influxdb3-clustered/templates/app-instance.yml
+++ b/charts/influxdb3-clustered/templates/app-instance.yml
@@ -27,9 +27,9 @@ spec:
               key: {{required "missing catalog.dsn.SecretKey" .Values.catalog.dsn.SecretKey}}
       {{- if or .Values.images.overrides .Values.images.registryOverride}}
       images:
-        {{- if .Values.images.overrides}}
-        overrides: {{.Values.images.overrides}}
-        {{- end}}
+        {{- with .Values.images.overrides }}
+        overrides: {{ . | toYaml | nindent 8 }}
+        {{- end }}
         {{- if .Values.images.registryOverride}}
         registryOverride: {{.Values.images.registryOverride}}
         {{- end}}


### PR DESCRIPTION
key getting the following error when adding a list for `image.overrides`

`Error: YAML parse error on influxdb3-clustered/templates/app-instance.yml: error converting YAML to JSON: yaml: line 19: did not find expected ',' or ']'`

Added with block to resolve issue for image overrides.