### PR TITLE
fix(influxdb-ent): TLS secret permissions

### DIFF
--- a/charts/influxdb-enterprise/Chart.yaml
+++ b/charts/influxdb-enterprise/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.12.3
 engine: gotpl
 

--- a/charts/influxdb-enterprise/README.md
+++ b/charts/influxdb-enterprise/README.md
@@ -163,6 +163,26 @@ meta:
     insecure: true # Only enable if your CA isn't trusted
 ```
 
+When using `defaultMode: 0600`, TLS secret files are root-owned and readable only by UID 0.
+If you configure non-root containers (for example `meta.securityContext.runAsUser`,
+`meta.securityContext.runAsNonRoot`, `data.securityContext.runAsUser`, or
+`data.securityContext.runAsNonRoot`), the process may not be able to read `tls.key`.
+
+If you must run non-root, use this temporary compatibility configuration:
+
+```yaml
+meta:
+  https:
+    secret:
+      defaultMode: 0640
+    insecureCertificate: true
+data:
+  https:
+    secret:
+      defaultMode: 0640
+    insecureCertificate: true
+```
+
 If you cannot mount TLS files with restrictive permissions, you can temporarily skip local certificate/key permission checks:
 
 ```yaml
@@ -174,7 +194,7 @@ data:
     insecureCertificate: true
 ```
 
-Use this only as a temporary compatibility workaround. It reduces TLS safety and should be disabled after fixing secret file permissions.
+Use this only as a temporary compatibility workaround. It reduces TLS safety and should be disabled after fixing secret file permissions and/or non-root file access.
 
 #### DDL/DML (Optional)
 

--- a/charts/influxdb-enterprise/README.md
+++ b/charts/influxdb-enterprise/README.md
@@ -159,6 +159,7 @@ meta:
   https:
     secret:
       name: my-tls-secret
+      defaultMode: 0600 # Restrictive mode required for TLS private key files
     insecure: true # Only enable if your CA isn't trusted
 ```
 

--- a/charts/influxdb-enterprise/README.md
+++ b/charts/influxdb-enterprise/README.md
@@ -163,26 +163,6 @@ meta:
     insecure: true # Only enable if your CA isn't trusted
 ```
 
-When using `defaultMode: 0600`, TLS secret files are root-owned and readable only by UID 0.
-If you configure non-root containers (for example `meta.securityContext.runAsUser`,
-`meta.securityContext.runAsNonRoot`, `data.securityContext.runAsUser`, or
-`data.securityContext.runAsNonRoot`), the process may not be able to read `tls.key`.
-
-If you must run non-root, use this temporary compatibility configuration:
-
-```yaml
-meta:
-  https:
-    secret:
-      defaultMode: 0640
-    insecureCertificate: true
-data:
-  https:
-    secret:
-      defaultMode: 0640
-    insecureCertificate: true
-```
-
 If you cannot mount TLS files with restrictive permissions, you can temporarily skip local certificate/key permission checks:
 
 ```yaml
@@ -194,7 +174,7 @@ data:
     insecureCertificate: true
 ```
 
-Use this only as a temporary compatibility workaround. It reduces TLS safety and should be disabled after fixing secret file permissions and/or non-root file access.
+Use this only as a temporary compatibility workaround. It reduces TLS safety and should be disabled after fixing secret file permissions.
 
 #### DDL/DML (Optional)
 

--- a/charts/influxdb-enterprise/README.md
+++ b/charts/influxdb-enterprise/README.md
@@ -163,6 +163,19 @@ meta:
     insecure: true # Only enable if your CA isn't trusted
 ```
 
+If you cannot mount TLS files with restrictive permissions, you can temporarily skip local certificate/key permission checks:
+
+```yaml
+meta:
+  https:
+    insecureCertificate: true
+data:
+  https:
+    insecureCertificate: true
+```
+
+Use this only as a temporary compatibility workaround. It reduces TLS safety and should be disabled after fixing secret file permissions.
+
 #### DDL/DML (Optional)
 
 If you wish to create databases or import data after installation, we've provided this DDL/DML hook. Your config map must contain the keys `ddl` and `dml`.

