### PR TITLE
fix(kubit): add default resource overrides and correct namespaceOverride typo for app-instance

### DIFF
--- a/charts/influxdb3-clustered/templates/app-instance.yml
+++ b/charts/influxdb3-clustered/templates/app-instance.yml
@@ -82,7 +82,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: app-instance
-  namespace: {{ .Values.NamspaceOverride | default .Release.Namespace }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
 data:
   app-instance: |
     {{ include "app-instance.influxdb" . | fromYaml | toJson }}

--- a/charts/influxdb3-clustered/templates/kubit.yml
+++ b/charts/influxdb3-clustered/templates/kubit.yml
@@ -113,13 +113,11 @@ spec:
             port: 8080
           initialDelaySeconds: 5
           periodSeconds: 10
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 10m
-            memory: 64Mi
+        {{- $default_kubit_resources := dict
+              "requests" (dict "cpu" "50m" "memory" "64Mi")
+              "limits"   (dict "cpu" "100m" "memory" "128Mi") -}}
+        {{- $kubit_resources := mergeOverwrite $default_kubit_resources (.Values.kubit.resources | default dict) -}}
+        resources: {{ $kubit_resources | include "mapTrim" | trim | nindent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
Fix typo in `namespaceOverride` (was `NamspaceOverride`).
Add support for overriding Kubit resource requests and limits via `.Values.kubit.resources`.

#### What this PR does
- Fixes typo in `namespaceOverride`
- Adds support for overriding Kubit resource requests and limits via `.Values.kubit.resources`
- Adds default CPU/memory requests and limits for Kubit
- Prevents `mapTrim requires a map` when `kubit: {}` is empty in values.yaml

#### Why
Without these changes, the Kubit template fails rendering when resource overrides are not defined.
This ensures users can deploy with sensible defaults and adjust resource settings as needed.

#### How tested
- Rendered with `helm template influxdb3-clustered -f values.yaml`
  - Verified defaults applied correctly with empty `kubit: {}`
  - Verified override behavior works when custom resource values are provided
- Confirmed valid YAML output and Helm template success.

#### Checklist
- [x] CHANGELOG.md updated *(not applicable – no changelog in chart)*  
- [x] Rebased/mergable  
- [x] Tests pass (`helm template` validation)  
- [x] Signed [CLA](https://influxdata.com/community/cla/)
