### PR TITLE
fix(telegraf): use subPath for telegraf.conf to support additional config mounts

### DIFF
--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -60,7 +60,9 @@ spec:
 {{- end }}
         volumeMounts:
         - name: config
-          mountPath: /etc/telegraf
+          mountPath: /etc/telegraf/telegraf.conf
+          subPath: telegraf.conf
+          readOnly: true
         {{- range .Values.volumeMounts }}
         - name: {{ .name }}
           mountPath: {{ .mountPath }}


### PR DESCRIPTION
Fix: #721 

## Summary

This PR updates the `volumeMounts` for `telegraf.conf` to use `subPath`, allowing users to mount additional configuration files (e.g., for inputs and outputs) under /etc/telegraf/telegraf.d.

## Problem

Currently, the Helm chart mounts the full ConfigMap at /etc/telegraf:

```
    volumeMounts:
      - name: config
        mountPath: /etc/telegraf
```

This prevents mounting any other files under /etc/telegraf, such as custom .conf files.

## Solution

By changing the mount to:

```
    volumeMounts:
      - name: config
        mountPath: /etc/telegraf/telegraf.conf
        subPath: telegraf.conf
        readOnly: true
```

we allow users to mount additional configuration files (e.g., /etc/telegraf/telegraf.d/*.conf) in parallel without conflict.

## Benefits

- Supports mounting supplemental configs via separate ConfigMaps
- Promotes flexibility and extensibility for more complex Telegraf setups

## Notes

- readOnly: true is explicitly set for safety when using subPath
