### PR TITLE
feat: support define telegraf container ports

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.51
+version: 1.8.52
 appVersion: 1.31.2
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.52
+version: 1.8.53
 appVersion: 1.31.2
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -41,6 +41,10 @@ spec:
 {{- end }}
         image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
+{{- if .Values.containerPorts }}
+        ports:
+{{ toYaml .Values.containerPorts | indent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         {{- if .Values.args }}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -181,7 +181,7 @@ pdb:
   minAvailable: 1
   # maxUnavailable: 1
 
-containerPorts:
-  - name: http
-    containerPort: 9273
-    protocol: TCP
+# containerPorts:
+# - name: http
+#   containerPort: 9273
+#   protocol: TCP

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -180,3 +180,8 @@ pdb:
   create: true
   minAvailable: 1
   # maxUnavailable: 1
+
+containerPorts:
+  - name: http
+    containerPort: 9273
+    protocol: TCP


### PR DESCRIPTION
Support define telegraf container ports for success as  [victoria metrics agent](https://github.com/VictoriaMetrics/helm-charts/tree/4040c7e6f9a134972535fb1fdf9c973a2dfb53be/charts/victoria-metrics-agent) scrape targets.
- default drop rule in [kubernetes-service-endpoints-job](https://github.com/VictoriaMetrics/helm-charts/blob/4040c7e6f9a134972535fb1fdf9c973a2dfb53be/charts/victoria-metrics-agent/values.yaml#L422-L426)