### PR TITLE
Add ServiceMonitor support to Telegraf chart

### DIFF
--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -104,4 +104,7 @@ spec:
   {{- end }}
   selector:
     {{- include "telegraf.selectorLabels" . | nindent 4 }}
+    {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
 {{- end -}}

--- a/charts/telegraf/templates/servicemonitor.yml
+++ b/charts/telegraf/templates/servicemonitor.yml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "telegraf.fullname" . }}
+  labels:
+    app: {{ include "telegraf.name" . }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "telegraf.name" . }}
+  endpoints:
+    - port: prometheus-client
+      interval: {{ .Values.serviceMonitor.interval | default "10s" }}
+{{- end }}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -185,3 +185,9 @@ pdb:
 # - name: http
 #   containerPort: 9273
 #   protocol: TCP
+
+serviceMonitor:
+  enabled: false      # Set to true to enable ServiceMonitor
+  interval: 10s       # Scrape interval; adjust as needed
+  labels:             # Optional: add custom labels if desired
+    release: ""


### PR DESCRIPTION
PR: Add ServiceMonitor Support and LoadBalancerIP Option
Overview
This pull request introduces two enhancements to the official Telegraf Helm chart:

ServiceMonitor Support:
A new template has been added to create a ServiceMonitor resource for Prometheus Operator integration. This enables users to automatically have their Telegraf metrics scraped by Prometheus.

LoadBalancerIP Option:
An optional parameter has been added to the Service template. When the service type is set to LoadBalancer and a loadBalancerIP is provided in the values, this IP will be assigned to the Service. This allows users to reserve a static IP address for their LoadBalancer.

Details
ServiceMonitor Enhancements
Template Addition:
A new template (servicemonitor.yml) has been added that conditionally creates a ServiceMonitor resource if serviceMonitor.enabled is set to true in the values file.

Configuration Options:
Users can now configure the ServiceMonitor with the following options in their values.yaml:

serviceMonitor:
  enabled: true         # Set to true to enable ServiceMonitor creation
  interval: "10s"       # Scrape interval for Prometheus
  labels:
    team: "frontend"    # Custom labels (optional)
Compatibility:
This change is backward compatible. If serviceMonitor.enabled is not set or is false, the chart behaves as before.

LoadBalancerIP Support
Template Update:
The Service template has been updated to conditionally include the loadBalancerIP field when:

The service type is set to LoadBalancer
A loadBalancerIP is provided in the values file
Configuration Option:
To use this feature, users can update their values.yaml as follows:

service:
  type: LoadBalancer
  # Uncomment and set to your desired static IP if using LoadBalancer
  loadBalancerIP: "1.2.3.4"
Outcome:
This ensures that when a static IP is required, it will be applied to the Service, while remaining backward compatible for users who do not set this value.

Testing
ServiceMonitor Testing:
Verified that when serviceMonitor.enabled is true, a ServiceMonitor resource is created with the proper endpoint configuration (using the port name from the Service).

LoadBalancerIP Testing:
Confirmed that when the service type is LoadBalancer and a loadBalancerIP is provided, the Service correctly includes the loadBalancerIP field.

Conclusion
These changes enhance the usability of the Telegraf Helm chart by providing native support for Prometheus Operator and offering greater control over LoadBalancer configurations. Feedback and further suggestions are welcome!