### PR TITLE
fix(influxdb3-ent): replace deprecated environment variables

### DIFF
--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.2.0
-appVersion: "3.8.4"
+version: 0.3.0
+appVersion: "3.9.1"
 keywords:
   - influxdb
   - time-series

--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -3,7 +3,7 @@ name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
 version: 0.3.0
-appVersion: "3.9.1"
+appVersion: "3.9.2"
 keywords:
   - influxdb
   - time-series

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -482,6 +482,10 @@ logs:
 | `objectStorage.bucket` | Bucket/container name | `influxdb3-enterprise-data` |
 | `objectStorage.s3.region` | AWS region | `us-east-1` |
 | `objectStorage.s3.endpoint` | S3 endpoint (for S3-compatible) | `""` |
+| `objectStorage.requestTimeout` | Object store request timeout | `""` (server default `30s`) |
+| `objectStorage.tlsAllowInsecure` | Skip object-store TLS cert verification (testing only) | `false` |
+| `objectStorage.tlsCa.certPath` | Path to custom CA PEM file for object-store TLS verification | `""` |
+| `objectStorage.tlsCa.existingSecret` | Secret containing object-store CA PEM (`ca.crt`) | `""` |
 | `objectStorage.s3.accessKeyId` / `secretAccessKey` | S3 credentials | `""` |
 | `objectStorage.s3.sessionToken` | Optional session token | `""` |
 | `objectStorage.s3.credentialsFile` | Credentials file content (use `--set-file objectStorage.s3.credentialsFile=/path/to/file`) | `""` |

--- a/charts/influxdb3-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb3-enterprise/templates/_helpers.tpl
@@ -152,6 +152,18 @@ Validate Google object storage auth config
 {{- end }}
 
 {{/*
+Validate object store TLS CA config
+*/}}
+{{- define "influxdb3-enterprise.validateObjectStoreTlsCa" -}}
+{{- $tlsCa := .Values.objectStorage.tlsCa | default dict -}}
+{{- $certPath := get $tlsCa "certPath" | default "" -}}
+{{- $existingSecret := get $tlsCa "existingSecret" | default "" -}}
+{{- if and $certPath $existingSecret -}}
+{{- fail "Set only one of objectStorage.tlsCa.certPath or objectStorage.tlsCa.existingSecret." -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 License checksum (handles existingSecret via lookup)
 */}}
 {{- define "influxdb3-enterprise.licenseChecksum" -}}
@@ -327,6 +339,12 @@ Shared volume mounts (license/TLS/GCS and user extras)
   mountPath: /etc/influxdb/tls
   readOnly: true
 {{- end }}
+{{- $tlsCa := .Values.objectStorage.tlsCa | default dict }}
+{{- if get $tlsCa "existingSecret" }}
+- name: object-store-ca
+  mountPath: /etc/influxdb/object-store-ca
+  readOnly: true
+{{- end }}
 {{- with .Values.extraVolumeMounts }}
 {{ toYaml . }}
 {{- end }}
@@ -371,6 +389,15 @@ Shared volumes (license/TLS/GCS and user extras)
 - name: tls
   secret:
     secretName: {{ include "influxdb3-enterprise.tlsSecretName" . }}
+{{- end }}
+{{- $tlsCa := .Values.objectStorage.tlsCa | default dict }}
+{{- if get $tlsCa "existingSecret" }}
+- name: object-store-ca
+  secret:
+    secretName: {{ get $tlsCa "existingSecret" }}
+    items:
+      - key: ca.crt
+        path: ca.crt
 {{- end }}
 {{- with .Values.extraVolumes }}
 {{ toYaml . }}

--- a/charts/influxdb3-enterprise/templates/compactor-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/compactor-statefulset.yaml
@@ -112,7 +112,7 @@ spec:
             {{- end }}
             {{- with .Values.compactor.datafusion }}
             {{- if .numThreads }}
