### PR TITLE
fix(influxdb3-ent): add gRPC/Flight Ingress route

### DIFF
--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -3,7 +3,7 @@ name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
 version: 0.3.0
-appVersion: "3.8.4"
+appVersion: "3.9.1"
 keywords:
   - influxdb
   - time-series

--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "3.8.4"
 keywords:
   - influxdb

--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: "3.9.2"
 keywords:
   - influxdb

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -91,15 +91,13 @@ At minimum, you must configure:
      # For commercial licenses use `file: /path/to/license` or `existingSecret`
    ```
 
-3. **Ingress Hosts**:
+3. **Ingress Host**:
    ```yaml
    ingress:
-     write:
-       hosts:
-         - host: writes.your-domain.com
-     query:
-       hosts:
-         - host: query.your-domain.com
+     host: "influxdb.example.com"
+     # Optional Flight host override (defaults to ingress.host)
+     flight:
+       host: ""
    ```
 
 ## Configuration
@@ -221,29 +219,43 @@ tls:
 
 #### Ingress Configuration
 
-Separate ingresses for write and query traffic:
+The chart creates separate ingresses for write, query, and Flight/gRPC traffic:
 
 ```yaml
 ingress:
+  enabled: true
+  className: "nginx"
+  host: "influxdb.example.com"
+  tls:
+    - secretName: influxdb-tls
+      hosts:
+        - influxdb.example.com
+
   write:
-    enabled: true
-    className: "nginx"
     annotations:
