### PR TITLE
fix: processor plugins PVC and mount rendering

### DIFF
--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "3.9.2"
 keywords:
   - influxdb

--- a/charts/influxdb3-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb3-enterprise/templates/_helpers.tpl
@@ -365,7 +365,7 @@ Processor plugin volume mounts (chart-managed plugins PVC or shared mounts)
 - name: plugins
   mountPath: {{ $pluginDir }}
 {{- end }}
-{{- include "influxdb3-enterprise.sharedVolumeMounts" $root }}
+{{ include "influxdb3-enterprise.sharedVolumeMounts" $root }}
 {{- end }}
 
 {{/*

--- a/charts/influxdb3-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb3-enterprise/templates/_helpers.tpl
@@ -383,7 +383,7 @@ Whether processor pluginDir is actually mounted by processorPluginVolumeMounts
 {{- $mounts := include "influxdb3-enterprise.processorPluginVolumeMounts" . -}}
 {{- $pluginDir := .pluginDir | default "/plugins" -}}
 {{- $needle := printf "mountPath: %s\n" $pluginDir -}}
-{{- if contains $needle $mounts -}}
+{{- if contains $needle (printf "%s\n" $mounts) -}}
 true
 {{- else -}}
 false

--- a/charts/influxdb3-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb3-enterprise/templates/_helpers.tpl
@@ -352,6 +352,45 @@ Shared volume mounts (license/TLS/GCS and user extras)
 {{- end }}
 
 {{/*
+Processor plugin volume mounts (chart-managed plugins PVC or shared mounts)
+*/}}
+{{- define "influxdb3-enterprise.processorPluginVolumeMounts" -}}
+{{- $pluginsPVCEnabled := true -}}
+{{- if hasKey . "pluginsPVCEnabled" -}}
+{{- $pluginsPVCEnabled = (get . "pluginsPVCEnabled") -}}
+{{- end -}}
+{{- $pluginDir := .pluginDir | default "/plugins" -}}
+{{- $root := .root -}}
+{{- if $pluginsPVCEnabled }}
+- name: plugins
+  mountPath: {{ $pluginDir }}
+{{- end }}
+{{- include "influxdb3-enterprise.sharedVolumeMounts" $root }}
+{{- end }}
+
+{{/*
+Whether processor plugin volume mounts are present
+*/}}
+{{- define "influxdb3-enterprise.hasProcessorPluginVolumeMounts" -}}
+{{- $mounts := include "influxdb3-enterprise.processorPluginVolumeMounts" . | trim -}}
+{{- ternary "true" "false" (ne $mounts "") -}}
+{{- end }}
+
+{{/*
+Whether processor pluginDir is actually mounted by processorPluginVolumeMounts
+*/}}
+{{- define "influxdb3-enterprise.hasProcessorPluginDirMount" -}}
+{{- $mounts := include "influxdb3-enterprise.processorPluginVolumeMounts" . -}}
+{{- $pluginDir := .pluginDir | default "/plugins" -}}
+{{- $needle := printf "mountPath: %s\n" $pluginDir -}}
+{{- if contains $needle $mounts -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end }}
+
+{{/*
 Shared volumes (license/TLS/GCS and user extras)
 */}}
 {{- define "influxdb3-enterprise.sharedVolumes" -}}

--- a/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
@@ -5,7 +5,9 @@
 {{- $pluginsPVCEnabled = (get $processorPersistence "enabled") }}
 {{- end }}
 {{- $pluginVolumeMountCtx := dict "root" . "pluginsPVCEnabled" $pluginsPVCEnabled "pluginDir" (.Values.processingEngine.pluginDir | default "/plugins") }}
-{{- if and (not $pluginsPVCEnabled) .Values.processingEngine.initPlugins (gt (len .Values.processingEngine.initPlugins) 0) (ne (include "influxdb3-enterprise.hasProcessorPluginDirMount" $pluginVolumeMountCtx) "true") }}
+{{- $hasProcessorPluginVolumeMounts := eq (include "influxdb3-enterprise.hasProcessorPluginVolumeMounts" $pluginVolumeMountCtx) "true" }}
+{{- $hasProcessorPluginDirMount := eq (include "influxdb3-enterprise.hasProcessorPluginDirMount" $pluginVolumeMountCtx) "true" }}
+{{- if and (not $pluginsPVCEnabled) .Values.processingEngine.initPlugins (gt (len .Values.processingEngine.initPlugins) 0) (not $hasProcessorPluginDirMount) }}
 {{- fail "processingEngine.initPlugins requires processingEngine.pluginDir to be mounted. Set processingEngine.persistence.enabled=true or configure extraVolumes/extraVolumeMounts to mount processingEngine.pluginDir." }}
 {{- end }}
 
@@ -55,7 +57,7 @@ spec:
             - -c
             - >
               influxdb3 install package {{ .name | quote }}{{- if .source }} --source {{ .source | quote }}{{- end }} --plugin-dir {{ $.Values.processingEngine.pluginDir | default "/plugins" | quote }}
-          {{- if eq (include "influxdb3-enterprise.hasProcessorPluginVolumeMounts" $pluginVolumeMountCtx) "true" }}
+          {{- if $hasProcessorPluginVolumeMounts }}
           volumeMounts:
             {{- include "influxdb3-enterprise.processorPluginVolumeMounts" $pluginVolumeMountCtx | nindent 12 }}
           {{- end }}
@@ -146,7 +148,7 @@ spec:
           {{- include "influxdb3-enterprise.probes" . | nindent 10 }}
           resources:
             {{- toYaml .Values.processingEngine.resources | nindent 12 }}