--- a/charts/influxdb-enterprise/templates/data-configmap.yaml
+++ b/charts/influxdb-enterprise/templates/data-configmap.yaml
@@ -21,6 +21,10 @@ data:
     https-certificate = "/var/run/secrets/tls/tls.crt"
     https-private-key = "/var/run/secrets/tls/tls.key"
 
+    {{ if .Values.data.https.insecureCertificate }}
+    https-insecure-certificate = true
+    {{ end }}
+
     {{ end }}
 
     {{ if .Values.data.flux.enabled }}
@@ -45,6 +49,9 @@ data:
 
     {{ if .Values.data.https.insecure }}
     https-insecure-tls = true
+    {{ end }}
+    {{ if .Values.data.https.insecureCertificate }}
+    https-insecure-certificate = true
     {{ end }}
     {{ end }}
 

--- a/charts/influxdb-enterprise/templates/data-statefulset.yaml
+++ b/charts/influxdb-enterprise/templates/data-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       {{- if .Values.data.https.enabled }}
       - name: tls
         secret:
-          defaultMode: {{ .Values.data.https.secret.defaultMode | default 0600 }}
+          defaultMode: {{ default 0600 (and .Values.data.https.secret .Values.data.https.secret.defaultMode) }}
           {{- if .Values.data.https.useCertManager }}
           secretName: {{ include "influxdb-enterprise.fullname" . }}-data-tls
           {{ else }}

--- a/charts/influxdb-enterprise/templates/data-statefulset.yaml
+++ b/charts/influxdb-enterprise/templates/data-statefulset.yaml
@@ -48,6 +48,7 @@ spec:
       {{- if .Values.data.https.enabled }}
       - name: tls
         secret:
+          defaultMode: {{ .Values.data.https.secret.defaultMode | default 0600 }}
           {{- if .Values.data.https.useCertManager }}
           secretName: {{ include "influxdb-enterprise.fullname" . }}-data-tls
           {{ else }}

--- a/charts/influxdb-enterprise/templates/meta-configmap.yaml
+++ b/charts/influxdb-enterprise/templates/meta-configmap.yaml
@@ -31,6 +31,9 @@ data:
       {{ if .Values.meta.https.insecure }}
       https-insecure-tls = true
       {{ end }}
+      {{ if .Values.meta.https.insecureCertificate }}
+      https-insecure-certificate = true
+      {{ end }}
 
       {{ end }}
 

--- a/charts/influxdb-enterprise/templates/meta-statefulset.yaml
+++ b/charts/influxdb-enterprise/templates/meta-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       {{- if .Values.meta.https.enabled }}
       - name: tls
         secret:
-          defaultMode: {{ .Values.meta.https.secret.defaultMode | default 0600 }}
+          defaultMode: {{ default 0600 (and .Values.meta.https.secret .Values.meta.https.secret.defaultMode) }}
           {{- if .Values.meta.https.useCertManager }}
           secretName: {{ include "influxdb-enterprise.fullname" . }}-meta-tls
           {{ else }}

--- a/charts/influxdb-enterprise/templates/meta-statefulset.yaml
+++ b/charts/influxdb-enterprise/templates/meta-statefulset.yaml
@@ -48,6 +48,7 @@ spec:
       {{- if .Values.meta.https.enabled }}
       - name: tls
         secret:
+          defaultMode: {{ .Values.meta.https.secret.defaultMode | default 0600 }}
           {{- if .Values.meta.https.useCertManager }}
           secretName: {{ include "influxdb-enterprise.fullname" . }}-meta-tls
           {{ else }}

--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -164,6 +164,9 @@ meta:
       name: influxdb-tls
       # crt: tls.crt
       # key: tls.key
+      # defaultMode sets file permissions for mounted TLS files.
+      # InfluxDB Enterprise requires restrictive permissions on the private key.
+      defaultMode: 0600
       # ca: ca.crt
       # caSecret: secret-name # only use if different from the above
     insecure: true
