### PR TITLE
Fix: Increase startup probe timeout for influxdb3-enterprise 3.2+

### DIFF
--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "3.6.0"
 keywords:
   - influxdb

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -614,12 +614,13 @@ probes:
 
   # Startup probe settings
   # Protects container during initialization. Once successful, never runs again.
-  # For ~15s startup: 10s initial + (12 × 5s) = 70s total (4-5x safety buffer)
+  # For ~100s startup in 3.2: 30s initial + (20 × 10s) = 230s total (~2.3x safety buffer)
+  # Accounts for Python Processing Engine initialization, WAL recovery, and compaction preloading
   startup:
-    initialDelaySeconds: 10           # Wait ~50% of expected startup time
-    periodSeconds: 5                  # Check every 5 seconds
-    timeoutSeconds: 5
-    failureThreshold: 12              # 10s + (12 × 5s) = 70s total
+    initialDelaySeconds: 30           # Wait ~30% of expected startup time
+    periodSeconds: 10                 # Check every 10 seconds (less aggressive)
+    timeoutSeconds: 10                # Increased timeout for slower environments
+    failureThreshold: 20              # 30s + (20 × 10s) = 230s total
 
   # Liveness probe settings
   # Only starts checking AFTER startup probe succeeds


### PR DESCRIPTION
## Description

This PR fixes CrashLoopBackOff issues across **all components** (ingester, querier, compactor, processor) in InfluxDB 3.2+ deployments by increasing the startup probe timeout to accommodate longer initialization times.

Fixes #800

## Changes

### Chart Version
- Bump version from \