### PR TITLE
[Telegraf] Add initContainers to helm chart

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.59
+version: 1.8.60
 appVersion: 1.35.1
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
 {{ toYaml .Values.securityContext | indent 8 }}
 {{- end }}
       serviceAccountName: {{ template "telegraf.serviceAccountName" . }}
+      {{- with.Values.initContainers }}
+      initContainers:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
 {{- if .Values.containerSecurityContext }}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -32,6 +32,12 @@ env:
 #   mountPath: /etc/telegraf/conf.d
 #   subPath: influxdb2.conf
 
+
+# Init containers for the pod
+initContainers: []
+# - name: ubuntu
+#   image: ubuntu 
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 resources: {}


### PR DESCRIPTION
I need an `initContainer` to configure my postgres database during startup before running telegraf.
The content is a copy of #347 
closes #395