### PR TITLE
chore(influxdb3-clustered): update clustered helm chart

### DIFF
--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -35,13 +35,13 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed)
+          changed=$(ct list-changed --target-branch=master)
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint
+        run: ct lint --target-branch=master
 
       - name: Create kind cluster
         uses: helm/kind-action@v1

--- a/charts/influxdb3-clustered/Chart.yaml
+++ b/charts/influxdb3-clustered/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 
-version: 0.1.9
+version: 0.1.10
 appVersion: "20241217-1494922"
 name: influxdb3-clustered
 description: InfluxDB 3.0 Clustered

--- a/charts/influxdb3-clustered/templates/app-instance.yml
+++ b/charts/influxdb3-clustered/templates/app-instance.yml
@@ -12,8 +12,8 @@ spec:
     spec:
       {{- if .Values.hostingEnvironment}}
       hostingEnvironment:
-        {{- if hasKey .Values.hostingEnvironment "eks"}}
-        eks: {{.Values.hostingEnvironment.eks | include "mapTrim" | trim | nindent 10}}
+        {{- if hasKey .Values.hostingEnvironment "aws"}}
+        aws: {{.Values.hostingEnvironment.aws | include "mapTrim" | trim | nindent 10}}
         {{- else if hasKey .Values.hostingEnvironment "openshift"}}
         openshift: {{.Values.hostingEnvironment.openshift | include "mapTrim" | trim | nindent 10}}
         {{- else if hasKey .Values.hostingEnvironment "gke"}}

--- a/charts/influxdb3-clustered/templates/app-instance.yml
+++ b/charts/influxdb3-clustered/templates/app-instance.yml
@@ -67,6 +67,12 @@ spec:
       {{- if .Values.featureFlags}}
       featureFlags: {{.Values.featureFlags | toYaml | nindent 6}}
       {{- end}}
+      {{- if .Values.observability.serviceMonitor}}
+      observability:
+        serviceMonitor:
+          interval: {{required "missing observability.serviceMonitor.interval" .Values.observability.serviceMonitor.interval}}
+          scrapeTimeout: {{required "missing observability.serviceMonitor.scrapeTimeout" .Values.observability.serviceMonitor.scrapeTimeout}}
+      {{- end}}
 ---
 {{- end }}
 

--- a/charts/influxdb3-clustered/values.yaml
+++ b/charts/influxdb3-clustered/values.yaml
@@ -184,6 +184,10 @@ resources:
   router:
     requests:
     limits:
+  # The Catalog stores metadata related to schema information and physical locations of partitions.
+  catalog:
+    requests:
+    limits:
 
 admin:
  # The list of users to grant access to Clustered via influxctl

--- a/charts/influxdb3-clustered/values.yaml
+++ b/charts/influxdb3-clustered/values.yaml
@@ -221,3 +221,9 @@ egress:
 
 # This can be used to enable certain features that are still in testing
 featureFlags: []
+
+# Parameters to tune observability configuration, such as Prometheus ServiceMonitor's.
+observability: {}
+  # serviceMonitor:
+  #  interval: 10s
+  #  scrapeTimeout: 30s

--- a/charts/influxdb3-clustered/values.yaml
+++ b/charts/influxdb3-clustered/values.yaml
@@ -16,7 +16,7 @@ operatorImageOverride: ""
 skipOperator: false
 
 hostingEnvironment: {}
-#  eks:
+#  aws:
 #    eksRoleArn: "" # "arn:aws:iam::111111111111:role/your-influxdb-clustered-role"
 #  # Note: there are currently no OpenShift-specific parameters. The empty object is still required for proper function
 #  openshift: {}


### PR DESCRIPTION
Closes https://github.com/influxdata/EAR/issues/5836

This adds the `observability.ServiceMonitor` keys and changes `hostingEnvironment.eks` to `hostingEnvironment.aws`.