### PR TITLE
[telegraf] Subtable were not correctly formed in the manifests

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.55
+version: 1.8.56
 appVersion: 1.32.1
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/_helpers.tpl
+++ b/charts/telegraf/templates/_helpers.tpl
@@ -250,7 +250,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
           {{- range $key, $value := $config -}}
           {{- $tp := typeOf $value -}}
           {{- if eq $tp "map[string]interface {}" }}
-      [inputs.{{ $input }}.{{ $key }}]
+      [[inputs.{{ $input }}.{{ $key }}]]
             {{- range $k, $v := $value }}
               {{- $tps := typeOf $v }}
               {{- if eq $tps "string" }}
@@ -274,7 +274,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
               {{- range $k, $v := $value }}
               {{- $tps := typeOf $v }}
               {{- if eq $tps "map[string]interface {}"}}
-          [inputs.{{ $input }}.{{ $key }}.{{ $k }}]
+          [[inputs.{{ $input }}.{{ $key }}.{{ $k }}]]
                 {{- range $foo, $bar := $v }}
             {{ $foo }} = {{ $bar | quote }}
                 {{- end }}


### PR DESCRIPTION
# Telegraf CloudWatch Input Plugin Configuration Resolution in Helm Template

## Configuration

```yaml
configuration:
  config:
    agent:
      interval: "10s"
      # ... other settings ...
    inputs:
      - cloudwatch:
          region: "eu-west-1"
          role_arn: $AWS_ROLE_ARN
          web_identity_token_file: $AWS_WEB_IDENTITY_TOKEN_FILE
          period: "5m"
          delay: "1m"
          namespaces:
            - "AWS/EC2"
          metrics:
            names:
              - "CPUUtilization"
              - "DiskReadOps"
              - "NetworkIn"
```

## Initial Error

```
2024-11-28T11:17:01Z I! Loading config: /etc/telegraf/telegraf.conf
2024-11-28T11:17:01Z E! loading config file /etc/telegraf/telegraf.conf failed: error parsing cloudwatch, line 41: cannot unmarshal TOML table into ]*cloudwatch.cloudwatchMetric (need struct or map)
Stream closed EOF for telegraf/telegraf-7c58fdcfc8-gxx8n (telegraf)
```

## Problematic Helm Template

```toml
[[inputs.cloudwatch]]
  delay = "1m"
  namespaces = [
    "AWS/EC2"
  ]
  period = "5m"
  region = "eu-west-1"
  role_arn = "$AWS_ROLE_ARN"
  web_identity_token_file = "$AWS_WEB_IDENTITY_TOKEN_FILE"
  [inputs.cloudwatch.metrics]
    names = [
        "CPUUtilization",
        "DiskReadOps",
        "NetworkIn"
    ]
```

## Corrected Helm Template

```toml
[[inputs.cloudwatch]]
  delay = "1m"
  namespaces = [
    "AWS/EC2"
  ]
  period = "5m"
  region = "eu-west-1"
  role_arn = "$AWS_ROLE_ARN"
  web_identity_token_file = "$AWS_WEB_IDENTITY_TOKEN_FILE"
  [[inputs.cloudwatch.metrics]]
    names = [
        "CPUUtilization",
        "DiskReadOps",
        "NetworkIn"
    ]
```

## Changes

- This fixes the TOML parsing issue with the CloudWatch input plugin when generated by Helm

## Reference

- [Telegraf CloudWatch Input Plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/cloudwatch)