### PR TITLE
fix(telegraf-ds|telegraf): add tpl support for podAnnotations

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.1.47
+version: 1.1.48
 appVersion: 1.38.1
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/ci/tpl-pod-annotations-values.yaml
+++ b/charts/telegraf-ds/ci/tpl-pod-annotations-values.yaml
@@ -1,0 +1,5 @@
+# Validates that podAnnotations values are evaluated through tpl(),
+# allowing Helm template expressions such as {{ .Release.Name }}.
+podAnnotations:
+  example.io/release: "{{ .Release.Name }}"
+  example.io/namespace: "{{ .Release.Namespace }}"

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         # This means that if the configmap changes, the deployment will be rolled
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
+{{ tpl (toYaml .Values.podAnnotations) . | indent 8 }}
         {{- end }}
     spec:
       {{- if .Values.imagePullSecrets }}

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.68
+version: 1.8.69
 appVersion: 1.38.1
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/ci/tpl-pod-annotations-values.yaml
+++ b/charts/telegraf/ci/tpl-pod-annotations-values.yaml
@@ -1,0 +1,5 @@
+# Validates that podAnnotations values are evaluated through tpl(),
+# allowing Helm template expressions such as {{ .Release.Name }}.
+podAnnotations:
+  example.io/release: "{{ .Release.Name }}"
+  example.io/namespace: "{{ .Release.Namespace }}"

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
+{{ tpl (toYaml .Values.podAnnotations) . | indent 8 }}
         {{- end }}
     spec:
 {{- if .Values.securityContext }}


### PR DESCRIPTION
Allow Helm template expressions in `podAnnotations` by wrapping the existing `toYaml` call with `tpl()` in both `telegraf` and `telegraf-ds`.

This is backward compatible. Static annotation values are unaffected.