### PR TITLE
Fixed incorrect type coercion on float64 and int64 lists in aggregators

### DIFF
--- a/charts/telegraf/templates/_helpers.tpl
+++ b/charts/telegraf/templates/_helpers.tpl
@@ -322,13 +322,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
         {{ $val | quote }}
                   {{- end }}
                   {{- if eq $tp "float64" }}
-        {{ $val | int64 }}
+        {{ $val | float64 }}
                   {{- end }}
                 {{- else }}
                   {{- if eq $tp "string" }}
         {{ $val | quote }},
                   {{- end}}
-                  {{- if eq $tp "float64" }}
+                  {{- if eq $tp "int" }}
         {{ $val | int64 }},
                   {{- end }}
                 {{- end }}


### PR DESCRIPTION
Aggregators with a list containing floats such as:

`
  aggregators:
    - quantile:
        quantiles: [0.25, 0.5, 0.75, 0.9, 0.95, 0.99]
`

Are not parsed properly by helm templates. The above results in a configmap like so:

`
    [[aggregators.quantile]]
      quantiles = [
        0,
        0,
        0,
        0,
        0,
        0
      ]
`

This is due to the _helpers.tpl template improperly coercing types for lists containing ints or floats.