-            - name: INFLUXDB3_DATAFUSION_NUM_THREADS
+            - name: INFLUXDB3_NUM_DATAFUSION_THREADS
               value: {{ .numThreads | quote }}
             {{- end }}
             {{- if .maxParquetFanout }}

--- a/charts/influxdb3-enterprise/templates/configmap.yaml
+++ b/charts/influxdb3-enterprise/templates/configmap.yaml
@@ -53,22 +53,22 @@ data:
   INFLUXDB3_BUCKET: {{ .Values.objectStorage.bucket | quote }}
   {{- end }}
   {{- if .Values.objectStorage.connectionLimit }}
-  OBJECT_STORE_CONNECTION_LIMIT: {{ .Values.objectStorage.connectionLimit | quote }}
+  INFLUXDB3_OBJECT_STORE_CONNECTION_LIMIT: {{ .Values.objectStorage.connectionLimit | quote }}
   {{- end }}
   {{- if hasKey .Values.objectStorage "http2Only" }}
-  OBJECT_STORE_HTTP2_ONLY: {{ ternary "true" "false" .Values.objectStorage.http2Only | quote }}
+  INFLUXDB3_OBJECT_STORE_HTTP2_ONLY: {{ ternary "true" "false" .Values.objectStorage.http2Only | quote }}
   {{- end }}
   {{- if .Values.objectStorage.http2MaxFrameSize }}
-  OBJECT_STORE_HTTP2_MAX_FRAME_SIZE: {{ .Values.objectStorage.http2MaxFrameSize | quote }}
+  INFLUXDB3_OBJECT_STORE_HTTP2_MAX_FRAME_SIZE: {{ .Values.objectStorage.http2MaxFrameSize | quote }}
   {{- end }}
   {{- if .Values.objectStorage.maxRetries }}
-  OBJECT_STORE_MAX_RETRIES: {{ .Values.objectStorage.maxRetries | quote }}
+  INFLUXDB3_OBJECT_STORE_MAX_RETRIES: {{ .Values.objectStorage.maxRetries | quote }}
   {{- end }}
   {{- if .Values.objectStorage.retryTimeout }}
-  OBJECT_STORE_RETRY_TIMEOUT: {{ .Values.objectStorage.retryTimeout | quote }}
+  INFLUXDB3_OBJECT_STORE_RETRY_TIMEOUT: {{ .Values.objectStorage.retryTimeout | quote }}
   {{- end }}
   {{- if .Values.objectStorage.cacheEndpoint }}
-  OBJECT_STORE_CACHE_ENDPOINT: {{ .Values.objectStorage.cacheEndpoint | quote }}
+  INFLUXDB3_OBJECT_STORE_CACHE_ENDPOINT: {{ .Values.objectStorage.cacheEndpoint | quote }}
   {{- end }}
   {{- if eq .Values.objectStorage.type "s3" }}
   {{- $s3 := .Values.objectStorage.s3 | default dict }}
@@ -172,13 +172,13 @@ data:
   # Logs
   {{- with .Values.logs }}
   {{- if .logFilter }}
-  LOG_FILTER: {{ .logFilter | quote }}
+  INFLUXDB3_LOG_FILTER: {{ .logFilter | quote }}
   {{- end }}
   {{- if .logDestination }}
-  LOG_DESTINATION: {{ .logDestination | quote }}
+  INFLUXDB3_LOG_DESTINATION: {{ .logDestination | quote }}
   {{- end }}
   {{- if .logFormat }}
-  LOG_FORMAT: {{ .logFormat | quote }}
+  INFLUXDB3_LOG_FORMAT: {{ .logFormat | quote }}
   {{- end }}
   {{- if .queryLogSize }}
   INFLUXDB3_QUERY_LOG_SIZE: {{ .queryLogSize }}
@@ -187,28 +187,28 @@ data:
 
   # Tracing
   {{- with .Values.traces }}
-  TRACES_EXPORTER: {{ .exporter | quote }}
+  INFLUXDB3_TRACES_EXPORTER: {{ .exporter | quote }}
   {{- with .jaeger }}
   {{- if .agentHost }}
