### PR TITLE
fix(influxdb): use gcloud instead of gsutil with workload identity

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.12.5
+version: 4.12.6
 appVersion: 1.8.10
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/backup-cronjob.yaml
+++ b/charts/influxdb/templates/backup-cronjob.yaml
@@ -83,8 +83,10 @@ spec:
             - |
               if [ -n "$KEY_FILE" ]; then
                 gcloud auth activate-service-account --key-file $KEY_FILE
+                gsutil -m cp -r /backup/* "$DST_URL"
+              else
+                gcloud storage cp -r /backup/* "$DST_URL"
               fi
-              gsutil -m cp -r /backup/* "$DST_URL"
               rm -rf /backup/*
             volumeMounts:
             - name: backup


### PR DESCRIPTION
`gsutil` does not support workload identity (see GoogleCloudPlatform/gsutil#1407). When using workload identity (i.e. not using a key file), use `gcloud storage` instead.