### PR TITLE
chore(ci): update k8s matrix

### DIFF
--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -8,8 +8,9 @@ jobs:
     strategy:
       matrix:
         node_image_version:
-          - v1.21.1
-          - v1.22.4
+          - v1.33.10
+          - v1.34.6
+          - v1.35.3
     name: lint-test (k8s ${{ matrix.node_image_version }})
     steps:
       - name: Checkout

--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -8,9 +8,8 @@ jobs:
     strategy:
       matrix:
         node_image_version:
-          - v1.33.10
-          - v1.34.6
-          - v1.35.3
+          - v1.31.14
+          - v1.36.1
     name: lint-test (k8s ${{ matrix.node_image_version }})
     steps:
       - name: Checkout


### PR DESCRIPTION
CI uses **really** obsolete k8s versions (1.22 EOL was late 2022!). This PR updates the test matrix to currently supported versions:
  - 1.36 - current stable
  - 1.31 - 22 months old - conservative enterprise baseline; eg. has extended support and ends on AWS on November 26, 2026