-  TRACES_EXPORTER_JAEGER_AGENT_HOST: {{ .agentHost | quote }}
+  INFLUXDB3_TRACES_EXPORTER_JAEGER_AGENT_HOST: {{ .agentHost | quote }}
   {{- end }}
   {{- if .agentPort }}
-  TRACES_EXPORTER_JAEGER_AGENT_PORT: {{ .agentPort | quote }}
+  INFLUXDB3_TRACES_EXPORTER_JAEGER_AGENT_PORT: {{ .agentPort | quote }}
   {{- end }}
   {{- if .serviceName }}
-  TRACES_EXPORTER_JAEGER_SERVICE_NAME: {{ .serviceName | quote }}
+  INFLUXDB3_TRACES_EXPORTER_JAEGER_SERVICE_NAME: {{ .serviceName | quote }}
   {{- end }}
   {{- if .traceContextHeaderName }}
-  TRACES_EXPORTER_JAEGER_TRACE_CONTEXT_HEADER_NAME: {{ .traceContextHeaderName | quote }}
+  INFLUXDB3_TRACES_EXPORTER_JAEGER_TRACE_CONTEXT_HEADER_NAME: {{ .traceContextHeaderName | quote }}
   {{- end }}
   {{- if .debugName }}
-  TRACES_EXPORTER_JAEGER_DEBUG_NAME: {{ .debugName | quote }}
+  INFLUXDB3_TRACES_JAEGER_DEBUG_NAME: {{ .debugName | quote }}
   {{- end }}
   {{- if .tags }}
-  TRACES_EXPORTER_JAEGER_TAGS: {{ .tags | quote }}
+  INFLUXDB3_TRACES_JAEGER_TAGS: {{ .tags | quote }}
   {{- end }}
   {{- if .maxMsgsPerSecond }}
