### PR TITLE
fix(influxdb3-ent): use image entrypoint and support extra env variables

### DIFF
--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -54,8 +54,8 @@ jobs:
       # Our Enterprise chart requires some resources created
       - name: Create Enterprise Test Resources
         run: |
-          kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.4/cert-manager.yaml
-          sleep 30 # wait for CertManager
+          kubectl apply --validate=false -f https://github.com/cert-manager/cert-manager/releases/download/v1.19.3/cert-manager.yaml
+          kubectl wait --namespace cert-manager --for=condition=Available --timeout=45s deployment --all
           kubectl apply -f ./charts/influxdb-enterprise/example-resources.yaml
           kubectl create secret generic influxdb-license --from-literal=INFLUXDB_ENTERPRISE_LICENSE_KEY=${INFLUXDB_ENTERPRISE_LICENSE_KEY}
         env:

--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.4.0
-appVersion: "3.9.2"
+version: 0.5.0
+appVersion: "3.9.3"
 keywords:
   - influxdb
   - time-series

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -341,7 +341,7 @@ extraEnv:
     value: "custom-value"
 ```
 
-Use component-specific `extraEnv` to target only one component. Component-specific entries are rendered after top-level `extraEnv`, so a component entry with the same name is intended to override the global value for that component. Avoid duplicate names unless this override is intentional.
+Use component-specific `extraEnv` to target only one component. Component-specific entries override top-level `extraEnv` entries with the same `name`.
 
 ```yaml
 processingEngine:

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -331,6 +331,25 @@ networkPolicy:
 
 Each component has an optional PDB controlled by `podDisruptionBudget.enabled` and `maxUnavailable` in `values.yaml`. Defaults are disabled; enable per component or via the command line (e.g., `--set ingester.podDisruptionBudget.enabled=true`).
 
+#### Extra Environment Variables
+
+Use top-level `extraEnv` for environment variables that should be applied to every component:
+
+```yaml
+extraEnv:
+  - name: CUSTOM_VAR
+    value: "custom-value"
+```
+
+Use component-specific `extraEnv` to target only one component. Component-specific entries are rendered after top-level `extraEnv`, so a component entry with the same name is intended to override the global value for that component. Avoid duplicate names unless this override is intentional.
+
+```yaml
+processingEngine:
+  extraEnv:
+    - name: INFLUXDB3_UNSET_VARS
+      value: "INFLUXDB3_PLUGIN_DIR"
+```
+
 #### Monitoring
 
 Enable Prometheus ServiceMonitor:
@@ -543,6 +562,7 @@ logs:
 | `security.auth.permissionTokens.existingSecret` | Secret with offline permission tokens key `permission-tokens.json` | `""` |
 | `security.auth.permissionTokens.file` | Path to offline permission tokens file; mutually exclusive with `security.auth.permissionTokens.existingSecret` | `""` |
 | `security.auth.adminToken.recovery.httpBind` | Bind address for admin token recovery endpoint (`INFLUXDB3_ADMIN_TOKEN_RECOVERY_HTTP_BIND`) | `""` |
+| `extraEnv` | Extra environment variables applied to all components | `[]` |
 
 ### Object Storage Parameters
 
@@ -574,6 +594,10 @@ logs:
 | `querier.replicas` | Number of querier replicas | `2` |
 | `compactor.replicas` | Number of compactor replicas | `1` (fixed) |
 | `processingEngine.enabled` | Enable Processing Engine | `false` |
+| `ingester.extraEnv` | Extra environment variables applied only to ingester pods | `[]` |
+| `querier.extraEnv` | Extra environment variables applied only to querier pods | `[]` |
+| `compactor.extraEnv` | Extra environment variables applied only to compactor pods | `[]` |
+| `processingEngine.extraEnv` | Extra environment variables applied only to Processing Engine pods | `[]` |
 | `*.podDisruptionBudget.enabled` | Enable PDB per component | `false` |
 | `*.podDisruptionBudget.maxUnavailable` | Max unavailable when PDB enabled | component-specific |
 

