### PR TITLE
feat: [telegraf-operator] add image tag handling and podLabels via va…

### DIFF
--- a/charts/telegraf-operator/templates/_helpers.tpl
+++ b/charts/telegraf-operator/templates/_helpers.tpl
@@ -32,13 +32,21 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Define image version
+*/}}
+{{- define "telegraf-operator.version" -}}
+{{- $version := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s" $version -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "telegraf-operator.labels" -}}
 helm.sh/chart: {{ include "telegraf-operator.chart" . }}
 {{ include "telegraf-operator.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ include "telegraf-operator.version" . | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}

--- a/charts/telegraf-operator/templates/deployment.yaml
+++ b/charts/telegraf-operator/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
     metadata:
       labels:
         {{- include "telegraf-operator.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{ toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
 {{- if eq .Values.certManager.enable false }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/tls.yml") . | sha256sum }}
@@ -23,7 +26,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ include "telegraf-operator.version" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "--telegraf-default-class={{ .Values.classes.default }}"

--- a/charts/telegraf-operator/values.yaml
+++ b/charts/telegraf-operator/values.yaml
@@ -1,6 +1,7 @@
 replicaCount: 3
 image:
   repository: quay.io/influxdb/telegraf-operator
+  tag: v1.3.11
   pullPolicy: IfNotPresent
   sidecarImage: "docker.io/library/telegraf:1.22"
 
@@ -52,6 +53,7 @@ sidecarResources:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+podLabels: {}
 requireAnnotationsForSecret: false
 enableDefaultInternalPlugin: true
 # allow hot reload ; disabled by default to support versions of telegraf


### PR DESCRIPTION
…lues

I wanted to be able to change which image tag was used via values.yaml instead of Chart.yaml, and thought other folks might want to be able to do the same! Also needed the ability to apply custom labels to the telegraf-operator pods and I didn't see an existing way to do so. Thanks in advance for taking a look!