### PR TITLE
feat(influxdb3-ent): add bootstrap token support

### DIFF
--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -64,9 +64,15 @@ jobs:
 
       - name: Create Enterprise V3 Test Resources
         run: |
+          kubectl create secret generic influxdb3-license \
+            --namespace=default \
+            --from-literal=license-email=${INFLUXDB3_ENTERPRISE_TRIAL_LICENSE_EMAIL}
           kubectl create secret generic influxdb3-bootstrap-tokens \
+            --namespace=default \
             --from-file=admin-token.json=./charts/influxdb3-enterprise/ci/admin-token.json \
             --from-file=permission-tokens.json=./charts/influxdb3-enterprise/ci/permission-tokens.json
+        env:
+          INFLUXDB3_ENTERPRISE_TRIAL_LICENSE_EMAIL: "${{ secrets.INFLUXDB3_ENTERPRISE_TRIAL_LICENSE_EMAIL }}"
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -62,6 +62,13 @@ jobs:
           INFLUXDB_ENTERPRISE_LICENSE_KEY: "${{ secrets.INFLUXDB_ENTERPRISE_LICENSE_KEY }}"
         if: steps.list-changed.outputs.changed == 'true'
 
+      - name: Create Enterprise V3 Test Resources
+        run: |
+          kubectl create secret generic influxdb3-bootstrap-tokens \
+            --from-file=admin-token.json=./charts/influxdb3-enterprise/ci/admin-token.json \
+            --from-file=permission-tokens.json=./charts/influxdb3-enterprise/ci/permission-tokens.json
+        if: steps.list-changed.outputs.changed == 'true'
+
       - name: Run chart-testing (install)
         id: install
         run: |

--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -78,6 +78,7 @@ jobs:
       - name: Run chart-testing (install)
         id: install
         run: |
+          set -o pipefail
           ct install --namespace=default --target-branch=master 2>&1 | tee $RUNNER_TEMP/$GITHUB_RUN_NUMBER.txt
 # When https://github.com/helm/chart-testing/issues/212 is fixed, this can be used to set the license key instead of using env from secret
 #        run: ct install --namespace=default --helm-extra-args="--set license.key=${INFLUXDB_ENTERPRISE_LICENSE_KEY}"

--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.6.3
+          version: v3.16.4
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Run chart-testing (install)
         id: install
         run: |
-          ct install --namespace=default 2>&1 | tee $RUNNER_TEMP/$GITHUB_RUN_NUMBER.txt
+          ct install --namespace=default --target-branch=master 2>&1 | tee $RUNNER_TEMP/$GITHUB_RUN_NUMBER.txt
 # When https://github.com/helm/chart-testing/issues/212 is fixed, this can be used to set the license key instead of using env from secret
 #        run: ct install --namespace=default --helm-extra-args="--set license.key=${INFLUXDB_ENTERPRISE_LICENSE_KEY}"
 #        env:

--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.3.2
+version: 0.4.0
 appVersion: "3.9.2"
 keywords:
   - influxdb

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -102,6 +102,36 @@ At minimum, you must configure:
          - host: query.your-domain.com
    ```
 
+### Preconfigured Admin Token
+
+Use this when you want the cluster to start with a known offline-generated admin token.
+
+1. Generate an offline admin token file:
+   ```bash
+   influxdb3 create token --admin --name bootstrap-admin --expiry 365d --offline --output-file admin-token.json
+   chmod 600 admin-token.json
+   ```
+
+2. Create a Kubernetes secret from that file:
+   ```bash
+   kubectl -n influxdb3 create secret generic influxdb3-admin-token \
+     --from-file=admin-token.json=admin-token.json
+   ```
+
+3. Configure the chart:
+   ```yaml
+   security:
+     auth:
+       adminToken:
+         existingSecret: influxdb3-admin-token
+   ```
+
+Notes:
+- Secret key must be `admin-token.json`.
+- The chart mounts it at `/etc/influxdb/admin-token/admin-token.json`.
+- `security.auth.adminToken.existingSecret` and `security.auth.adminToken.file` are mutually exclusive.
+- If using `security.auth.adminToken.file`, ensure that path exists inside the container (for example via `extraVolumes`/`extraVolumeMounts`).
+
 ## Configuration
 
 ### Component Architecture
@@ -473,6 +503,10 @@ logs:
 | `license.email` | Email for trial/home | `""` |
 | `license.file` | License file content (use `--set-file license.file=/path/to/file`) | `""` |
 | `license.existingSecret` | Secret with `license-email` or `license-file` | `""` |
+| `security.auth.adminToken.existingSecret` | Secret with offline admin token key `admin-token.json` | `""` |
+| `security.auth.adminToken.file` | Path to offline admin token file; mutually exclusive with `security.auth.adminToken.existingSecret` | `""` |
+| `security.auth.permissionTokens.existingSecret` | Secret with offline permission tokens key `permission-tokens.json` | `""` |
+| `security.auth.permissionTokens.file` | Path to offline permission tokens file; mutually exclusive with `security.auth.permissionTokens.existingSecret` | `""` |
 
 ### Object Storage Parameters
 

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -134,6 +134,30 @@ Notes:
 - `security.auth.adminToken.recovery.httpBind` enables an unauthenticated recovery endpoint. Use only when necessary and keep it accessible only from trusted networks.
 - See: https://docs.influxdata.com/influxdb3/enterprise/reference/config-options/#admin-token-recovery-http-bind
 
+### Preconfigured Permission Tokens
+
+Use this when you want the cluster to start with known offline-generated permission tokens.
+
+1. Generate an offline permission tokens file.
+2. Create a Kubernetes secret from that file:
+   ```bash
+   kubectl -n influxdb3 create secret generic influxdb3-permission-tokens \
+     --from-file=permission-tokens.json=permission-tokens.json
+   ```
+3. Configure the chart:
+   ```yaml
+   security:
+     auth:
+       permissionTokens:
+         existingSecret: influxdb3-permission-tokens
+   ```
+
+Notes:
+- Secret key must be `permission-tokens.json`.
+- The chart mounts it at `/etc/influxdb/permission-tokens/permission-tokens.json`.
+- `security.auth.permissionTokens.existingSecret` and `security.auth.permissionTokens.file` are mutually exclusive.
+- See: https://docs.influxdata.com/influxdb3/enterprise/reference/config-options/#permission-tokens-file
+
 ## Configuration
 
 ### Component Architecture

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -109,7 +109,6 @@ Use this when you want the cluster to start with a known offline-generated admin
 1. Generate an offline admin token file:
    ```bash
    influxdb3 create token --admin --name bootstrap-admin --expiry 365d --offline --output-file admin-token.json
