### PR TITLE
chore: update chart for 20250508-1719206 release

### DIFF
--- a/charts/influxdb3-clustered/Chart.yaml
+++ b/charts/influxdb3-clustered/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 
-version: 0.1.12
-appVersion: "20250212-1570743"
+version: 0.1.13
+appVersion: "20250508-1719206"
 name: influxdb3-clustered
 description: InfluxDB 3.0 Clustered
 maintainers:


### PR DESCRIPTION
Updates the clustered helm charts to the `20250508-1719206` release