### PR TITLE
[influxdb] Support configurable StatefulSet labels/annotations

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.12.5
+version: 4.12.6
 appVersion: 1.8.10
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/README.md
+++ b/charts/influxdb/README.md
@@ -71,6 +71,8 @@ The following table lists configurable parameters, their descriptions, and their
 | persistence.size | Storage size | 8Gi                                                                  |
 | podAnnotations | Annotations for pod | {}                                                                   |
 | podLabels | Labels for pod | {}                                                                   |
+| statefulSetAnnotations | Annotations for StatefulSet | {}                                                                   |
+| statefulSetLabels | Labels for StatefulSet | {}                                                                   |
 | ingress.enabled | Boolean flag to enable or disable ingress | false                                                                |
 | ingress.tls | Boolean to enable or disable tls for ingress. If enabled provide a secret in `ingress.secretName` containing TLS private key and certificate. | false                                                                |
 | ingress.secretName | Kubernetes secret containing TLS private key and certificate. It is `only` required if `ingress.tls` is enabled. | nil                                                                  |

--- a/charts/influxdb/templates/meta-statefulset.yaml
+++ b/charts/influxdb/templates/meta-statefulset.yaml
@@ -6,6 +6,13 @@ metadata:
   labels:
     {{- include "influxdb.labels" . | nindent 4 }}
     app.kubernetes.io/component: meta
+    {{- if .Values.statefulSetLabels }}
+{{ toYaml .Values.statefulSetLabels | indent 4 }}
+    {{- end }}
+  {{- if .Values.statefulSetAnnotations }}
+  annotations:
+{{ toYaml .Values.statefulSetAnnotations | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.enterprise.meta.clusterSize }}
   selector:

--- a/charts/influxdb/templates/statefulset.yaml
+++ b/charts/influxdb/templates/statefulset.yaml
@@ -4,6 +4,13 @@ metadata:
   name: {{ include "influxdb.fullname" . }}
   labels:
     {{- include "influxdb.labels" . | nindent 4 }}
+    {{- if .Values.statefulSetLabels }}
+{{ toYaml .Values.statefulSetLabels | indent 4 }}
+    {{- end }}
+  {{- if .Values.statefulSetAnnotations }}
+  annotations:
+{{ toYaml .Values.statefulSetAnnotations | indent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.enterprise.enabled }}
   replicas: {{ .Values.enterprise.clusterSize }}

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -136,6 +136,12 @@ podAnnotations: {}
 # Labels to be added to InfluxDB pods
 podLabels: {}
 
+# Annotations to be added to InfluxDB statefulsets
+statefulSetAnnotations: {}
+
+# Labels to be added to InfluxDB statefulsets
+statefulSetLabels: {}
+
 ingress:
   enabled: false
   tls: false


### PR DESCRIPTION
Adds the `statefulSetAnnotations`/`statefulSetLabels` properties to `values.yaml` to allow users to specify custom labels and annotations on the resulting StatefulSets.

This feature would be tremendously useful for environments that require certain labels to be set - the only alternative would be to fork the chart internally.

---

- ~~[ ] CHANGELOG.md updated~~ None found
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)