### PR TITLE
fix: update Clustered chart to latest kubit for binami image fix

### DIFF
--- a/charts/influxdb3-clustered/Chart.yaml
+++ b/charts/influxdb3-clustered/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 
-version: 0.1.21
+version: 0.1.22
 appVersion: "20250925-1878107"
 name: influxdb3-clustered
 description: InfluxDB 3.0 Clustered

--- a/charts/influxdb3-clustered/values.yaml
+++ b/charts/influxdb3-clustered/values.yaml
@@ -9,7 +9,7 @@ nameOverride: ""
 namespaceOverride: ""
 fullnameOverride: ""
 kubitSingleNamespace: false
-operatorImageVersion: "v0.0.20"
+operatorImageVersion: "v0.0.22"
 operatorImageOverride: ""
 
 # Pause kubit operator for backup and restore


### PR DESCRIPTION
This updates the Clustered chart to pull in a fix in the latest kubit release for a bitnami image that is no longer available. See https://github.com/kubecfg/kubit/pull/600 for more details.