### PR TITLE
[chronograf] Support configurable common labels

### DIFF
--- a/charts/chronograf/Chart.yaml
+++ b/charts/chronograf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: chronograf
-version: 1.2.6
+version: 1.2.7
 appVersion: 1.9.4
 description: Open-source web application written in Go and React.js that provides
   the tools to visualize your monitoring data and easily create alerting and automation

--- a/charts/chronograf/README.md
+++ b/charts/chronograf/README.md
@@ -80,6 +80,7 @@ The following table lists configurable parameters, their descriptions, and their
 | `oauth.heroku.gh_orgs`       | oauth github                                                                                              | ""                                          |
 | `env`                        | Extra environment variables that will be passed onto deployment pods                                      | {}                                          |
 | `envFromSecret`              | The name of a secret in the same kubernetes namespace which contain values to be added to the environment | {}                                          |
+| `extraLabels`                | Additional common labels to add to the generated resources                                                | {}                                          |
 | `nodeSelector`               | Node labels for pod assignment                                                                            | {}                                          |
 | `tolerations`                | Toleration labels for pod assignment                                                                      | []                                          |
 | `affinity`                   | Affinity settings for pod assignment                                                                      | {}                                          |

--- a/charts/chronograf/templates/_helpers.tpl
+++ b/charts/chronograf/templates/_helpers.tpl
@@ -32,6 +32,9 @@ helm.sh/chart: {{ include "chronograf.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/chronograf/values.yaml
+++ b/charts/chronograf/values.yaml
@@ -132,6 +132,9 @@ env:
 ## This can be useful for auth tokens, etc
 envFromSecret: ""
 
+## Additional common labels to add to generated resources
+extraLabels: {}
+
 # volumes:
 # - name: chronograf-output-influxdb2
 #   configMap:


### PR DESCRIPTION
Adds the `extraLabels` property to `values.yaml` which allows users to provide custom labels to be added to generated resources.

This feature would be tremendously useful for environments that require certain labels to be set - the only alternative would be to fork the chart internally.

---

- ~~[ ] CHANGELOG.md updated~~ None found
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)