@@ -261,6 +264,9 @@ data:
       name: influxdb-tls
       # crt: tls.crt
       # key: tls.key
+      # defaultMode sets file permissions for mounted TLS files.
+      # InfluxDB Enterprise requires restrictive permissions on the private key.
+      defaultMode: 0600
       # ca: ca.crt
       # caSecret: secret-name # only use if different from the above
     insecure: true

--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -169,7 +169,12 @@ meta:
       defaultMode: 0600
       # ca: ca.crt
       # caSecret: secret-name # only use if different from the above
+    # Disable TLS peer certificate verification for remote endpoints
+    # (maps to `https-insecure-tls` option).
     insecure: true
+    # Skip local TLS certificate/private key file permission checks; use only as a
+    # temporary compatibility escape hatch (maps to `https-insecure-certificate` option).
+    insecureCertificate: false
   ## Additional data container environment variables e.g.:
   ##   INFLUXDB_HTTP_FLUX_ENABLED: "true"
   env: {}
@@ -269,7 +274,12 @@ data:
       defaultMode: 0600
       # ca: ca.crt
       # caSecret: secret-name # only use if different from the above
+    # Disable TLS peer certificate verification for remote endpoints
+    # (maps to `https-insecure-tls` option).
     insecure: true
+    # Skip local TLS certificate/private key file permission checks; use only as a
+    # temporary compatibility escape hatch (maps to `https-insecure-certificate` option).
+    insecureCertificate: false
   flux:
     enabled: true
   ## Additional data container environment variables e.g.:

--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -166,8 +166,6 @@ meta:
       # key: tls.key
       # defaultMode sets file permissions for mounted TLS files.
       # InfluxDB Enterprise requires restrictive permissions on the private key.
-      # Files are mounted as root-owned; with runAsNonRoot/runAsUser, 0600 may not be readable.
-      # For temporary non-root compatibility, use 0640 with `insecureCertificate: true`.
       defaultMode: 0600
       # ca: ca.crt
       # caSecret: secret-name # only use if different from the above
@@ -273,8 +271,6 @@ data:
       # key: tls.key
       # defaultMode sets file permissions for mounted TLS files.
       # InfluxDB Enterprise requires restrictive permissions on the private key.
-      # Files are mounted as root-owned; with runAsNonRoot/runAsUser, 0600 may not be readable.
-      # For temporary non-root compatibility, use 0640 with `insecureCertificate: true`.
       defaultMode: 0600
       # ca: ca.crt
       # caSecret: secret-name # only use if different from the above

--- a/charts/influxdb-enterprise/values.yaml
+++ b/charts/influxdb-enterprise/values.yaml
@@ -166,6 +166,8 @@ meta:
       # key: tls.key
       # defaultMode sets file permissions for mounted TLS files.
       # InfluxDB Enterprise requires restrictive permissions on the private key.
+      # Files are mounted as root-owned; with runAsNonRoot/runAsUser, 0600 may not be readable.
+      # For temporary non-root compatibility, use 0640 with `insecureCertificate: true`.
       defaultMode: 0600
       # ca: ca.crt
       # caSecret: secret-name # only use if different from the above
@@ -271,6 +273,8 @@ data:
       # key: tls.key
       # defaultMode sets file permissions for mounted TLS files.
       # InfluxDB Enterprise requires restrictive permissions on the private key.
+      # Files are mounted as root-owned; with runAsNonRoot/runAsUser, 0600 may not be readable.
+      # For temporary non-root compatibility, use 0640 with `insecureCertificate: true`.
       defaultMode: 0600
       # ca: ca.crt
       # caSecret: secret-name # only use if different from the above


### PR DESCRIPTION
This PR
* fixes TLS key-permission startup failures introduced by stricter certificate/key permission checks in v1.12.2+ by mounting TLS secrets with secure mode 0600 for meta and data pods
* adds optional `insecureCertificate` values (default `false`) that maps to `https-insecure-certificate`  v1.12.3+ configuration option, just for compatibility edge cases.