-          {{- if eq (include "influxdb3-enterprise.hasProcessorPluginVolumeMounts" $pluginVolumeMountCtx) "true" }}
+          {{- if $hasProcessorPluginVolumeMounts }}
           volumeMounts:
             {{- include "influxdb3-enterprise.processorPluginVolumeMounts" $pluginVolumeMountCtx | nindent 12 }}
           {{- end }}

--- a/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.processingEngine.enabled }}
+{{- $processorPersistence := .Values.processingEngine.persistence | default dict }}
+{{- $pluginsPVCEnabled := true }}
+{{- if hasKey $processorPersistence "enabled" }}
+{{- $pluginsPVCEnabled = (get $processorPersistence "enabled") }}
+{{- end }}
+
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -46,8 +52,10 @@ spec:
             - >
               influxdb3 install package {{ .name | quote }}{{- if .source }} --source {{ .source | quote }}{{- end }} --plugin-dir {{ $.Values.processingEngine.pluginDir | default "/plugins" | quote }}
           volumeMounts:
+            {{- if $pluginsPVCEnabled }}
             - name: plugins
               mountPath: {{ $.Values.processingEngine.pluginDir | default "/plugins" }}
+            {{- end }}
         {{- end }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
@@ -136,8 +144,10 @@ spec:
           resources:
             {{- toYaml .Values.processingEngine.resources | nindent 12 }}
           volumeMounts:
+            {{- if $pluginsPVCEnabled }}
             - name: plugins
               mountPath: {{ .Values.processingEngine.pluginDir | default "/plugins" }}
+            {{- end }}
             {{ include "influxdb3-enterprise.sharedVolumeMounts" . | nindent 12 }}
       {{- with .Values.processingEngine.nodeSelector }}
       nodeSelector:
@@ -153,6 +163,7 @@ spec:
       {{- end }}
       volumes:
         {{ include "influxdb3-enterprise.sharedVolumes" . | nindent 8 }}
+  {{- if $pluginsPVCEnabled }}
   volumeClaimTemplates:
     - metadata:
         name: plugins
@@ -165,4 +176,5 @@ spec:
         resources:
           requests:
             storage: {{ .Values.processingEngine.persistence.size }}
+  {{- end }}
 {{- end }}

--- a/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
@@ -4,6 +4,10 @@
 {{- if hasKey $processorPersistence "enabled" }}
 {{- $pluginsPVCEnabled = (get $processorPersistence "enabled") }}
 {{- end }}
+{{- $pluginVolumeMountCtx := dict "root" . "pluginsPVCEnabled" $pluginsPVCEnabled "pluginDir" (.Values.processingEngine.pluginDir | default "/plugins") }}
+{{- if and (not $pluginsPVCEnabled) .Values.processingEngine.initPlugins (gt (len .Values.processingEngine.initPlugins) 0) (ne (include "influxdb3-enterprise.hasProcessorPluginDirMount" $pluginVolumeMountCtx) "true") }}
+{{- fail "processingEngine.initPlugins requires processingEngine.pluginDir to be mounted. Set processingEngine.persistence.enabled=true or configure extraVolumes/extraVolumeMounts to mount processingEngine.pluginDir." }}
+{{- end }}
 
 apiVersion: apps/v1
 kind: StatefulSet
@@ -51,11 +55,10 @@ spec:
             - -c
             - >
               influxdb3 install package {{ .name | quote }}{{- if .source }} --source {{ .source | quote }}{{- end }} --plugin-dir {{ $.Values.processingEngine.pluginDir | default "/plugins" | quote }}
+          {{- if eq (include "influxdb3-enterprise.hasProcessorPluginVolumeMounts" $pluginVolumeMountCtx) "true" }}
           volumeMounts:
-            {{- if $pluginsPVCEnabled }}
-            - name: plugins
-              mountPath: {{ $.Values.processingEngine.pluginDir | default "/plugins" }}
-            {{- end }}
+            {{- include "influxdb3-enterprise.processorPluginVolumeMounts" $pluginVolumeMountCtx | nindent 12 }}
+          {{- end }}
         {{- end }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
@@ -143,12 +146,10 @@ spec:
           {{- include "influxdb3-enterprise.probes" . | nindent 10 }}
           resources:
             {{- toYaml .Values.processingEngine.resources | nindent 12 }}
+          {{- if eq (include "influxdb3-enterprise.hasProcessorPluginVolumeMounts" $pluginVolumeMountCtx) "true" }}
           volumeMounts:
-            {{- if $pluginsPVCEnabled }}
-            - name: plugins
-              mountPath: {{ .Values.processingEngine.pluginDir | default "/plugins" }}
-            {{- end }}
-            {{ include "influxdb3-enterprise.sharedVolumeMounts" . | nindent 12 }}
+            {{- include "influxdb3-enterprise.processorPluginVolumeMounts" $pluginVolumeMountCtx | nindent 12 }}
+          {{- end }}
       {{- with .Values.processingEngine.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -461,6 +461,7 @@ processingEngine:
 
   # Persistent storage for plugins
   persistence:
+    enabled: true
     storageClass: ""
     size: "5Gi"
     accessMode: ReadWriteOnce


### PR DESCRIPTION
Closes #785 

Previously, the chart still rendered the processor plugins PVC template and /plugins `volumeMount` unconditionally, which caused duplicate `mountPath` conflicts when users mounted a shared plugin volume via `extraVolumes`/`extraVolumeMounts`.

Now, when `processingEngine.persistence.enabled=false`, the chart skips both the processor plugins `volumeClaimTemplates` and the chart-owned `/plugins` mounts, allowing external shared plugin volumes to be mounted cleanly.