### PR TITLE
fix: use yamale v6 to work around bug

### DIFF
--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -31,6 +31,8 @@ jobs:
       - name: Install chart-testing tools
         id: lint
         uses: helm/chart-testing-action@v2
+        with:
+          yamale_version: '6.0.0'
 
       - name: Run chart-testing (list-changed)
         id: list-changed


### PR DESCRIPTION
This forces helm/chart-testing-action to use yamale v6 to get work around a bug as outlined in https://github.com/helm/chart-testing-action/issues/177#issuecomment-3386841674.

Thanks @bnpfeife for finding the related issue 🙌