-  TRACES_JAEGER_MAX_MSGS_PER_SECOND: {{ .maxMsgsPerSecond | quote }}
+  INFLUXDB3_TRACES_JAEGER_MAX_MSGS_PER_SECOND: {{ .maxMsgsPerSecond | quote }}
   {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/influxdb3-enterprise/templates/configmap.yaml
+++ b/charts/influxdb3-enterprise/templates/configmap.yaml
@@ -2,6 +2,7 @@
 {{- include "influxdb3-enterprise.validateAzureObjectStorageAuth" . }}
 {{- include "influxdb3-enterprise.validateS3ObjectStorageAuth" . }}
 {{- include "influxdb3-enterprise.validateGoogleObjectStorageAuth" . }}
+{{- include "influxdb3-enterprise.validateObjectStoreTlsCa" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -60,6 +61,18 @@ data:
   {{- end }}
   {{- if .Values.objectStorage.http2MaxFrameSize }}
   INFLUXDB3_OBJECT_STORE_HTTP2_MAX_FRAME_SIZE: {{ .Values.objectStorage.http2MaxFrameSize | quote }}
+  {{- end }}
+  {{- if .Values.objectStorage.requestTimeout }}
+  INFLUXDB3_OBJECT_STORE_REQUEST_TIMEOUT: {{ .Values.objectStorage.requestTimeout | quote }}
+  {{- end }}
+  {{- if hasKey .Values.objectStorage "tlsAllowInsecure" }}
+  INFLUXDB3_OBJECT_STORE_TLS_ALLOW_INSECURE: {{ ternary "true" "false" .Values.objectStorage.tlsAllowInsecure | quote }}
+  {{- end }}
+  {{- $tlsCa := .Values.objectStorage.tlsCa | default dict }}
+  {{- if get $tlsCa "certPath" }}
+  INFLUXDB3_OBJECT_STORE_TLS_CA: {{ get $tlsCa "certPath" | quote }}
+  {{- else if get $tlsCa "existingSecret" }}
+  INFLUXDB3_OBJECT_STORE_TLS_CA: "/etc/influxdb/object-store-ca/ca.crt"
   {{- end }}
   {{- if .Values.objectStorage.maxRetries }}
   INFLUXDB3_OBJECT_STORE_MAX_RETRIES: {{ .Values.objectStorage.maxRetries | quote }}

--- a/charts/influxdb3-enterprise/templates/configmap.yaml
+++ b/charts/influxdb3-enterprise/templates/configmap.yaml
@@ -202,10 +202,10 @@ data:
   INFLUXDB3_TRACES_EXPORTER_JAEGER_TRACE_CONTEXT_HEADER_NAME: {{ .traceContextHeaderName | quote }}
   {{- end }}
   {{- if .debugName }}
-  INFLUXDB3_TRACES_JAEGER_DEBUG_NAME: {{ .debugName | quote }}
+  INFLUXDB3_TRACES_EXPORTER_JAEGER_DEBUG_NAME: {{ .debugName | quote }}
   {{- end }}
   {{- if .tags }}
-  INFLUXDB3_TRACES_JAEGER_TAGS: {{ .tags | quote }}
+  INFLUXDB3_TRACES_EXPORTER_JAEGER_TAGS: {{ .tags | quote }}
   {{- end }}
   {{- if .maxMsgsPerSecond }}
   INFLUXDB3_TRACES_JAEGER_MAX_MSGS_PER_SECOND: {{ .maxMsgsPerSecond | quote }}

--- a/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
@@ -103,7 +103,7 @@ spec:
             {{- end }}
             {{- with .Values.ingester.datafusion }}
             {{- if .numThreads }}
-            - name: INFLUXDB3_DATAFUSION_NUM_THREADS
+            - name: INFLUXDB3_NUM_DATAFUSION_THREADS
               value: {{ .numThreads | quote }}
             {{- end }}
             {{- if .maxParquetFanout }}

--- a/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
@@ -113,7 +113,7 @@ spec:
             {{- end }}
             {{- with .Values.processingEngine.datafusion }}
             {{- if .numThreads }}
-            - name: INFLUXDB3_DATAFUSION_NUM_THREADS
+            - name: INFLUXDB3_NUM_DATAFUSION_THREADS
               value: {{ .numThreads | quote }}
             {{- end }}
             {{- if .maxParquetFanout }}

--- a/charts/influxdb3-enterprise/templates/querier-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/querier-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
             {{- end }}
             {{- with .Values.querier.datafusion }}
             {{- if .numThreads }}
-            - name: INFLUXDB3_DATAFUSION_NUM_THREADS
+            - name: INFLUXDB3_NUM_DATAFUSION_THREADS
               value: {{ .numThreads | quote }}
             {{- end }}
             {{- if .maxParquetFanout }}

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -49,9 +49,15 @@ objectStorage:
   # connectionLimit: 16             # Max connections to object store (doc default 16)
   # http2Only: false                # Force HTTP/2 connections (optional)
   # http2MaxFrameSize: ""           # HTTP/2 max frame size (optional)
+  # requestTimeout: ""              # Object store request timeout (optional, server default: 30s)
   # maxRetries: ""                  # Object store retry attempts (optional)
   # retryTimeout: ""                # Object store retry timeout (optional)
   # cacheEndpoint: ""               # Object store cache endpoint (optional)
+  # tlsAllowInsecure: false         # Skip object-store TLS cert verification (testing only)
+  # tlsCa:
+  #   certPath: ""                  # Path to custom CA PEM file for object-store TLS verification
+  #   existingSecret: ""            # Alternative to certPath; secret with key "ca.crt"
+  # NOTE: set only one of tlsCa.certPath or tlsCa.existingSecret
 
   # S3 and S3-compatible storage (MinIO, etc.)
   s3:


### PR DESCRIPTION
Closes #781 , #787

* updates InfluxDB to the latest version available (3.9.2, per https://hub.docker.com/_/influxdb)
*  replace deprecated environment variables
   * including those previously not emitted