### PR TITLE
fix: keep EXPORTER segment in two Jaeger env names

### DIFF
--- a/charts/influxdb3-enterprise/templates/configmap.yaml
+++ b/charts/influxdb3-enterprise/templates/configmap.yaml
@@ -202,10 +202,10 @@ data:
   INFLUXDB3_TRACES_EXPORTER_JAEGER_TRACE_CONTEXT_HEADER_NAME: {{ .traceContextHeaderName | quote }}
   {{- end }}
   {{- if .debugName }}
-  INFLUXDB3_TRACES_JAEGER_DEBUG_NAME: {{ .debugName | quote }}
+  INFLUXDB3_TRACES_EXPORTER_JAEGER_DEBUG_NAME: {{ .debugName | quote }}
   {{- end }}
   {{- if .tags }}
-  INFLUXDB3_TRACES_JAEGER_TAGS: {{ .tags | quote }}
+  INFLUXDB3_TRACES_EXPORTER_JAEGER_TAGS: {{ .tags | quote }}
   {{- end }}
   {{- if .maxMsgsPerSecond }}
   INFLUXDB3_TRACES_JAEGER_MAX_MSGS_PER_SECOND: {{ .maxMsgsPerSecond | quote }}


### PR DESCRIPTION
## Summary
Two of the Jaeger env vars in this PR drop the `EXPORTER_` segment. The InfluxDB 3 server actually reads these names with `EXPORTER_` retained:

| current (this PR) | server reads |
| --- | --- |
| `INFLUXDB3_TRACES_JAEGER_DEBUG_NAME` | `INFLUXDB3_TRACES_EXPORTER_JAEGER_DEBUG_NAME` |
| `INFLUXDB3_TRACES_JAEGER_TAGS` | `INFLUXDB3_TRACES_EXPORTER_JAEGER_TAGS` |

The CLI flag (`--traces-jaeger-debug-name`, `--traces-jaeger-tags`) does drop `exporter`, but the env var keeps it — that divergence is in the InfluxDB source.

Verified at influxdata/influxdb tag `v3.9.2` (`influxdb3_startup::env_compat::ENV_ALIASES` and `core/trace_exporters/src/lib.rs`).

The docs that originally led to this naming have been corrected in influxdata/docs-v2#7182.

Targeting `fix/ent-v3-envvars` so this folds into #783 before it ships.

Refs influxdata/DAR#686