-   chmod 600 admin-token.json
    ```
 
 2. Create a Kubernetes secret from that file:
@@ -138,7 +137,17 @@ Notes:
 
 Use this when you want the cluster to start with known offline-generated permission tokens.
 
-1. Generate an offline permission tokens file.
+1. Generate an offline permission tokens file:
+   ```bash
+   influxdb3 create token \
+     --name "bootstrap-token" \
+     --permission "db:db1,db2:read,write" \
+     --permission "db:db3:read" \
+     --expiry 365d \
+     --offline \
+     --create-databases db1,db2 \
+     --output-file permission-tokens.json
+   ```
 2. Create a Kubernetes secret from that file:
    ```bash
    kubectl -n influxdb3 create secret generic influxdb3-permission-tokens \

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -131,6 +131,8 @@ Notes:
 - The chart mounts it at `/etc/influxdb/admin-token/admin-token.json`.
 - `security.auth.adminToken.existingSecret` and `security.auth.adminToken.file` are mutually exclusive.
 - If using `security.auth.adminToken.file`, ensure that path exists inside the container (for example via `extraVolumes`/`extraVolumeMounts`).
+- `security.auth.adminToken.recovery.httpBind` enables an unauthenticated recovery endpoint. Use only when necessary and keep it accessible only from trusted networks.
+- See: https://docs.influxdata.com/influxdb3/enterprise/reference/config-options/#admin-token-recovery-http-bind
 
 ## Configuration
 

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -507,6 +507,7 @@ logs:
 | `security.auth.adminToken.file` | Path to offline admin token file; mutually exclusive with `security.auth.adminToken.existingSecret` | `""` |
 | `security.auth.permissionTokens.existingSecret` | Secret with offline permission tokens key `permission-tokens.json` | `""` |
 | `security.auth.permissionTokens.file` | Path to offline permission tokens file; mutually exclusive with `security.auth.permissionTokens.existingSecret` | `""` |
+| `security.auth.adminToken.recovery.httpBind` | Bind address for admin token recovery endpoint (`INFLUXDB3_ADMIN_TOKEN_RECOVERY_HTTP_BIND`) | `""` |
 
 ### Object Storage Parameters
 

--- a/charts/influxdb3-enterprise/ci/admin-token.json
+++ b/charts/influxdb3-enterprise/ci/admin-token.json
@@ -1,0 +1,5 @@
+{
+  "token": "apiv3_2_sms_SzgiOB9nD2u7SSOf0GdQyBFCW67COcFn4ng2d0JEC8FBeyNXXaDVsCVbCX5iAy4teDtXoUJjY1YC2rQQ",
+  "name": "example-admin-token",
+  "expiry_millis": 1914080061529
+}

--- a/charts/influxdb3-enterprise/ci/admin-token.json
+++ b/charts/influxdb3-enterprise/ci/admin-token.json
@@ -1,5 +1,5 @@
 {
-  "token": "apiv3_2_sms_SzgiOB9nD2u7SSOf0GdQyBFCW67COcFn4ng2d0JEC8FBeyNXXaDVsCVbCX5iAy4teDtXoUJjY1YC2rQQ",
+  "token": "apiv3_ci_test_only_not_a_real_secret_token_000000000000000000000000000000000000",
   "name": "example-admin-token",
   "expiry_millis": 1914080061529
 }

