### PR TITLE
fix: place pause on outer spec

### DIFF
--- a/charts/influxdb3-clustered/Chart.yaml
+++ b/charts/influxdb3-clustered/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 
-version: 0.1.18
+version: 0.1.19
 appVersion: "20250721-1796368"
 name: influxdb3-clustered
 description: InfluxDB 3.0 Clustered

--- a/charts/influxdb3-clustered/templates/app-instance.yml
+++ b/charts/influxdb3-clustered/templates/app-instance.yml
@@ -5,12 +5,12 @@ metadata:
   name: {{.Values.nameOverride | default .Release.Name}}
   namespace: {{.Values.namespaceOverride | default .Release.Namespace}}
 spec:
+  pause: {{.Values.pause }}
   imagePullSecrets: {{.Values.imagePullSecrets | toYaml | nindent 2}}
   package:
     image: "{{.Values.fullnameOverride | default "us-docker.pkg.dev/influxdb2-artifacts/clustered/influxdb"}}:{{ .Values.image.tag | default .Chart.AppVersion }}"
     apiVersion: influxdata.com/v1alpha1
     spec:
-      pause: {{.Values.pause }}
       {{- if .Values.hostingEnvironment}}
       hostingEnvironment:
         {{- if hasKey .Values.hostingEnvironment "aws"}}


### PR DESCRIPTION
Tested this locally and realized the pause needs to be on the outer spec

see: https://docs.influxdata.com/influxdb3/clustered/admin/backup-restore/#use-the-same-influxdb-clustered-version-used-to-generate-the-snapshot