### PR TITLE
influxdb: add support for priorityClassName

### DIFF
--- a/charts/influxdb/templates/backup-cronjob.yaml
+++ b/charts/influxdb/templates/backup-cronjob.yaml
@@ -55,6 +55,9 @@ spec:
           {{- end }}
           {{- end }}
           serviceAccountName: {{ include "influxdb.serviceAccountName" . }}
+          {{- with default .Values.priorityClassName .Values.backup.priorityClassName }}
+          priorityClassName: {{ . }}
+          {{- end }}
           initContainers:
           - name: influxdb-backup
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/influxdb/templates/backup-retention-cronjob.yaml
+++ b/charts/influxdb/templates/backup-retention-cronjob.yaml
@@ -47,6 +47,9 @@ spec:
           {{- end }}
           {{- end }}
           serviceAccountName: {{ include "influxdb.serviceAccountName" . }}
+          {{- with default .Values.priorityClassName .Values.backup.priorityClassName }}
+          priorityClassName: {{ . }}
+          {{- end }}
           containers:
           {{- if .Values.backupRetention.gcs }}
           {{- end }}

--- a/charts/influxdb/templates/meta-statefulset.yaml
+++ b/charts/influxdb/templates/meta-statefulset.yaml
@@ -30,6 +30,9 @@ spec:
       {{- end}}
       {{- end }}
       serviceAccountName: {{ include "influxdb.serviceAccountName" . }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
       - name: "{{ include "influxdb.fullname" . }}-meta"
         image: "{{ .Values.image.repository }}:{{ .Values.enterprise.meta.image.tag }}"

--- a/charts/influxdb/templates/statefulset.yaml
+++ b/charts/influxdb/templates/statefulset.yaml
@@ -52,6 +52,9 @@ spec:
       {{- end}}
       {{- end }}
       serviceAccountName: {{ include "influxdb.serviceAccountName" . }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
       - name: {{ include "influxdb.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -8,11 +8,12 @@ image:
   # pullSecrets:
   #   - registry-secret
 
-
 serviceAccount:
   create: true
   name:
   annotations: {}
+
+priorityClassName: ""
 
 ## Customize liveness, readiness and startup probes
 ## ref: https://docs.influxdata.com/influxdb/v1.8/tools/api/#ping-http-endpoint
@@ -261,6 +262,7 @@ backup:
     annotations:
     accessMode: ReadWriteOnce
     size: 8Gi
+  priorityClassName: ""
   schedule: "0 0 * * *"
   startingDeadlineSeconds: ""
   annotations: {}


### PR DESCRIPTION
This adds the possibility to set priorityClassNames for the influxdb helm chart