### PR TITLE
[influxdb] Support imagePullSecrets configuration for influxdb backup cron job

### DIFF
--- a/charts/influxdb/templates/backup-cronjob.yaml
+++ b/charts/influxdb/templates/backup-cronjob.yaml
@@ -55,6 +55,12 @@ spec:
           {{- end }}
           {{- end }}
           serviceAccountName: {{ include "influxdb.serviceAccountName" . }}
+          {{- if .Values.image.pullSecrets }}
+          imagePullSecrets:
+          {{- range .Values.image.pullSecrets }}
+            - name: {{ . }}
+          {{- end }}
+          {{- end }}
           initContainers:
           - name: influxdb-backup
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Adds support for influxdb backup cronjob to configure .spec.imagePullSecrets based on .Values.image.pullSecrets

This feature would be tremendously useful for private artefact repositories where internal network policies mandate the use of a proxy for downloading artifacts and e.g. influxdb:1.8.10-alpine cannot be used. 

Currently .Values.image.pullSecrets is passed only to main pod where influxdb is running.