-      cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    hosts:
-      - host: writes.influxdb.example.com
-        paths:
-          - path: /api/v3/write_lp
-            pathType: Prefix
-          - path: /api/v2/write
-            pathType: Prefix
-          - path: /write
-            pathType: Prefix
-    tls:
-      - secretName: influxdb-write-tls
-        hosts:
-          - writes.influxdb.example.com
+      nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+
+  query:
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+
+  # Flight/gRPC ingress to querier
+  flight:
+    host: "" # Optional override; defaults to ingress.host
+    paths:
+      - /arrow.flight.protocol.FlightService
+      - /arrow.flight.protocol.sql.FlightSqlService
+    annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
 ```
+
+Route summary:
+- Write ingress routes `/api/v3/write_lp`, `/api/v2/write`, `/write` to ingester.
+- Query ingress routes `/api/v3/query`, `/query`, `/` to querier.
+- Flight ingress routes `ingress.flight.paths` (default Arrow Flight service paths) to querier with gRPC backend protocol.
+- Processor ingress routes `/api/v3/engine` to processor when processing engine is enabled.
 
 #### Network Policies
 
@@ -331,10 +343,11 @@ processingEngine:
 
 ### Data Flow
 
-1. **Write Path**: Client → Ingress → Ingester Service → Ingester Pods → Object Storage
-2. **Query Path**: Client → Ingress → Querier Service → Querier Pods → Object Storage
-3. **Compaction**: Compactor reads from Object Storage, compacts data, writes back
-4. **Processing**: Processor nodes execute plugins on data writes, schedules, or HTTP requests
+1. **Write Path**: Client → Write Ingress → Ingester Service → Ingester Pods → Object Storage
+2. **HTTP Query Path**: Client → Query Ingress → Querier Service → Querier Pods → Object Storage
+3. **Flight/gRPC Query Path**: Client → Flight Ingress → Querier Service → Querier Pods → Object Storage
+4. **Compaction**: Compactor reads from Object Storage, compacts data, writes back
+5. **Processing**: Processor nodes execute plugins on data writes, schedules, or HTTP requests
 
 ## Upgrading
 
@@ -520,8 +533,18 @@ logs:
 | `ingress.className` | Ingress class | `nginx` |
 | `ingress.port` | Host port referenced in NOTES | `8181` |
 | `ingress.tls` | TLS host/secret list | `[]` |
+| `ingress.write.annotations` | Write ingress annotations | `proxy-body-size/read-timeout` |
+| `ingress.query.annotations` | Query ingress annotations | `proxy-read-timeout` |
+| `ingress.flight.host` | Optional host override for Flight ingress | `""` (uses `ingress.host`) |
+| `ingress.flight.tls` | Optional TLS override for Flight ingress | `[]` (uses `ingress.tls`) |
+| `ingress.flight.paths` | Flight/gRPC service paths routed to querier | Flight + Flight SQL paths |
+| `ingress.flight.annotations` | Flight ingress annotations (includes GRPC backend protocol) | includes `backend-protocol: GRPC` |
+| `ingress.processor.annotations` | Processor ingress annotations | `{}` |
 
-Ingress paths are fixed in the templates: write ingress exposes `/api/v3/write_lp`, `/api/v2/write`, `/write`; query ingress exposes `/api/v3/query`, `/query`, and `/`.
+Ingress routes:
+- Write ingress exposes `/api/v3/write_lp`, `/api/v2/write`, `/write`.
+- Query ingress exposes `/api/v3/query`, `/query`, `/`.
+- Flight ingress exposes `ingress.flight.paths` (defaults to Arrow Flight service paths).
 
 ### Network Policy Parameters
 

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -243,9 +243,6 @@ ingress:
   # Flight/gRPC ingress to querier
   flight:
     host: "" # Optional override; defaults to ingress.host
-    paths:
-      - /arrow.flight.protocol.FlightService
-      - /arrow.flight.protocol.sql.FlightSqlService
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
@@ -254,7 +251,7 @@ ingress:
 Route summary:
 - Write ingress routes `/api/v3/write_lp`, `/api/v2/write`, `/write` to ingester.
 - Query ingress routes `/api/v3/query`, `/query`, `/` to querier.
-- Flight ingress routes `ingress.flight.paths` (default Arrow Flight service paths) to querier with gRPC backend protocol.
+- Flight ingress routes `/arrow.flight.protocol.FlightService` and `/arrow.flight.protocol.sql.FlightSqlService` to querier with gRPC backend protocol.
 - Processor ingress routes `/api/v3/engine` to processor when processing engine is enabled.
 
 #### Network Policies
@@ -537,14 +534,13 @@ logs:
 | `ingress.query.annotations` | Query ingress annotations | `proxy-read-timeout` |
 | `ingress.flight.host` | Optional host override for Flight ingress | `""` (uses `ingress.host`) |
 | `ingress.flight.tls` | Optional TLS override for Flight ingress | `[]` (uses `ingress.tls`) |
-| `ingress.flight.paths` | Flight/gRPC service paths routed to querier | Flight + Flight SQL paths |
 | `ingress.flight.annotations` | Flight ingress annotations (includes GRPC backend protocol) | includes `backend-protocol: GRPC` |
 | `ingress.processor.annotations` | Processor ingress annotations | `{}` |
 
 Ingress routes:
 - Write ingress exposes `/api/v3/write_lp`, `/api/v2/write`, `/write`.
 - Query ingress exposes `/api/v3/query`, `/query`, `/`.
-- Flight ingress exposes `ingress.flight.paths` (defaults to Arrow Flight service paths).
+- Flight ingress exposes `/arrow.flight.protocol.FlightService` and `/arrow.flight.protocol.sql.FlightSqlService`.
 
 ### Network Policy Parameters
 

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -91,15 +91,13 @@ At minimum, you must configure:
      # For commercial licenses use `file: /path/to/license` or `existingSecret`
    ```
 
-3. **Ingress Hosts**:
+3. **Ingress Host**:
    ```yaml
    ingress:
-     write:
-       hosts:
-         - host: writes.your-domain.com
-     query:
-       hosts:
-         - host: query.your-domain.com
+     host: "influxdb.example.com"
+     # Optional Flight host override (defaults to ingress.host)
+     flight:
+       host: ""
    ```
 
 ### Preconfigured Admin Token
@@ -286,29 +284,43 @@ tls:
 
 #### Ingress Configuration
 
-Separate ingresses for write and query traffic:
+The chart creates separate ingresses for write, query, and Flight/gRPC traffic:
 
 ```yaml
 ingress:
+  enabled: true
+  className: "nginx"
+  host: "influxdb.example.com"
+  tls:
+    - secretName: influxdb-tls
+      hosts:
+        - influxdb.example.com
+
   write:
-    enabled: true
-    className: "nginx"
     annotations:
-      cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    hosts:
-      - host: writes.influxdb.example.com
-        paths:
-          - path: /api/v3/write_lp
-            pathType: Prefix
-          - path: /api/v2/write
-            pathType: Prefix
-          - path: /write
-            pathType: Prefix
-    tls:
-      - secretName: influxdb-write-tls
-        hosts:
-          - writes.influxdb.example.com
+      nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+
+  query:
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+
+  # Flight/gRPC ingress to querier
+  flight:
+    host: "" # Optional override; defaults to ingress.host
+    paths:
+      - /arrow.flight.protocol.FlightService
+      - /arrow.flight.protocol.sql.FlightSqlService
+    annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
 ```