--- a/charts/influxdb3-enterprise/ci/component-extra-env-values.yaml
+++ b/charts/influxdb3-enterprise/ci/component-extra-env-values.yaml
@@ -17,6 +17,13 @@ extraEnv:
 
 ingester:
   replicas: 1
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
   extraEnv:
     - name: INFLUXDB3_UNSET_VARS
       value: "INFLUXDB3_PLUGIN_DIR INFLUXDB3_HTTP_BIND_ADDR"
@@ -27,12 +34,26 @@ ingester:
 
 querier:
   replicas: 1
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
   extraEnv:
     - name: INFLUXDB3_UNSET_VARS
       value: "INFLUXDB3_PLUGIN_DIR INFLUXDB3_HTTP_BIND_ADDR"
 
 compactor:
   replicas: 1
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
   extraEnv:
     - name: INFLUXDB3_UNSET_VARS
       value: "INFLUXDB3_PLUGIN_DIR INFLUXDB3_HTTP_BIND_ADDR"
@@ -40,6 +61,13 @@ compactor:
 processingEngine:
   enabled: true
   replicas: 1
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
   extraEnv:
     - name: INFLUXDB3_UNSET_VARS
       value: "INFLUXDB3_HTTP_BIND_ADDR"

--- a/charts/influxdb3-enterprise/ci/component-extra-env-values.yaml
+++ b/charts/influxdb3-enterprise/ci/component-extra-env-values.yaml
@@ -1,0 +1,49 @@
+license:
+  existingSecret: influxdb3-license
+
+objectStorage:
+  type: memory
+
+ingress:
+  enabled: false
+
+extraEnv:
+  - name: GLOBAL_COMPONENT_OVERRIDE_TEST
+    value: "global"
+  # Intentionally invalid. Component INFLUXDB3_UNSET_VARS must remove it;
+  # otherwise the pod fails to start and ct install fails.
+  - name: INFLUXDB3_HTTP_BIND_ADDR
+    value: "invalid-address"
+
+ingester:
+  replicas: 1
+  extraEnv:
+    - name: INFLUXDB3_UNSET_VARS
+      value: "INFLUXDB3_PLUGIN_DIR INFLUXDB3_HTTP_BIND_ADDR"
+    - name: GLOBAL_COMPONENT_OVERRIDE_TEST
+      value: "ingester"
+  persistence:
+    enabled: false
+
+querier:
+  replicas: 1
+  extraEnv:
+    - name: INFLUXDB3_UNSET_VARS
+      value: "INFLUXDB3_PLUGIN_DIR INFLUXDB3_HTTP_BIND_ADDR"
+
+compactor:
+  replicas: 1
+  extraEnv:
+    - name: INFLUXDB3_UNSET_VARS
+      value: "INFLUXDB3_PLUGIN_DIR INFLUXDB3_HTTP_BIND_ADDR"
+
+processingEngine:
+  enabled: true
+  replicas: 1
+  extraEnv:
+    - name: INFLUXDB3_UNSET_VARS
+      value: "INFLUXDB3_HTTP_BIND_ADDR"
+    - name: PROCESSOR_ONLY_TEST_VAR
+      value: "processor-only"
+  persistence:
+    enabled: false

--- a/charts/influxdb3-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb3-enterprise/templates/_helpers.tpl
@@ -339,12 +339,26 @@ Pod name environment for stable StatefulSet node IDs
 {{- end }}
 
 {{/*
-Global plus component-specific extra environment variables
+Global plus component-specific extra environment variables.
+Component-specific entries override global entries with the same name.
 */}}
 {{- define "influxdb3-enterprise.componentExtraEnv" -}}
 {{- $global := .root.Values.extraEnv | default (list) -}}
 {{- $component := .component.extraEnv | default (list) -}}
-{{- $extraEnv := concat $global $component -}}
+{{- $componentNames := dict -}}
+{{- range $env := $component }}
+{{- with $env.name }}
+{{- $_ := set $componentNames . true -}}
+{{- end }}
+{{- end }}
+{{- $extraEnv := list -}}
+{{- range $env := $global }}
+{{- $name := $env.name | default "" -}}
+{{- if or (not $name) (not (hasKey $componentNames $name)) }}
+{{- $extraEnv = append $extraEnv $env -}}
+{{- end }}
+{{- end }}
+{{- $extraEnv = concat $extraEnv $component -}}
 {{- if $extraEnv }}
 {{- toYaml $extraEnv }}
 {{- end }}

