### PR TITLE
[telegraf] Support configurable Deployment labels/annotations

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.53
+version: 1.8.54
 appVersion: 1.31.3
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -4,6 +4,13 @@ metadata:
   name: {{ include "telegraf.fullname" . }}
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
+    {{- if .Values.deploymentLabels }}
+{{ toYaml .Values.deploymentLabels | indent 4 }}
+    {{- end }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml .Values.deploymentAnnotations | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -7,8 +7,15 @@ image:
   repo: "docker.io/library/telegraf"
   tag: "1.31-alpine"
   pullPolicy: IfNotPresent
+
+# Annotations/Labels to be added to Telegraf Pods
 podAnnotations: {}
 podLabels: {}
+
+# Annotations/Labels to be added to Telegraf Deployments
+deploymentAnnotations: {}
+deploymentLabels: {}
+
 imagePullSecrets: []
 ## Configure args passed to Telegraf containers
 args: []


### PR DESCRIPTION
Adds the `deploymentAnnotations`/`deploymentLabels` properties to `values.yaml` to allow users to specify custom labels and annotations on the Deployments.

This feature would be tremendously useful for environments that require certain labels to be set - the only alternative would be to fork the chart internally.

---

- ~~[ ] CHANGELOG.md updated~~ None found
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)