+
+Route summary:
+- Write ingress routes `/api/v3/write_lp`, `/api/v2/write`, `/write` to ingester.
+- Query ingress routes `/api/v3/query`, `/query`, `/` to querier.
+- Flight ingress routes `ingress.flight.paths` (default Arrow Flight service paths) to querier with gRPC backend protocol.
+- Processor ingress routes `/api/v3/engine` to processor when processing engine is enabled.
 
 #### Network Policies
 
@@ -396,10 +408,11 @@ processingEngine:
 
 ### Data Flow
 
-1. **Write Path**: Client → Ingress → Ingester Service → Ingester Pods → Object Storage
-2. **Query Path**: Client → Ingress → Querier Service → Querier Pods → Object Storage
-3. **Compaction**: Compactor reads from Object Storage, compacts data, writes back
-4. **Processing**: Processor nodes execute plugins on data writes, schedules, or HTTP requests
+1. **Write Path**: Client → Write Ingress → Ingester Service → Ingester Pods → Object Storage
+2. **HTTP Query Path**: Client → Query Ingress → Querier Service → Querier Pods → Object Storage
+3. **Flight/gRPC Query Path**: Client → Flight Ingress → Querier Service → Querier Pods → Object Storage
+4. **Compaction**: Compactor reads from Object Storage, compacts data, writes back
+5. **Processing**: Processor nodes execute plugins on data writes, schedules, or HTTP requests
 
 ## Upgrading
 
@@ -594,8 +607,18 @@ logs:
 | `ingress.className` | Ingress class | `nginx` |
 | `ingress.port` | Host port referenced in NOTES | `8181` |
 | `ingress.tls` | TLS host/secret list | `[]` |
+| `ingress.write.annotations` | Write ingress annotations | `proxy-body-size/read-timeout` |
+| `ingress.query.annotations` | Query ingress annotations | `proxy-read-timeout` |
+| `ingress.flight.host` | Optional host override for Flight ingress | `""` (uses `ingress.host`) |
+| `ingress.flight.tls` | Optional TLS override for Flight ingress | `[]` (uses `ingress.tls`) |
+| `ingress.flight.paths` | Flight/gRPC service paths routed to querier | Flight + Flight SQL paths |
+| `ingress.flight.annotations` | Flight ingress annotations (includes GRPC backend protocol) | includes `backend-protocol: GRPC` |
+| `ingress.processor.annotations` | Processor ingress annotations | `{}` |
 
-Ingress paths are fixed in the templates: write ingress exposes `/api/v3/write_lp`, `/api/v2/write`, `/write`; query ingress exposes `/api/v3/query`, `/query`, and `/`.
+Ingress routes:
+- Write ingress exposes `/api/v3/write_lp`, `/api/v2/write`, `/write`.
+- Query ingress exposes `/api/v3/query`, `/query`, `/`.
+- Flight ingress exposes `ingress.flight.paths` (defaults to Arrow Flight service paths).
 
 ### Network Policy Parameters
 

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -631,7 +631,7 @@ logs:
 | `ingress.write.annotations` | Write ingress annotations | `proxy-body-size/read-timeout` |
 | `ingress.query.annotations` | Query ingress annotations | `proxy-read-timeout` |
 | `ingress.flight.host` | Optional host override for Flight ingress | `""` (uses `ingress.host`) |
-| `ingress.flight.tls` | Optional TLS override for Flight ingress | `[]` (uses `ingress.tls`) |
+| `ingress.flight.tls` | Optional TLS override for Flight ingress. Required when `ingress.flight.host` differs from `ingress.host`. | `[]` |
 | `ingress.flight.annotations` | Flight ingress annotations (includes GRPC backend protocol) | includes `backend-protocol: GRPC` |
 | `ingress.processor.annotations` | Processor ingress annotations | `{}` |
 

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -308,9 +308,6 @@ ingress:
   # Flight/gRPC ingress to querier
   flight:
     host: "" # Optional override; defaults to ingress.host
-    paths:
-      - /arrow.flight.protocol.FlightService
-      - /arrow.flight.protocol.sql.FlightSqlService
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
@@ -319,7 +316,7 @@ ingress:
 Route summary:
 - Write ingress routes `/api/v3/write_lp`, `/api/v2/write`, `/write` to ingester.
 - Query ingress routes `/api/v3/query`, `/query`, `/` to querier.