--- a/charts/influxdb3-enterprise/ci/auth-existing-secret-values.yaml
+++ b/charts/influxdb3-enterprise/ci/auth-existing-secret-values.yaml
@@ -1,6 +1,3 @@
-license:
-  email: "dburton+test@influxdata.com"
-
 objectStorage:
   type: memory
 

--- a/charts/influxdb3-enterprise/ci/auth-existing-secret-values.yaml
+++ b/charts/influxdb3-enterprise/ci/auth-existing-secret-values.yaml
@@ -1,3 +1,6 @@
+license:
+  existingSecret: influxdb3-license
+
 objectStorage:
   type: memory
 

--- a/charts/influxdb3-enterprise/ci/auth-existing-secret-values.yaml
+++ b/charts/influxdb3-enterprise/ci/auth-existing-secret-values.yaml
@@ -1,0 +1,60 @@
+license:
+  email: "dburton+test@influxdata.com"
+
+objectStorage:
+  type: memory
+
+ingress:
+  enabled: false
+
+ingester:
+  replicas: 2
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+  persistence:
+    enabled: false
+
+querier:
+  replicas: 2
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+
+compactor:
+  replicas: 1
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+
+processingEngine:
+  enabled: true
+  replicas: 1
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+  persistence:
+    enabled: false
+
+security:
+  auth:
+    adminToken:
+      existingSecret: influxdb3-bootstrap-tokens
+    permissionTokens:
+      existingSecret: influxdb3-bootstrap-tokens

--- a/charts/influxdb3-enterprise/ci/auth-existing-secret-values.yaml
+++ b/charts/influxdb3-enterprise/ci/auth-existing-secret-values.yaml
@@ -8,7 +8,7 @@ ingress:
   enabled: false
 
 ingester:
-  replicas: 2
+  replicas: 1
   resources:
     requests:
       cpu: "250m"
@@ -20,7 +20,7 @@ ingester:
     enabled: false
 
 querier:
-  replicas: 2
+  replicas: 1
   resources:
     requests:
       cpu: "250m"

--- a/charts/influxdb3-enterprise/ci/auth-file-values.yaml
+++ b/charts/influxdb3-enterprise/ci/auth-file-values.yaml
@@ -1,6 +1,3 @@
-license:
-  email: "dburton+test@influxdata.com"
-
 objectStorage:
   type: memory
 

--- a/charts/influxdb3-enterprise/ci/auth-file-values.yaml
+++ b/charts/influxdb3-enterprise/ci/auth-file-values.yaml
@@ -1,3 +1,6 @@
+license:
+  existingSecret: influxdb3-license
+
 objectStorage:
   type: memory
 

--- a/charts/influxdb3-enterprise/ci/auth-file-values.yaml
+++ b/charts/influxdb3-enterprise/ci/auth-file-values.yaml
@@ -1,0 +1,70 @@
+license:
+  email: "dburton+test@influxdata.com"
+
+objectStorage:
+  type: memory
+
+ingress:
+  enabled: false
+
+ingester:
+  replicas: 2
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+  persistence:
+    enabled: false
+
+querier:
+  replicas: 2
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+
+compactor:
+  replicas: 1
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+
+processingEngine:
+  enabled: true
+  replicas: 1
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+  persistence:
+    enabled: false
+
+security:
+  auth:
+    adminToken:
+      file: /etc/influxdb/bootstrap/admin-token.json
+    permissionTokens:
+      file: /etc/influxdb/bootstrap/permission-tokens.json
+
+extraVolumes:
+  - name: bootstrap-tokens
+    secret:
+      secretName: influxdb3-bootstrap-tokens
+
+extraVolumeMounts:
+  - name: bootstrap-tokens
+    mountPath: /etc/influxdb/bootstrap
+    readOnly: true

--- a/charts/influxdb3-enterprise/ci/auth-file-values.yaml
+++ b/charts/influxdb3-enterprise/ci/auth-file-values.yaml
@@ -8,7 +8,7 @@ ingress:
   enabled: false
 
 ingester:
-  replicas: 2
+  replicas: 1
   resources:
     requests:
       cpu: "250m"
@@ -20,7 +20,7 @@ ingester:
     enabled: false
 
 querier:
-  replicas: 2
+  replicas: 1
   resources:
     requests:
       cpu: "250m"

--- a/charts/influxdb3-enterprise/ci/default-values.yaml
+++ b/charts/influxdb3-enterprise/ci/default-values.yaml
@@ -1,0 +1,53 @@
+license:
+  email: "dburton+test@influxdata.com"
+
+objectStorage:
+  type: memory
+
+ingress:
+  enabled: false
+
+ingester:
+  replicas: 2
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+  persistence:
+    enabled: false
+
+querier:
+  replicas: 2
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+
+compactor:
+  replicas: 1
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+
+processingEngine:
+  enabled: true
+  replicas: 1
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+  persistence:
+    enabled: false

