### PR TITLE
chore(ci): update k8s versions matrix

### DIFF
--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -8,8 +8,9 @@ jobs:
     strategy:
       matrix:
         node_image_version:
-          - v1.21.1
-          - v1.22.4
+          - v1.33.4
+          - v1.34.1
+          - v1.35.0
     name: lint-test (k8s ${{ matrix.node_image_version }})
     steps:
       - name: Checkout


### PR DESCRIPTION
CI uses k8s version 1.21 and 1.22. They EOL-ed in **2022**.
The Kubernetes project maintains release branches for the most recent three minor releases, i.e. 1.35, 1.34, 1.33.
This PR updates matrix accordingly.