-- Flight ingress routes `ingress.flight.paths` (default Arrow Flight service paths) to querier with gRPC backend protocol.
+- Flight ingress routes `/arrow.flight.protocol.FlightService` and `/arrow.flight.protocol.sql.FlightSqlService` to querier with gRPC backend protocol.
 - Processor ingress routes `/api/v3/engine` to processor when processing engine is enabled.
 
 #### Network Policies
@@ -611,14 +608,13 @@ logs:
 | `ingress.query.annotations` | Query ingress annotations | `proxy-read-timeout` |
 | `ingress.flight.host` | Optional host override for Flight ingress | `""` (uses `ingress.host`) |
 | `ingress.flight.tls` | Optional TLS override for Flight ingress | `[]` (uses `ingress.tls`) |
-| `ingress.flight.paths` | Flight/gRPC service paths routed to querier | Flight + Flight SQL paths |
 | `ingress.flight.annotations` | Flight ingress annotations (includes GRPC backend protocol) | includes `backend-protocol: GRPC` |
 | `ingress.processor.annotations` | Processor ingress annotations | `{}` |
 
 Ingress routes:
 - Write ingress exposes `/api/v3/write_lp`, `/api/v2/write`, `/write`.
 - Query ingress exposes `/api/v3/query`, `/query`, `/`.
-- Flight ingress exposes `ingress.flight.paths` (defaults to Arrow Flight service paths).
+- Flight ingress exposes `/arrow.flight.protocol.FlightService` and `/arrow.flight.protocol.sql.FlightSqlService`.
 
 ### Network Policy Parameters
 

--- a/charts/influxdb3-enterprise/templates/ingress-flight.yaml
+++ b/charts/influxdb3-enterprise/templates/ingress-flight.yaml
@@ -41,6 +41,7 @@ spec:
         paths:
           {{- range .Values.ingress.flight.paths }}
           - path: {{ . | quote }}
+            # Keep ImplementationSpecific for dotted gRPC service paths.
             pathType: ImplementationSpecific
             backend:
               service:

--- a/charts/influxdb3-enterprise/templates/ingress-flight.yaml
+++ b/charts/influxdb3-enterprise/templates/ingress-flight.yaml
@@ -39,14 +39,20 @@ spec:
     - host: {{ $flightHost | quote }}
       http:
         paths:
-          {{- range .Values.ingress.flight.paths }}
-          - path: {{ . | quote }}
+          - path: /arrow.flight.protocol.FlightService
             # Keep ImplementationSpecific for dotted gRPC service paths.
             pathType: ImplementationSpecific
             backend:
               service:
-                name: {{ include "influxdb3-enterprise.fullname" $ }}-querier
+                name: {{ include "influxdb3-enterprise.fullname" . }}-querier
                 port:
-                  number: {{ $.Values.querier.service.port }}
-          {{- end }}
+                  number: {{ .Values.querier.service.port }}
+          - path: /arrow.flight.protocol.sql.FlightSqlService
+            # Keep ImplementationSpecific for dotted gRPC service paths.
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ include "influxdb3-enterprise.fullname" . }}-querier
+                port:
+                  number: {{ .Values.querier.service.port }}
 {{- end }}

--- a/charts/influxdb3-enterprise/templates/ingress-flight.yaml
+++ b/charts/influxdb3-enterprise/templates/ingress-flight.yaml
@@ -1,0 +1,51 @@
+{{- if and .Values.ingress.enabled .Values.querier.enabled }}
+{{- $flightHost := default .Values.ingress.host .Values.ingress.flight.host }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "influxdb3-enterprise.fullname" . }}-flight
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-enterprise.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ingress-flight
+  {{- with .Values.ingress.flight.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.flight.tls }}
+  tls:
+    {{- range .Values.ingress.flight.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- else if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ $flightHost | quote }}
+      http:
+        paths:
+          {{- range .Values.ingress.flight.paths }}
+          - path: {{ . | quote }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ include "influxdb3-enterprise.fullname" $ }}-querier
+                port:
+                  number: {{ $.Values.querier.service.port }}
+          {{- end }}
+{{- end }}

--- a/charts/influxdb3-enterprise/templates/ingress-flight.yaml
+++ b/charts/influxdb3-enterprise/templates/ingress-flight.yaml
@@ -1,5 +1,6 @@
 {{- if and .Values.ingress.enabled .Values.querier.enabled }}
 {{- $flightHost := default .Values.ingress.host .Values.ingress.flight.host }}