--- a/charts/influxdb3-enterprise/ci/default-values.yaml
+++ b/charts/influxdb3-enterprise/ci/default-values.yaml
@@ -1,6 +1,3 @@
-license:
-  email: "dburton+test@influxdata.com"
-
 objectStorage:
   type: memory
 

--- a/charts/influxdb3-enterprise/ci/default-values.yaml
+++ b/charts/influxdb3-enterprise/ci/default-values.yaml
@@ -1,3 +1,6 @@
+license:
+  existingSecret: influxdb3-license
+
 objectStorage:
   type: memory
 

--- a/charts/influxdb3-enterprise/ci/default-values.yaml
+++ b/charts/influxdb3-enterprise/ci/default-values.yaml
@@ -8,7 +8,7 @@ ingress:
   enabled: false
 
 ingester:
-  replicas: 2
+  replicas: 1
   resources:
     requests:
       cpu: "250m"
@@ -20,7 +20,7 @@ ingester:
     enabled: false
 
 querier:
-  replicas: 2
+  replicas: 1
   resources:
     requests:
       cpu: "250m"

--- a/charts/influxdb3-enterprise/ci/permission-tokens.json
+++ b/charts/influxdb3-enterprise/ci/permission-tokens.json
@@ -1,0 +1,18 @@
+{
+  "create_databases": [
+    "db1",
+    "db2",
+    "db3"
+  ],
+  "tokens": [
+    {
+      "token": "apiv3_iwm47dJlXDF2wYSazrJHONCuvmJ1Th3Bgh0xNs4RIIS7q4mjGZ3J7103mqMcdm2c5y2ZlZ61bmwECuso8oJDbQ",
+      "name": "example-token",
+      "expiry_millis": 1914080061529,
+      "permissions": [
+        "db:db1,db2:read,write",
+        "db:db3:read"
+      ]
+    }
+  ]
+}

