### PR TITLE
chore: Bump github action versions

### DIFF
--- a/.github/workflows/helm-charts-release.yaml
+++ b/.github/workflows/helm-charts-release.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Fetch history
         run: git fetch --prune --unshallow
@@ -34,12 +34,12 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v4
         with:
           version: v3.6.3
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true

--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -8,42 +8,43 @@ jobs:
     strategy:
       matrix:
         node_image_version:
-          - v1.21.1 # default used by helm/kind-action@v1.2.0 (kubernetes-sigs/kind@0.11.1)
+          - v1.21.1
           - v1.22.4
     name: lint-test (k8s ${{ matrix.node_image_version }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Fetch history
         run: git fetch --prune --unshallow
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v4
         with:
           version: v3.6.3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: '3.x'
+          check-latest: true
 
       - name: Install chart-testing tools
         id: lint
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2
 
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
           changed=$(ct list-changed)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)
         run: ct lint
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1
         with:
           node_image: kindest/node:${{ matrix.node_image_version }}
         if: steps.list-changed.outputs.changed == 'true'


### PR DESCRIPTION
This is an attempt to fix the recent workflow errors complaining about python v3.7 not being available for Ubuntu 24.04. While being at it, this PR bumps all actions to their latest available version.