--- a/charts/influxdb3-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb3-enterprise/templates/_helpers.tpl
@@ -329,6 +329,28 @@ Preconfigured permission tokens environment
 {{- end }}
 
 {{/*
+Pod name environment for stable StatefulSet node IDs
+*/}}
+{{- define "influxdb3-enterprise.podNameEnv" -}}
+- name: POD_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.name
+{{- end }}
+
+{{/*
+Global plus component-specific extra environment variables
+*/}}
+{{- define "influxdb3-enterprise.componentExtraEnv" -}}
+{{- $global := .root.Values.extraEnv | default (list) -}}
+{{- $component := .component.extraEnv | default (list) -}}
+{{- $extraEnv := concat $global $component -}}
+{{- if $extraEnv }}
+{{- toYaml $extraEnv }}
+{{- end }}
+{{- end }}
+
+{{/*
 Probe configuration (shared across components)
 */}}
 {{- define "influxdb3-enterprise.probes" -}}

--- a/charts/influxdb3-enterprise/templates/compactor-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/compactor-statefulset.yaml
@@ -57,21 +57,18 @@ spec:
           {{- end }}
           image: {{ include "influxdb3-enterprise.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - /bin/sh
-            - -c
-            - |
-              exec influxdb3 \
-                {{- with .Values.compactor.numIOThreads }}
-                --num-io-threads={{ . }} \
-                {{- end }}
-                serve \
-                --mode=compact \
-                --node-id=$(hostname)
+          args:
+            {{- with .Values.compactor.numIOThreads }}
+            - --num-io-threads={{ . }}
+            {{- end }}
+            - serve
+            - --mode=compact
+            - --node-id=$(POD_NAME)
           envFrom:
             - configMapRef:
                 name: {{ include "influxdb3-enterprise.fullname" . }}-config
           env:
+            {{- include "influxdb3-enterprise.podNameEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.licenseEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.objectStoreSecretEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.adminTokenEnv" . | nindent 12 }}
@@ -126,9 +123,7 @@ spec:
               value: {{ .config | quote }}
             {{- end }}
             {{- end }}
-            {{- with .Values.extraEnv }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+            {{- include "influxdb3-enterprise.componentExtraEnv" (dict "root" . "component" .Values.compactor) | nindent 12 }}
           ports:
             - name: http
               containerPort: 8181

--- a/charts/influxdb3-enterprise/templates/compactor-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/compactor-statefulset.yaml
@@ -58,9 +58,6 @@ spec:
           image: {{ include "influxdb3-enterprise.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            {{- with .Values.compactor.numIOThreads }}
-            - --num-io-threads={{ . }}
-            {{- end }}
             - serve
             - --mode=compact
             - --node-id=$(POD_NAME)
@@ -73,6 +70,10 @@ spec:
             {{- include "influxdb3-enterprise.objectStoreSecretEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.adminTokenEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.permissionTokensEnv" . | nindent 12 }}
+            {{- with .Values.compactor.numIOThreads }}
+            - name: INFLUXDB3_NUM_IO_THREADS
+              value: {{ . | quote }}
+            {{- end }}
             {{- with .Values.compactor.compaction }}
             {{- if .gen2Duration }}
             - name: INFLUXDB3_ENTERPRISE_COMPACTION_GEN2_DURATION

--- a/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
@@ -52,21 +52,18 @@ spec:
           {{- end }}
           image: {{ include "influxdb3-enterprise.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - /bin/sh
-            - -c
-            - |
-              exec influxdb3 \
-                {{- with .Values.ingester.numIOThreads }}
-                --num-io-threads={{ . }} \
-                {{- end }}
-                serve \
-                --mode=ingest \
-                --node-id=$(hostname)
+          args:
+            {{- with .Values.ingester.numIOThreads }}
+            - --num-io-threads={{ . }}
+            {{- end }}
+            - serve
+            - --mode=ingest
+            - --node-id=$(POD_NAME)
           envFrom:
             - configMapRef:
                 name: {{ include "influxdb3-enterprise.fullname" . }}-config
           env:
+            {{- include "influxdb3-enterprise.podNameEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.licenseEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.objectStoreSecretEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.adminTokenEnv" . | nindent 12 }}
@@ -117,9 +114,7 @@ spec:
               value: {{ .config | quote }}
             {{- end }}
             {{- end }}
-            {{- with .Values.extraEnv }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+            {{- include "influxdb3-enterprise.componentExtraEnv" (dict "root" . "component" .Values.ingester) | nindent 12 }}
           ports:
             - name: http
               containerPort: 8181

--- a/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
@@ -53,9 +53,6 @@ spec:
           image: {{ include "influxdb3-enterprise.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            {{- with .Values.ingester.numIOThreads }}
-            - --num-io-threads={{ . }}
-            {{- end }}
             - serve
             - --mode=ingest
             - --node-id=$(POD_NAME)
@@ -68,6 +65,10 @@ spec:
             {{- include "influxdb3-enterprise.objectStoreSecretEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.adminTokenEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.permissionTokensEnv" . | nindent 12 }}
+            {{- with .Values.ingester.numIOThreads }}
+            - name: INFLUXDB3_NUM_IO_THREADS
+              value: {{ . | quote }}
+            {{- end }}
             {{- with .Values.ingester.wal }}
             {{- if .flushInterval }}
             - name: INFLUXDB3_WAL_FLUSH_INTERVAL

--- a/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
@@ -97,9 +97,6 @@ spec:
           image: {{ include "influxdb3-enterprise.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            {{- with .Values.processingEngine.numIOThreads }}
-            - --num-io-threads={{ . }}
-            {{- end }}
             - serve
             - --mode=process
             - --node-id=$(POD_NAME)
@@ -112,6 +109,10 @@ spec:
             {{- include "influxdb3-enterprise.objectStoreSecretEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.adminTokenEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.permissionTokensEnv" . | nindent 12 }}
+            {{- with .Values.processingEngine.numIOThreads }}
+            - name: INFLUXDB3_NUM_IO_THREADS
+              value: {{ . | quote }}
+            {{- end }}
             {{- with .Values.processingEngine.pluginDir }}
             - name: INFLUXDB3_PLUGIN_DIR
               value: {{ . | quote }}

--- a/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
@@ -11,6 +11,7 @@
 {{- $hasAdminTokenVolumeMounts := ne $adminTokenVolumeMounts "" }}
 {{- $permissionTokensVolumeMounts := include "influxdb3-enterprise.permissionTokensVolumeMounts" . | trim }}
 {{- $hasPermissionTokensVolumeMounts := ne $permissionTokensVolumeMounts "" }}
+{{- $processorExtraEnv := include "influxdb3-enterprise.componentExtraEnv" (dict "root" . "component" .Values.processingEngine) | trim }}
 {{- if and (not $pluginsPVCEnabled) .Values.processingEngine.initPlugins (gt (len .Values.processingEngine.initPlugins) 0) (not $hasProcessorPluginDirMount) }}
 {{- fail "processingEngine.initPlugins requires processingEngine.pluginDir to be mounted. Set processingEngine.persistence.enabled=true or configure extraVolumes/extraVolumeMounts to mount processingEngine.pluginDir." }}
 {{- end }}
@@ -56,11 +57,21 @@ spec:
         - name: init-plugin-{{ .name | default "plugin" | replace "." "-" | replace "_" "-" | trunc 51 | trimSuffix "-" }}
           image: {{ include "influxdb3-enterprise.image" $ }}
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
-          command:
-            - /bin/sh
-            - -c
-            - >
-              influxdb3 install package {{ .name | quote }}{{- if .source }} --source {{ .source | quote }}{{- end }} --plugin-dir {{ $.Values.processingEngine.pluginDir | default "/plugins" | quote }}
+          args:
+            - influxdb3
+            - install
+            - package
+            - {{ .name | quote }}
+            {{- with .source }}
+            - --source
+            - {{ . | quote }}
+            {{- end }}
+            - --plugin-dir
+            - {{ $.Values.processingEngine.pluginDir | default "/plugins" | quote }}
+          {{- if $processorExtraEnv }}
+          env:
+            {{- $processorExtraEnv | nindent 12 }}
+          {{- end }}
           {{- if $hasProcessorPluginVolumeMounts }}
           volumeMounts:
             {{- include "influxdb3-enterprise.processorPluginVolumeMounts" $pluginVolumeMountCtx | nindent 12 }}
@@ -85,21 +96,18 @@ spec:
           {{- end }}
           image: {{ include "influxdb3-enterprise.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - /bin/sh
-            - -c
-            - |
-              exec influxdb3 \
-                {{- with .Values.processingEngine.numIOThreads }}
-                --num-io-threads={{ . }} \
-                {{- end }}
-                serve \
-                --mode=process \
-                --node-id=$(hostname)
+          args:
+            {{- with .Values.processingEngine.numIOThreads }}
+            - --num-io-threads={{ . }}
+            {{- end }}
+            - serve
+            - --mode=process
+            - --node-id=$(POD_NAME)
           envFrom:
             - configMapRef:
                 name: {{ include "influxdb3-enterprise.fullname" . }}-config
           env:
+            {{- include "influxdb3-enterprise.podNameEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.licenseEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.objectStoreSecretEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.adminTokenEnv" . | nindent 12 }}
@@ -144,9 +152,7 @@ spec:
               value: {{ .config | quote }}
             {{- end }}
             {{- end }}
-            {{- with .Values.extraEnv }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+            {{- include "influxdb3-enterprise.componentExtraEnv" (dict "root" . "component" .Values.processingEngine) | nindent 12 }}
           ports:
             - name: http
               containerPort: 8181

--- a/charts/influxdb3-enterprise/templates/querier-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/querier-statefulset.yaml
@@ -52,21 +52,18 @@ spec:
           {{- end }}
           image: {{ include "influxdb3-enterprise.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - /bin/sh
-            - -c
-            - |
-              exec influxdb3 \
-                {{- with .Values.querier.numIOThreads }}
-                --num-io-threads={{ . }} \
-                {{- end }}
-                serve \
-                --mode=query \
-                --node-id=$(hostname)
+          args:
+            {{- with .Values.querier.numIOThreads }}
+            - --num-io-threads={{ . }}
+            {{- end }}
+            - serve
+            - --mode=query
+            - --node-id=$(POD_NAME)
           envFrom:
             - configMapRef:
                 name: {{ include "influxdb3-enterprise.fullname" . }}-config
           env:
+            {{- include "influxdb3-enterprise.podNameEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.licenseEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.objectStoreSecretEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.adminTokenEnv" . | nindent 12 }}
@@ -95,9 +92,7 @@ spec:
               value: {{ .config | quote }}
             {{- end }}
             {{- end }}
-            {{- with .Values.extraEnv }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+            {{- include "influxdb3-enterprise.componentExtraEnv" (dict "root" . "component" .Values.querier) | nindent 12 }}
           ports:
             - name: http
               containerPort: 8181

--- a/charts/influxdb3-enterprise/templates/querier-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/querier-statefulset.yaml
@@ -53,9 +53,6 @@ spec:
           image: {{ include "influxdb3-enterprise.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            {{- with .Values.querier.numIOThreads }}
-            - --num-io-threads={{ . }}
-            {{- end }}
             - serve
             - --mode=query
             - --node-id=$(POD_NAME)
@@ -68,6 +65,10 @@ spec:
             {{- include "influxdb3-enterprise.objectStoreSecretEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.adminTokenEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.permissionTokensEnv" . | nindent 12 }}
+            {{- with .Values.querier.numIOThreads }}
+            - name: INFLUXDB3_NUM_IO_THREADS
+              value: {{ . | quote }}
+            {{- end }}
             {{- with .Values.querier.memory }}
             {{- if .execMemPoolBytes }}
             - name: INFLUXDB3_EXEC_MEM_POOL_BYTES

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -182,6 +182,11 @@ ingester:
   # Thread configuration
   # numIOThreads: 2             # Global IO threads (--num-io-threads)
 
+  # Extra environment variables for ingester pods. Rendered after top-level extraEnv.
+  extraEnv: []
+    # - name: INFLUXDB3_UNSET_VARS
+    #   value: "INFLUXDB3_PLUGIN_DIR"
+
   # Memory tuning
   # memory:
   #   execMemPoolBytes: "20%"            # --exec-mem-pool-bytes
@@ -277,6 +282,11 @@ querier:
   # Thread configuration
   # numIOThreads: 2             # Global IO threads (--num-io-threads)
 
+  # Extra environment variables for querier pods. Rendered after top-level extraEnv.
+  extraEnv: []
+    # - name: INFLUXDB3_UNSET_VARS
+    #   value: "INFLUXDB3_PLUGIN_DIR"
+
   # Memory tuning
   # memory:
   #   execMemPoolBytes: "20%"            # --exec-mem-pool-bytes
@@ -363,6 +373,11 @@ compactor:
   # Thread configuration
   # numIOThreads: 2             # Global IO threads (--num-io-threads)
 
+  # Extra environment variables for compactor pods. Rendered after top-level extraEnv.
+  extraEnv: []
+    # - name: INFLUXDB3_UNSET_VARS
+    #   value: "INFLUXDB3_PLUGIN_DIR"
+
   # Memory tuning
   # memory:
   #   execMemPoolBytes: "20%"            # --exec-mem-pool-bytes
@@ -442,6 +457,11 @@ processingEngine:
 
   # Thread configuration
   # numIOThreads: 2             # Global IO threads (--num-io-threads)
+
+  # Extra environment variables for Processing Engine pods. Rendered after top-level extraEnv.
+  extraEnv: []
+    # - name: PROCESSOR_ONLY_VAR
+    #   value: "processor-only"
 
   # Memory tuning
   # memory:
@@ -828,10 +848,11 @@ serviceAccount:
 # Additional Configuration
 # ============================================================================
 
-# Extra environment variables for all pods
+# Extra environment variables for all pods. Component-specific extraEnv entries
+# are rendered after these values and can override them by using the same name.
 extraEnv: []
   # - name: CUSTOM_VAR
-#   value: "custom-value"
+  #   value: "custom-value"
 
 # Extra volumes for all pods
 extraVolumes: []

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -182,7 +182,7 @@ ingester:
   # Thread configuration
   # numIOThreads: 2             # Global IO threads (--num-io-threads)
 
-  # Extra environment variables for ingester pods. Rendered after top-level extraEnv.
+  # Extra environment variables for ingester pods. Overrides top-level extraEnv entries with the same name.
   extraEnv: []
     # - name: INFLUXDB3_UNSET_VARS
     #   value: "INFLUXDB3_PLUGIN_DIR"
@@ -282,7 +282,7 @@ querier:
   # Thread configuration
   # numIOThreads: 2             # Global IO threads (--num-io-threads)
 
-  # Extra environment variables for querier pods. Rendered after top-level extraEnv.
+  # Extra environment variables for querier pods. Overrides top-level extraEnv entries with the same name.
   extraEnv: []
     # - name: INFLUXDB3_UNSET_VARS
     #   value: "INFLUXDB3_PLUGIN_DIR"
@@ -373,7 +373,7 @@ compactor:
   # Thread configuration
   # numIOThreads: 2             # Global IO threads (--num-io-threads)
 
-  # Extra environment variables for compactor pods. Rendered after top-level extraEnv.
+  # Extra environment variables for compactor pods. Overrides top-level extraEnv entries with the same name.
   extraEnv: []
     # - name: INFLUXDB3_UNSET_VARS
     #   value: "INFLUXDB3_PLUGIN_DIR"
@@ -458,7 +458,7 @@ processingEngine:
   # Thread configuration
   # numIOThreads: 2             # Global IO threads (--num-io-threads)
 
-  # Extra environment variables for Processing Engine pods. Rendered after top-level extraEnv.
+  # Extra environment variables for Processing Engine pods. Overrides top-level extraEnv entries with the same name.
   extraEnv: []
     # - name: PROCESSOR_ONLY_VAR
     #   value: "processor-only"
@@ -848,8 +848,8 @@ serviceAccount:
 # Additional Configuration
 # ============================================================================
 
-# Extra environment variables for all pods. Component-specific extraEnv entries
-# are rendered after these values and can override them by using the same name.
+# Extra environment variables for all pods. Component-specific extraEnv entries override
+# entries with the same name for one component.
 extraEnv: []
   # - name: CUSTOM_VAR
   #   value: "custom-value"


### PR DESCRIPTION
Closes #798 

- uses image `entrypoint` for containers. One of the benefits is that `INFLUXDB3_UNSET_VARS` works now.
- adds `extraEnv` values support; global with per-component overrides