### PR TITLE
chore: bump InfluxDB Enterprise version

### DIFF
--- a/charts/influxdb-enterprise/Chart.yaml
+++ b/charts/influxdb-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-version: 0.1.24
-appVersion: 1.10.0
+version: 0.2.0
+appVersion: 1.12.3
 engine: gotpl
 
 name: influxdb-enterprise


### PR DESCRIPTION
Bumps InfluxDB v1 Enterprise version to 1.12.3.

- [x] Chart installs
- [x] Connect Chronograf and show data in dashboard
- [x] Simple smoke tests passes (configuration: 3 meta nodes, 2 data nodes): create db, ingest & query data


smoke test:
```
  kubectl -n influxdb-enterprise port-forward svc/influxdb-enterprise-data 18086:8086

  curl -i -XPOST 'http://127.0.0.1:18086/query' --data-urlencode 'q=CREATE DATABASE smoke'
  curl -i -XPOST 'http://127.0.0.1:18086/write?db=smoke' --data-binary 'm,host=h1 v=1i'
  curl -i -G 'http://127.0.0.1:18086/query' --data-urlencode 'db=smoke' --data-urlencode 'q=SELECT * FROM m'

```