### PR TITLE
feat: add the ability to configure dnsPolicy on deployment (#733)

### DIFF
--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -28,6 +28,23 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
         {{- end }}
     spec:
+{{- if .Values.dnsPolicy }}
+      dnsPolicy:
+{{ toYaml .Values.dnsPolicy | indent 8}}
+{{- end }}
+{{- if and .Values.dnsConfig .Values.dnsConfig.nameservers }}
+      dnsConfig:
+        nameservers:
+{{ toYaml .Values.dnsConfig.nameservers | indent 10}}
+{{- end }}
+{{- if and .Values.dnsConfig .Values.dnsConfig.searches }}
+        searches:
+{{ toYaml .Values.dnsConfig.searches | indent 10}}
+{{- end }}
+{{- if and .Values.dnsConfig .Values.dnsConfig.options }}
+        options:
+{{ toYaml .Values.dnsConfig.options | indent 10}}
+{{- end }}
 {{- if .Values.securityContext }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
@@ -126,4 +143,4 @@ spec:
           name: {{ include "telegraf.fullname" . }}
       {{- if .Values.volumes }}
 {{ toYaml .Values.volumes | indent 6 }}
-      {{- end }}
+{{- end }}


### PR DESCRIPTION
- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Testing was done with a local manual deployment using the new template on a kind cluster. I verified that the values were passed through to the deployment by inspecting the deployment with kubectl.

Thanks, this really helps when dealing with devices in a complex network topology.