### PR TITLE
feat: add option for namespace selection for telegraf-operator webhook

### DIFF
--- a/charts/telegraf-operator/Chart.yaml
+++ b/charts/telegraf-operator/Chart.yaml
@@ -30,7 +30,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.4.0
+version: 1.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/telegraf-operator/templates/_helpers.tpl
+++ b/charts/telegraf-operator/templates/_helpers.tpl
@@ -99,6 +99,11 @@ webhooks:
     - DELETE
     resources:
     - pods
+    {{- if not (empty .Values.namespaceSelector) }}
+    scope: "Namespaced"
+    {{- end }}
+  namespaceSelector:
+    {{- toYaml .Values.namespaceSelector | nindent 4 }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/telegraf-operator/templates/mutatingwebhookconfiguration.yml
+++ b/charts/telegraf-operator/templates/mutatingwebhookconfiguration.yml
@@ -28,4 +28,9 @@ webhooks:
     - DELETE
     resources:
     - pods
+    {{- if not (empty .Values.namespaceSelector) }}
+    scope: "Namespaced"
+    {{- end }}
+  namespaceSelector:
+    {{- toYaml .Values.namespaceSelector | nindent 4 }}
 {{- end }}

--- a/charts/telegraf-operator/values.yaml
+++ b/charts/telegraf-operator/values.yaml
@@ -57,3 +57,4 @@ enableDefaultInternalPlugin: true
 # allow hot reload ; disabled by default to support versions of telegraf
 # that do not support hot-reload and --watch-config flag
 hotReload: false
+namespaceSelector: {}


### PR DESCRIPTION
I added an option for the webhook to only match certain namespaces instead of all of them
In GKE they complain when you have a webhook that can intercept requests for system namespaces (kube-system, kube-node-lease) so I needed a way to adhere to their [guidelines](https://cloud.google.com/kubernetes-engine/docs/how-to/optimize-webhooks#unsafe-webhooks)
I tested this on our company infra, seems fine
Thanks!