--- a/charts/influxdb3-enterprise/ci/permission-tokens.json
+++ b/charts/influxdb3-enterprise/ci/permission-tokens.json
@@ -6,7 +6,7 @@
   ],
   "tokens": [
     {
-      "token": "apiv3_iwm47dJlXDF2wYSazrJHONCuvmJ1Th3Bgh0xNs4RIIS7q4mjGZ3J7103mqMcdm2c5y2ZlZ61bmwECuso8oJDbQ",
+      "token": "apiv3_ci_test_only_not_a_real_secret_token_111111111111111111111111111111111111",
       "name": "example-token",
       "expiry_millis": 1914080061529,
       "permissions": [

--- a/charts/influxdb3-enterprise/templates/NOTES.txt
+++ b/charts/influxdb3-enterprise/templates/NOTES.txt
@@ -16,6 +16,16 @@ Components deployed:
   ✓ Processing Engine: {{ .Values.processingEngine.replicas }} replica(s)
 {{- end }}
 
+{{- $security := .Values.security | default dict }}
+{{- $auth := get $security "auth" | default dict }}
+{{- $adminToken := get $auth "adminToken" | default dict }}
+{{- if get $adminToken "existingSecret" }}
+
+Preconfigured admin token:
+  Enabled via secret: {{ get $adminToken "existingSecret" }}
+  Token file path: /etc/influxdb/admin-token/admin-token.json
+{{- end }}
+
 {{- /* Calculate total resource requests */ -}}
 {{- $totalCpuMillis := 0 }}
 {{- $totalMemoryGi := 0 }}

--- a/charts/influxdb3-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb3-enterprise/templates/_helpers.tpl
@@ -545,7 +545,6 @@ Admin token volumes
 - name: admin-token
   secret:
     secretName: {{ get $adminToken "existingSecret" }}
-    defaultMode: 0400
     items:
       - key: admin-token.json
         path: admin-token.json
@@ -563,7 +562,6 @@ Permission tokens volumes
 - name: permission-tokens
   secret:
     secretName: {{ get $permissionTokens "existingSecret" }}
-    defaultMode: 0400
     items:
       - key: permission-tokens.json
         path: permission-tokens.json

--- a/charts/influxdb3-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb3-enterprise/templates/_helpers.tpl
@@ -282,7 +282,10 @@ License environment (shared across components)
       name: {{ include "influxdb3-enterprise.licenseSecretName" . }}
       key: license-email
 {{- end }}
-{{- if or .Values.license.file .Values.license.existingSecret }}
+{{- if .Values.license.file }}
+- name: INFLUXDB3_ENTERPRISE_LICENSE_FILE
+  value: "/etc/influxdb/license"
+{{- else if and .Values.license.existingSecret (and (ne $licenseType "trial") (ne $licenseType "home")) }}
 - name: INFLUXDB3_ENTERPRISE_LICENSE_FILE
   value: "/etc/influxdb/license"
 {{- end }}
@@ -391,7 +394,13 @@ Shared volume mounts (license/TLS/GCS and user extras)
   mountPath: /etc/influxdb/aws
   readOnly: true
 {{- end }}
-{{- if or .Values.license.file .Values.license.existingSecret }}
+{{- $licenseType := .Values.license.type | default "trial" -}}
+{{- if .Values.license.file }}
+- name: license
+  mountPath: /etc/influxdb/license
+  subPath: license
+  readOnly: true
+{{- else if and .Values.license.existingSecret (and (ne $licenseType "trial") (ne $licenseType "home")) }}
 - name: license
   mountPath: /etc/influxdb/license
   subPath: license
@@ -506,7 +515,16 @@ Shared volumes (license/TLS/GCS and user extras)
       - key: credentials
         path: credentials
 {{- end }}
-{{- if or .Values.license.file .Values.license.existingSecret }}
+{{- $licenseType := .Values.license.type | default "trial" -}}
+{{- if .Values.license.file }}
+- name: license
+  secret:
+    secretName: {{ include "influxdb3-enterprise.licenseSecretName" . }}
+    optional: true
+    items:
+      - key: license-file
+        path: license
+{{- else if and .Values.license.existingSecret (and (ne $licenseType "trial") (ne $licenseType "home")) }}
 - name: license
   secret:
     secretName: {{ include "influxdb3-enterprise.licenseSecretName" . }}

--- a/charts/influxdb3-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb3-enterprise/templates/_helpers.tpl
@@ -164,6 +164,34 @@ Validate object store TLS CA config
 {{- end }}
 
 {{/*
+Validate admin token bootstrap config
+*/}}
+{{- define "influxdb3-enterprise.validateAdminTokenConfig" -}}
+{{- $security := .Values.security | default dict -}}
+{{- $auth := get $security "auth" | default dict -}}
+{{- $adminToken := get $auth "adminToken" | default dict -}}
+{{- $existingSecret := get $adminToken "existingSecret" | default "" -}}
+{{- $adminTokenFile := get $adminToken "file" | default "" -}}
+{{- if and $existingSecret $adminTokenFile -}}
+{{- fail "Set only one of security.auth.adminToken.existingSecret or security.auth.adminToken.file." -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate permission tokens bootstrap config
+*/}}
+{{- define "influxdb3-enterprise.validatePermissionTokensConfig" -}}
+{{- $security := .Values.security | default dict -}}
+{{- $auth := get $security "auth" | default dict -}}
+{{- $permissionTokens := get $auth "permissionTokens" | default dict -}}
+{{- $existingSecret := get $permissionTokens "existingSecret" | default "" -}}
+{{- $permissionTokensFile := get $permissionTokens "file" | default "" -}}
+{{- if and $existingSecret $permissionTokensFile -}}
+{{- fail "Set only one of security.auth.permissionTokens.existingSecret or security.auth.permissionTokens.file." -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 License checksum (handles existingSecret via lookup)
 */}}
 {{- define "influxdb3-enterprise.licenseChecksum" -}}
@@ -264,6 +292,40 @@ License environment (shared across components)
 {{- end }}
 
 {{/*
+Preconfigured admin token environment
+*/}}
+{{- define "influxdb3-enterprise.adminTokenEnv" -}}
+{{- $security := .Values.security | default dict -}}
+{{- $auth := get $security "auth" | default dict -}}
+{{- $adminToken := get $auth "adminToken" | default dict -}}
+{{- $adminTokenFile := get $adminToken "file" | default "" -}}
+{{- if get $adminToken "existingSecret" }}
+- name: INFLUXDB3_ADMIN_TOKEN_FILE
+  value: "/etc/influxdb/admin-token/admin-token.json"
+{{- else if $adminTokenFile }}
+- name: INFLUXDB3_ADMIN_TOKEN_FILE
+  value: {{ $adminTokenFile | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Preconfigured permission tokens environment
+*/}}
+{{- define "influxdb3-enterprise.permissionTokensEnv" -}}
+{{- $security := .Values.security | default dict -}}
+{{- $auth := get $security "auth" | default dict -}}
+{{- $permissionTokens := get $auth "permissionTokens" | default dict -}}
+{{- $permissionTokensFile := get $permissionTokens "file" | default "" -}}
+{{- if get $permissionTokens "existingSecret" }}
+- name: INFLUXDB3_PERMISSION_TOKENS_FILE
+  value: "/etc/influxdb/permission-tokens/permission-tokens.json"
+{{- else if $permissionTokensFile }}
+- name: INFLUXDB3_PERMISSION_TOKENS_FILE
+  value: {{ $permissionTokensFile | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
 Probe configuration (shared across components)
 */}}
 {{- define "influxdb3-enterprise.probes" -}}
@@ -348,6 +410,34 @@ Shared volume mounts (license/TLS/GCS and user extras)
 {{- end }}
 {{- with .Values.extraVolumeMounts }}
 {{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Admin token volume mounts
+*/}}
+{{- define "influxdb3-enterprise.adminTokenVolumeMounts" -}}
+{{- $security := .Values.security | default dict -}}
+{{- $auth := get $security "auth" | default dict -}}
+{{- $adminToken := get $auth "adminToken" | default dict -}}
+{{- if get $adminToken "existingSecret" }}
+- name: admin-token
+  mountPath: /etc/influxdb/admin-token
+  readOnly: true
+{{- end }}
+{{- end }}
+
+{{/*
+Permission tokens volume mounts
+*/}}
+{{- define "influxdb3-enterprise.permissionTokensVolumeMounts" -}}
+{{- $security := .Values.security | default dict -}}
+{{- $auth := get $security "auth" | default dict -}}
+{{- $permissionTokens := get $auth "permissionTokens" | default dict -}}
+{{- if get $permissionTokens "existingSecret" }}
+- name: permission-tokens
+  mountPath: /etc/influxdb/permission-tokens
+  readOnly: true
 {{- end }}
 {{- end }}
 
@@ -441,5 +531,41 @@ Shared volumes (license/TLS/GCS and user extras)
 {{- end }}
 {{- with .Values.extraVolumes }}
 {{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Admin token volumes
+*/}}
+{{- define "influxdb3-enterprise.adminTokenVolumes" -}}
+{{- $security := .Values.security | default dict -}}
+{{- $auth := get $security "auth" | default dict -}}
+{{- $adminToken := get $auth "adminToken" | default dict -}}
+{{- if get $adminToken "existingSecret" }}
+- name: admin-token
+  secret:
+    secretName: {{ get $adminToken "existingSecret" }}
+    defaultMode: 0400
+    items:
+      - key: admin-token.json
+        path: admin-token.json
+{{- end }}
+{{- end }}
+
+{{/*
+Permission tokens volumes
+*/}}
+{{- define "influxdb3-enterprise.permissionTokensVolumes" -}}
+{{- $security := .Values.security | default dict -}}
+{{- $auth := get $security "auth" | default dict -}}
+{{- $permissionTokens := get $auth "permissionTokens" | default dict -}}
+{{- if get $permissionTokens "existingSecret" }}
+- name: permission-tokens
+  secret:
+    secretName: {{ get $permissionTokens "existingSecret" }}
+    defaultMode: 0400
+    items:
+      - key: permission-tokens.json
+        path: permission-tokens.json
 {{- end }}
 {{- end }}

--- a/charts/influxdb3-enterprise/templates/compactor-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/compactor-statefulset.yaml
@@ -74,6 +74,8 @@ spec:
           env:
             {{- include "influxdb3-enterprise.licenseEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.objectStoreSecretEnv" . | nindent 12 }}
+            {{- include "influxdb3-enterprise.adminTokenEnv" . | nindent 12 }}
+            {{- include "influxdb3-enterprise.permissionTokensEnv" . | nindent 12 }}
             {{- with .Values.compactor.compaction }}
             {{- if .gen2Duration }}
             - name: INFLUXDB3_ENTERPRISE_COMPACTION_GEN2_DURATION
@@ -136,6 +138,8 @@ spec:
             {{- toYaml .Values.compactor.resources | nindent 12 }}
           volumeMounts:
             {{ include "influxdb3-enterprise.sharedVolumeMounts" . | nindent 12 }}
+            {{ include "influxdb3-enterprise.adminTokenVolumeMounts" . | nindent 12 }}
+            {{ include "influxdb3-enterprise.permissionTokensVolumeMounts" . | nindent 12 }}
       {{- with .Values.compactor.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -150,4 +154,6 @@ spec:
       {{- end }}
       volumes:
         {{ include "influxdb3-enterprise.sharedVolumes" . | nindent 8 }}
+        {{ include "influxdb3-enterprise.adminTokenVolumes" . | nindent 8 }}
+        {{ include "influxdb3-enterprise.permissionTokensVolumes" . | nindent 8 }}
   {{- end }}

--- a/charts/influxdb3-enterprise/templates/configmap.yaml
+++ b/charts/influxdb3-enterprise/templates/configmap.yaml
@@ -3,6 +3,8 @@
 {{- include "influxdb3-enterprise.validateS3ObjectStorageAuth" . }}
 {{- include "influxdb3-enterprise.validateGoogleObjectStorageAuth" . }}
 {{- include "influxdb3-enterprise.validateObjectStoreTlsCa" . }}
+{{- include "influxdb3-enterprise.validateAdminTokenConfig" . }}
+{{- include "influxdb3-enterprise.validatePermissionTokensConfig" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/influxdb3-enterprise/templates/configmap.yaml
+++ b/charts/influxdb3-enterprise/templates/configmap.yaml
@@ -37,6 +37,13 @@ data:
   {{- if .Values.security.auth.disableAuthz }}
   INFLUXDB3_DISABLE_AUTHZ: {{ join "," .Values.security.auth.disableAuthz | quote }}
   {{- end }}
+  {{- $security := .Values.security | default dict }}
+  {{- $auth := get $security "auth" | default dict }}
+  {{- $adminToken := get $auth "adminToken" | default dict }}
+  {{- $adminTokenRecovery := get $adminToken "recovery" | default dict }}
+  {{- if get $adminTokenRecovery "httpBind" }}
+  INFLUXDB3_ADMIN_TOKEN_RECOVERY_HTTP_BIND: {{ get $adminTokenRecovery "httpBind" | quote }}
+  {{- end }}
 
   # HTTP
   {{- with .Values.http }}

--- a/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
@@ -69,6 +69,8 @@ spec:
           env:
             {{- include "influxdb3-enterprise.licenseEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.objectStoreSecretEnv" . | nindent 12 }}
+            {{- include "influxdb3-enterprise.adminTokenEnv" . | nindent 12 }}
+            {{- include "influxdb3-enterprise.permissionTokensEnv" . | nindent 12 }}
             {{- with .Values.ingester.wal }}
             {{- if .flushInterval }}
             - name: INFLUXDB3_WAL_FLUSH_INTERVAL
@@ -135,6 +137,8 @@ spec:
               {{- end }}
           {{- end }}
             {{ include "influxdb3-enterprise.sharedVolumeMounts" . | nindent 12 }}
+            {{ include "influxdb3-enterprise.adminTokenVolumeMounts" . | nindent 12 }}
+            {{ include "influxdb3-enterprise.permissionTokensVolumeMounts" . | nindent 12 }}
       {{- with .Values.ingester.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -149,6 +153,8 @@ spec:
       {{- end }}
       volumes:
         {{ include "influxdb3-enterprise.sharedVolumes" . | nindent 8 }}
+        {{ include "influxdb3-enterprise.adminTokenVolumes" . | nindent 8 }}
+        {{ include "influxdb3-enterprise.permissionTokensVolumes" . | nindent 8 }}
   {{- if .Values.ingester.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
@@ -7,6 +7,10 @@
 {{- $pluginVolumeMountCtx := dict "root" . "pluginsPVCEnabled" $pluginsPVCEnabled "pluginDir" (.Values.processingEngine.pluginDir | default "/plugins") }}
 {{- $hasProcessorPluginVolumeMounts := eq (include "influxdb3-enterprise.hasProcessorPluginVolumeMounts" $pluginVolumeMountCtx) "true" }}
 {{- $hasProcessorPluginDirMount := eq (include "influxdb3-enterprise.hasProcessorPluginDirMount" $pluginVolumeMountCtx) "true" }}
+{{- $adminTokenVolumeMounts := include "influxdb3-enterprise.adminTokenVolumeMounts" . | trim }}
+{{- $hasAdminTokenVolumeMounts := ne $adminTokenVolumeMounts "" }}
+{{- $permissionTokensVolumeMounts := include "influxdb3-enterprise.permissionTokensVolumeMounts" . | trim }}
+{{- $hasPermissionTokensVolumeMounts := ne $permissionTokensVolumeMounts "" }}
 {{- if and (not $pluginsPVCEnabled) .Values.processingEngine.initPlugins (gt (len .Values.processingEngine.initPlugins) 0) (not $hasProcessorPluginDirMount) }}
 {{- fail "processingEngine.initPlugins requires processingEngine.pluginDir to be mounted. Set processingEngine.persistence.enabled=true or configure extraVolumes/extraVolumeMounts to mount processingEngine.pluginDir." }}
 {{- end }}
@@ -98,6 +102,8 @@ spec:
           env:
             {{- include "influxdb3-enterprise.licenseEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.objectStoreSecretEnv" . | nindent 12 }}
+            {{- include "influxdb3-enterprise.adminTokenEnv" . | nindent 12 }}
+            {{- include "influxdb3-enterprise.permissionTokensEnv" . | nindent 12 }}
             {{- with .Values.processingEngine.pluginDir }}
             - name: INFLUXDB3_PLUGIN_DIR
               value: {{ . | quote }}
@@ -148,9 +154,17 @@ spec:
           {{- include "influxdb3-enterprise.probes" . | nindent 10 }}
           resources:
             {{- toYaml .Values.processingEngine.resources | nindent 12 }}
-          {{- if $hasProcessorPluginVolumeMounts }}
+          {{- if or $hasProcessorPluginVolumeMounts $hasAdminTokenVolumeMounts $hasPermissionTokensVolumeMounts }}
           volumeMounts:
+            {{- if $hasProcessorPluginVolumeMounts }}
             {{- include "influxdb3-enterprise.processorPluginVolumeMounts" $pluginVolumeMountCtx | nindent 12 }}
+            {{- end }}
+            {{- if $hasAdminTokenVolumeMounts }}
+            {{- include "influxdb3-enterprise.adminTokenVolumeMounts" . | nindent 12 }}
+            {{- end }}
+            {{- if $hasPermissionTokensVolumeMounts }}
+            {{- include "influxdb3-enterprise.permissionTokensVolumeMounts" . | nindent 12 }}
+            {{- end }}
           {{- end }}
       {{- with .Values.processingEngine.nodeSelector }}
       nodeSelector:
@@ -166,6 +180,8 @@ spec:
       {{- end }}
       volumes:
         {{ include "influxdb3-enterprise.sharedVolumes" . | nindent 8 }}
+        {{ include "influxdb3-enterprise.adminTokenVolumes" . | nindent 8 }}
+        {{ include "influxdb3-enterprise.permissionTokensVolumes" . | nindent 8 }}
   {{- if $pluginsPVCEnabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/influxdb3-enterprise/templates/querier-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/querier-statefulset.yaml
@@ -69,6 +69,8 @@ spec:
           env:
             {{- include "influxdb3-enterprise.licenseEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.objectStoreSecretEnv" . | nindent 12 }}
+            {{- include "influxdb3-enterprise.adminTokenEnv" . | nindent 12 }}
+            {{- include "influxdb3-enterprise.permissionTokensEnv" . | nindent 12 }}
             {{- with .Values.querier.memory }}
             {{- if .execMemPoolBytes }}
             - name: INFLUXDB3_EXEC_MEM_POOL_BYTES
@@ -105,6 +107,8 @@ spec:
             {{- toYaml .Values.querier.resources | nindent 12 }}
           volumeMounts:
             {{ include "influxdb3-enterprise.sharedVolumeMounts" . | nindent 12 }}
+            {{ include "influxdb3-enterprise.adminTokenVolumeMounts" . | nindent 12 }}
+            {{ include "influxdb3-enterprise.permissionTokensVolumeMounts" . | nindent 12 }}
       {{- with .Values.querier.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -119,4 +123,6 @@ spec:
       {{- end }}
       volumes:
         {{ include "influxdb3-enterprise.sharedVolumes" . | nindent 8 }}
+        {{ include "influxdb3-enterprise.adminTokenVolumes" . | nindent 8 }}
+        {{ include "influxdb3-enterprise.permissionTokensVolumes" . | nindent 8 }}
 {{- end }}

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -556,8 +556,9 @@ security:
     adminToken:
       existingSecret: ""
       file: ""
-    # adminTokenRecovery:
-    #   httpBind: "127.0.0.1:8182"     # Recovery bind address when enabled (doc default)
+      # Admin token recovery configuration
+      # recovery:
+      #   httpBind: "127.0.0.1:8182"     # Recovery bind address when enabled (doc default)
     # Existing secret containing offline permission tokens JSON.
     # Secret must contain key: permission-tokens.json
     # Set only one of permissionTokens.existingSecret or permissionTokens.file.

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -550,11 +550,20 @@ security:
     # Available endpoints: health, ping, metrics
     # Set to [] to require authentication for all endpoints
     disableAuthz: ["health"]
-    # Offline token files (for automated deployments)
-    adminTokenFile: ""
-    permissionTokensFile: ""
+    # Existing secret containing an offline preconfigured admin token JSON.
+    # Secret must contain key: admin-token.json
+    # Set only one of adminToken.existingSecret or adminToken.file.
+    adminToken:
+      existingSecret: ""
+      file: ""
     # adminTokenRecovery:
     #   httpBind: "127.0.0.1:8182"     # Recovery bind address when enabled (doc default)
+    # Existing secret containing offline permission tokens JSON.
+    # Secret must contain key: permission-tokens.json
+    # Set only one of permissionTokens.existingSecret or permissionTokens.file.
+    permissionTokens:
+      existingSecret: ""
+      file: ""
 
 # HTTP server configuration
 http:


### PR DESCRIPTION
Closes #779 

Wires up offline tokens bootstrap and admin token recovery into the chart. The values keys already existed but nothing was actually consuming them in the templates.

Now supported:
- Offline admin token at startup via `security.auth.adminToken.existingSecret` or `.file`
- Offline permission tokens via `security.auth.permissionTokens.existingSecret` or `.file`
- Binding the admin token recovery HTTP endpoint via `security.auth.adminToken.recovery.httpBind`

Two keys were re-nested for consistency:

| Before | Now |
|--------|-------|
| `security.auth.adminTokenFile` | `security.auth.adminToken.file` |
| `security.auth.permissionTokensFile` | `security.auth.permissionTokens.file` |

Notes to reviewers:
  - The old flat keys were never wired to any template, so renaming them doesn't break anything at runtime.
  - `NOTES.txt` stays minimal by design; token file-path modes aren't echoed there

Tests:
  - adds resources in helm tests workflow for Ent V3 tests
  - adds tests for admin token and permission tokens
  - updates very outdated Helm in the workflow
  - fixes `ct install` tests - exit code was not propagated outside pipe ❗ 