+{{- $useGlobalTLS := eq $flightHost .Values.ingress.host }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -25,7 +26,7 @@ spec:
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
-  {{- else if .Values.ingress.tls }}
+  {{- else if and $useGlobalTLS .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
     - hosts:

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -692,7 +692,9 @@ ingress:
     host: ""
     # Optional TLS override. If empty, inherits ingress.tls.
     tls: []
-    # Path prefixes that should be treated as gRPC/Flight.
+    # Flight service path patterns.
+    # NOTE: ingress-flight uses pathType=ImplementationSpecific because
+    # ingress-nginx warns on these dotted gRPC service paths with Prefix.
     paths:
       - /arrow.flight.protocol.FlightService
       - /arrow.flight.protocol.sql.FlightSqlService

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -692,12 +692,6 @@ ingress:
     host: ""
     # Optional TLS override. If empty, inherits ingress.tls.
     tls: []
-    # Flight service path patterns.
-    # NOTE: ingress-flight uses pathType=ImplementationSpecific because
-    # ingress-nginx warns on these dotted gRPC service paths with Prefix.
-    paths:
-      - /arrow.flight.protocol.FlightService
-      - /arrow.flight.protocol.sql.FlightSqlService
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "600"

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -685,6 +685,21 @@ ingress:
     annotations:
       nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
 
+  # Ingress for Flight/gRPC query traffic (to queriers)
+  # Routes: /arrow.flight.protocol.* → Querier (gRPC backend)
+  flight:
+    # Optional host override. If empty, inherits ingress.host.
+    host: ""
+    # Optional TLS override. If empty, inherits ingress.tls.
+    tls: []
+    # Path prefixes that should be treated as gRPC/Flight.
+    paths:
+      - /arrow.flight.protocol.FlightService
+      - /arrow.flight.protocol.sql.FlightSqlService
+    annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+
   # Ingress for HTTP-triggered plugins (created only if processingEngine.enabled)
   processor:
     annotations: {}

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -727,7 +727,7 @@ ingress:
   flight:
     # Optional host override. If empty, inherits ingress.host.
     host: ""
-    # Optional TLS override. If empty, inherits ingress.tls.
+    # Optional TLS override. Required when host differs from ingress.host.
     tls: []
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "GRPC"

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -709,12 +709,6 @@ ingress:
     host: ""
     # Optional TLS override. If empty, inherits ingress.tls.
     tls: []
-    # Flight service path patterns.
-    # NOTE: ingress-flight uses pathType=ImplementationSpecific because
-    # ingress-nginx warns on these dotted gRPC service paths with Prefix.
-    paths:
-      - /arrow.flight.protocol.FlightService
-      - /arrow.flight.protocol.sql.FlightSqlService
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "600"

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -709,7 +709,9 @@ ingress:
     host: ""
     # Optional TLS override. If empty, inherits ingress.tls.
     tls: []
-    # Path prefixes that should be treated as gRPC/Flight.
+    # Flight service path patterns.
+    # NOTE: ingress-flight uses pathType=ImplementationSpecific because
+    # ingress-nginx warns on these dotted gRPC service paths with Prefix.
     paths:
       - /arrow.flight.protocol.FlightService
       - /arrow.flight.protocol.sql.FlightSqlService

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -702,6 +702,21 @@ ingress:
     annotations:
       nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
 
+  # Ingress for Flight/gRPC query traffic (to queriers)
+  # Routes: /arrow.flight.protocol.* → Querier (gRPC backend)
+  flight:
+    # Optional host override. If empty, inherits ingress.host.
+    host: ""
+    # Optional TLS override. If empty, inherits ingress.tls.
+    tls: []
+    # Path prefixes that should be treated as gRPC/Flight.
+    paths:
+      - /arrow.flight.protocol.FlightService
+      - /arrow.flight.protocol.sql.FlightSqlService
+    annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+
   # Ingress for HTTP-triggered plugins (created only if processingEngine.enabled)
   processor:
     annotations: {}


### PR DESCRIPTION
This PR 

Adds gRPC/Flight Ingress routing to InfluxDB3 Enterprise chart. It is necessary for querying with v3 client libraries. Keeps a single default ingress host for path-based write/query/Flight routing; an optional `ingress.flight.host` override is available for ingress-controller environments that require host-level separation of gRPC and HTTP traffic.
