### PR TITLE
fix(edge): need to set end block for http

### DIFF
--- a/charts/influxdb-enterprise/Chart.yaml
+++ b/charts/influxdb-enterprise/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.23
+version: 0.1.24
 appVersion: 1.10.0
 engine: gotpl
 

--- a/charts/influxdb-enterprise/templates/data-statefulset.yaml
+++ b/charts/influxdb-enterprise/templates/data-statefulset.yaml
@@ -121,8 +121,8 @@ spec:
               port: http
               {{- if .Values.data.https.enabled }}
               scheme: HTTPS
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 3600 }}
               {{- end }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 3600 }}
           readinessProbe:
             initialDelaySeconds: 30
             httpGet:

--- a/charts/influxdb-enterprise/templates/meta-statefulset.yaml
+++ b/charts/influxdb-enterprise/templates/meta-statefulset.yaml
@@ -112,8 +112,8 @@ spec:
               port: http
               {{- if .Values.meta.https.enabled }}
               scheme: HTTPS
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 3600 }}
               {{- end }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 3600 }}
           readinessProbe:
             httpGet:
               path: /ping


### PR DESCRIPTION
- typo when creating the initial PR
- Need to set up the end before the liveness probe or else it gets caught up in the https enabled false and you cannot set it 