### PR TITLE
Revert "chore: helm chart clustered update"

### DIFF
--- a/charts/influxdb3-clustered/Chart.yaml
+++ b/charts/influxdb3-clustered/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 
-version: 0.1.9
-appVersion: "20241217-1494922"
+version: 0.1.8
+appVersion: "20240925-1257864"
 name: influxdb3-clustered
 description: InfluxDB 3.0 Clustered
 maintainers:

--- a/charts/influxdb3-clustered/Chart.yaml
+++ b/charts/influxdb3-clustered/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 
-version: 0.1.8
+version: 0.1.10
 appVersion: "20240925-1257864"
 name: influxdb3-clustered
 description: InfluxDB 3.0 Clustered


### PR DESCRIPTION
Reverts influxdata/helm-charts#695

This release contains a defect that can, in some cases, cause data loss. It should not be used.