### PR TITLE
fix(influxdb3-ent): remove unnecessary ingester WAL PVC

### DIFF
--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.6.0
+version: 0.7.0
 appVersion: "3.9.3"
 keywords:
   - influxdb

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -481,16 +481,22 @@ After the upgraded ingester pods are healthy, delete the old ingester WAL PVCs.
 Chart 0.6.x created these PVCs when `ingester.persistence.enabled` was true, but
 they were unused leftovers: InfluxDB 3 Enterprise writes the WAL to the
 configured object store, not to those local PVC mounts. There is one old WAL PVC
-per ingester replica.
+per ingester replica. The PVC name pattern is
+`wal-<ingester-statefulset-name>-<ordinal>`, where `<ordinal>` starts at `0`.
 
 ```bash
-kubectl get pvc -n influxdb3 -l app.kubernetes.io/component=ingester
-# Default release name examples:
+# List old WAL PVCs for the default StatefulSet name and namespace:
+kubectl get pvc -n influxdb3 | grep '^wal-influxdb3-enterprise-ingester-'
+
+# Delete one old WAL PVC per old ingester replica:
 # wal-influxdb3-enterprise-ingester-0
 # wal-influxdb3-enterprise-ingester-1
 kubectl delete pvc -n influxdb3 wal-influxdb3-enterprise-ingester-0
 kubectl delete pvc -n influxdb3 wal-influxdb3-enterprise-ingester-1
 ```
+
+Replace `influxdb3-enterprise-ingester` with your old ingester StatefulSet name
+and delete one PVC for each old ingester replica ordinal.
 
 ### Rolling Updates
 

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -461,15 +461,14 @@ Chart 0.7.0 removes the ingester WAL `volumeClaimTemplates` from the
 StatefulSet. Kubernetes does not allow this field to be removed from an existing
 StatefulSet during an in-place `helm upgrade`.
 
-For existing 0.6.x releases using `objectStorage.type=file`, back up
-`objectStorage.file.dataDir` from the ingester pods before deleting them. File
-storage is intended for development/testing only, and chart 0.6.x did not mount
-the shared object-storage PVC at that path.
+For existing releases installed with chart 0.6.x, delete the ingester
+StatefulSet before upgrading. This is required for all object-store types
+because the immutable `volumeClaimTemplates` field changed.
 
-For existing releases installed with chart 0.6.x, schedule a maintenance window,
-stop writes, and allow the WAL to flush to the configured object store. Then
-delete the ingester StatefulSet before upgrading. The old WAL PVCs are retained
-by Kubernetes.
+For `objectStorage.type=file` only, chart 0.6.x stored object-store contents on
+the pod's ephemeral filesystem. File storage is intended for development/testing
+only. If you used file storage and want to preserve that dev/test data, back up
+`objectStorage.file.dataDir` from a live pod before deleting the StatefulSet.
 
 ```bash
 kubectl delete statefulset -n influxdb3 influxdb3-enterprise-ingester
@@ -478,9 +477,11 @@ helm upgrade influxdb3-enterprise . \
   -f my-values.yaml
 ```
 
-After the upgraded ingester pods are healthy and data has been verified in the
-configured object store, the old ingester WAL PVCs can be removed if they are no
-longer needed. There is one old WAL PVC per ingester replica.
+After the upgraded ingester pods are healthy, delete the old ingester WAL PVCs.
+Chart 0.6.x created these PVCs when `ingester.persistence.enabled` was true, but
+they were unused leftovers: InfluxDB 3 Enterprise writes the WAL to the
+configured object store, not to those local PVC mounts. There is one old WAL PVC
+per ingester replica.
 
 ```bash
 kubectl get pvc -n influxdb3 -l app.kubernetes.io/component=ingester

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -29,7 +29,7 @@ InfluxDB 3 Enterprise is a high-performance time series database designed for pr
 - Kubernetes 1.23+
 - Helm 3.8+
 - Object storage (S3, Azure Blob Storage, or Google Cloud Storage)
-- PersistentVolume provisioner support (for ingester WAL storage)
+- RWX PersistentVolume provisioner support when using `objectStorage.type=file`
 - InfluxDB 3 Enterprise license (trial, home, or commercial)
 - **NGINX Ingress Controller** (required if using ingress, which is enabled by default)
 
@@ -239,11 +239,22 @@ objectStorage:
 objectStorage:
   type: file
   # PVC is always created for file storage
-  # file:
-  #   dataDir: "/var/lib/influxdb3"
-  #   persistence:
-  #     size: 100Gi
+  file:
+    dataDir: "/var/lib/influxdb3"
+    persistence:
+      accessMode: ReadWriteMany
+      size: 100Gi
 ```
+
+For `objectStorage.type=s3`, `google`, `azure`, `memory`, or `memory-throttled`,
+the chart does not create a data or WAL PVC. WAL files, snapshots, catalog data,
+and Parquet files are persisted through the configured object store.
+
+For `objectStorage.type=file`, the chart creates one shared RWX object-storage
+PVC and mounts it at `objectStorage.file.dataDir` for Enterprise components.
+For single-node local testing only, you can set
+`objectStorage.file.persistence.accessMode=ReadWriteOnce` to use a local-path
+style StorageClass.
 
 #### Resource Configuration
 
@@ -654,10 +665,11 @@ Ingress routes:
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `ingester.persistence.enabled` | Enable WAL PVC | `true` |
-| `ingester.persistence.size` | WAL PVC size | `10Gi` |
+| `ingester.persistence.enabled` | Deprecated compatibility value; WAL is persisted through the configured object store | `false` |
+| `ingester.persistence.size` | Deprecated compatibility value; not used by default templates | `10Gi` |
 | `processingEngine.persistence.enabled` | Enable plugins PVC | `true` |
-| `objectStorage.type` `file` | Always creates PVC for file storage | — |
+| `objectStorage.type=file` | Creates one shared RWX object-storage PVC mounted at `objectStorage.file.dataDir` | — |
+| `objectStorage.file.persistence.accessMode` | Access mode for the file object-storage PVC | `ReadWriteMany` |
 
 ### Monitoring Parameters
 

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -256,9 +256,9 @@ lost when the pod restarts. These modes are intended for testing only.
 
 For `objectStorage.type=file`, the chart creates one shared RWX object-storage
 PVC and mounts it at `objectStorage.file.dataDir` for Enterprise components.
-For single-node local testing only, you can set
-`objectStorage.file.persistence.accessMode=ReadWriteOnce` to use a local-path
-style StorageClass.
+For single-node local testing only, where all pods run on the same node, you can
+set `objectStorage.file.persistence.accessMode=ReadWriteOnce` to use a
+local-path style StorageClass.
 
 #### Resource Configuration
 
@@ -273,9 +273,9 @@ ingester:
     limits:
       cpu: "8000m"
       memory: "16Gi"
-  threads:
-    io: 12              # For line protocol parsing
-    datafusion: 20      # For WAL snapshots
+  numIOThreads: 12
+  datafusion:
+    numThreads: 20
 ```
 
 #### TLS
@@ -712,7 +712,6 @@ Ingress routes:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `ingester.persistence.enabled` | Deprecated compatibility value; WAL is persisted through the configured object store | `false` |
-| `ingester.persistence.size` | Deprecated compatibility value; not used by default templates | `10Gi` |
 | `processingEngine.persistence.enabled` | Enable plugins PVC | `true` |
 | `objectStorage.type=file` | Creates one shared RWX object-storage PVC mounted at `objectStorage.file.dataDir` | — |
 | `objectStorage.file.persistence.accessMode` | Access mode for the file object-storage PVC | `ReadWriteMany` |

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -455,6 +455,37 @@ helm upgrade influxdb3-enterprise . \
   -f my-values.yaml
 ```
 
+#### Upgrade from chart 0.6.x
+
+Chart 0.7.0 removes the ingester WAL `volumeClaimTemplates` from the
+StatefulSet. Kubernetes does not allow this field to be removed from an existing
+StatefulSet during an in-place `helm upgrade`.
+
+For existing releases installed with chart 0.6.x, schedule a maintenance window,
+stop writes, and allow the WAL to flush to the configured object store. Then
+delete the ingester StatefulSet before upgrading. The old WAL PVCs are retained
+by Kubernetes.
+
+```bash
+kubectl delete statefulset -n influxdb3 influxdb3-enterprise-ingester
+helm upgrade influxdb3-enterprise . \
+  --namespace influxdb3 \
+  -f my-values.yaml
+```
+
+After the upgraded ingester pods are healthy and data has been verified in the
+configured object store, the old ingester WAL PVCs can be removed if they are no
+longer needed. There is one old WAL PVC per ingester replica.
+
+```bash
+kubectl get pvc -n influxdb3 -l app.kubernetes.io/component=ingester
+# Default release name examples:
+# wal-influxdb3-enterprise-ingester-0
+# wal-influxdb3-enterprise-ingester-1
+kubectl delete pvc -n influxdb3 wal-influxdb3-enterprise-ingester-0
+kubectl delete pvc -n influxdb3 wal-influxdb3-enterprise-ingester-1
+```
+
 ### Rolling Updates
 
 StatefulSets perform rolling updates by default. Pods are updated one at a time to ensure availability.

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -572,16 +572,22 @@ kubectl run -it --rm debug --image=amazon/aws-cli --restart=Never -- \
   s3 ls s3://your-bucket --region us-east-1
 ```
 
-#### Ingester WAL Issues
+#### Ingester WAL and Object Storage Issues
 
-Check PVC status:
+WAL files are persisted through the configured object store. Check object
+storage connectivity first:
 ```bash
-kubectl get pvc -n influxdb3
+kubectl logs -n influxdb3 influxdb3-enterprise-ingester-0 | grep -i object
 ```
 
 View ingester logs for WAL errors:
 ```bash
 kubectl logs -n influxdb3 influxdb3-enterprise-ingester-0 | grep -i wal
+```
+
+For `objectStorage.type=file`, also check the shared object-storage PVC:
+```bash
+kubectl get pvc -n influxdb3 influxdb3-enterprise-object-storage
 ```
 
 ### Debug Mode

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -461,6 +461,11 @@ Chart 0.7.0 removes the ingester WAL `volumeClaimTemplates` from the
 StatefulSet. Kubernetes does not allow this field to be removed from an existing
 StatefulSet during an in-place `helm upgrade`.
 
+For existing 0.6.x releases using `objectStorage.type=file`, back up
+`objectStorage.file.dataDir` from the ingester pods before deleting them. File
+storage is intended for development/testing only, and chart 0.6.x did not mount
+the shared object-storage PVC at that path.
+
 For existing releases installed with chart 0.6.x, schedule a maintenance window,
 stop writes, and allow the WAL to flush to the configured object store. Then
 delete the ingester StatefulSet before upgrading. The old WAL PVCs are retained

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -246,9 +246,13 @@ objectStorage:
       size: 100Gi
 ```
 
-For `objectStorage.type=s3`, `google`, `azure`, `memory`, or `memory-throttled`,
-the chart does not create a data or WAL PVC. WAL files, snapshots, catalog data,
-and Parquet files are persisted through the configured object store.
+For `objectStorage.type=s3`, `google`, or `azure`, the chart does not create a
+data or WAL PVC. WAL files, snapshots, catalog data, and Parquet files are
+persisted through the configured durable object store.
+
+For `objectStorage.type=memory` or `memory-throttled`, all object-store data
+(WAL files, snapshots, catalog data, and Parquet files) is held in memory and
+lost when the pod restarts. These modes are intended for testing only.
 
 For `objectStorage.type=file`, the chart creates one shared RWX object-storage
 PVC and mounts it at `objectStorage.file.dataDir` for Enterprise components.

--- a/charts/influxdb3-enterprise/TROUBLESHOOTING.md
+++ b/charts/influxdb3-enterprise/TROUBLESHOOTING.md
@@ -203,11 +203,11 @@ kubectl describe pvc -n influxdb3 influxdb3-enterprise-object-storage
 3. **Insufficient Capacity**
     - Solution: Increase node storage or reduce PVC size
 
-### WAL Disk Full
+### Object Storage Capacity Issues
 
 **Error Message:**
 ```
-WAL directory full, cannot accept more writes
+Failed to write WAL, snapshot, catalog, or Parquet data to object storage
 ```
 
 **Solution:**
@@ -231,9 +231,10 @@ WAL directory full, cannot accept more writes
 
 3. **Adjust WAL settings:**
    ```yaml
-   wal:
-     flushInterval: "500ms"  # More frequent flushes
-     snapshotSize: 300       # Smaller snapshots
+   ingester:
+     wal:
+       flushInterval: "500ms"  # More frequent flushes
+       snapshotSize: 300       # Smaller snapshots
    ```
 
 ---
@@ -338,8 +339,9 @@ kubectl describe networkpolicy -n influxdb3
 
 3. **Optimize WAL:**
    ```yaml
-   wal:
-     flushInterval: "500ms"  # More frequent flushes
+   ingester:
+     wal:
+       flushInterval: "500ms"  # More frequent flushes
    ```
 
 ### Slow Queries

--- a/charts/influxdb3-enterprise/TROUBLESHOOTING.md
+++ b/charts/influxdb3-enterprise/TROUBLESHOOTING.md
@@ -36,9 +36,9 @@ kubectl describe pod -n influxdb3 influxdb3-enterprise-ingester-0
     - Check node resources: `kubectl top nodes`
     - Solution: Add more nodes or reduce resource requests
 
-2. **PVC Not Bound**
+2. **Storage PVC Not Bound**
     - Check PVC status: `kubectl get pvc -n influxdb3`
-    - Solution: Verify StorageClass exists and can provision volumes
+    - Solution: Verify StorageClass exists and can provision object-storage or plugin volumes
 
 3. **Node Selector/Affinity**
     - Check if nodes match selector
@@ -175,18 +175,18 @@ Failed to connect to object store: connection refused
 - **Endpoint**: Ensure `objectStorage.s3.endpoint` is correct
 - **Credentials**: Rotate and update access keys
 
-### PVC Not Binding
+### Storage PVC Not Binding
 
 **Error:**
 ```bash
 kubectl get pvc -n influxdb3
 NAME                              STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS
-data-influxdb3-enterprise-ingester-0   Pending                                  gp3
+influxdb3-enterprise-object-storage   Pending                                  nfs
 ```
 
 **Diagnosis:**
 ```bash
-kubectl describe pvc -n influxdb3 data-influxdb3-enterprise-ingester-0
+kubectl describe pvc -n influxdb3 influxdb3-enterprise-object-storage
 ```
 
 **Common Causes:**
@@ -212,11 +212,15 @@ WAL directory full, cannot accept more writes
 
 **Solution:**
 
-1. **Increase PVC size:**
+1. **Verify object storage capacity and connectivity:**
+   - For cloud object stores, check bucket/container quota, credentials, and endpoint connectivity
+   - For `objectStorage.type=file`, increase the shared object-storage PVC size:
    ```yaml
-   ingester:
-     persistence:
-       size: "20Gi"  # Increase from 10Gi
+   objectStorage:
+     type: file
+     file:
+       persistence:
+         size: "200Gi"
    ```
 
 2. **Force snapshot creation:**

--- a/charts/influxdb3-enterprise/ci/auth-existing-secret-values.yaml
+++ b/charts/influxdb3-enterprise/ci/auth-existing-secret-values.yaml
@@ -2,7 +2,11 @@ license:
   existingSecret: influxdb3-license
 
 objectStorage:
-  type: memory
+  type: file
+  file:
+    persistence:
+      accessMode: ReadWriteOnce
+      size: 5Gi
 
 ingress:
   enabled: false
@@ -58,6 +62,3 @@ security:
       existingSecret: influxdb3-bootstrap-tokens
     permissionTokens:
       existingSecret: influxdb3-bootstrap-tokens
-
-cluster:
-  waitForRunningIngestor: "60s"

--- a/charts/influxdb3-enterprise/ci/auth-existing-secret-values.yaml
+++ b/charts/influxdb3-enterprise/ci/auth-existing-secret-values.yaml
@@ -58,3 +58,6 @@ security:
       existingSecret: influxdb3-bootstrap-tokens
     permissionTokens:
       existingSecret: influxdb3-bootstrap-tokens
+
+cluster:
+  waitForRunningIngestor: "60s"

--- a/charts/influxdb3-enterprise/ci/auth-existing-secret-values.yaml
+++ b/charts/influxdb3-enterprise/ci/auth-existing-secret-values.yaml
@@ -14,8 +14,8 @@ ingester:
       cpu: "250m"
       memory: "512Mi"
     limits:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "2000m"
+      memory: "4Gi"
   persistence:
     enabled: false
 
@@ -26,8 +26,8 @@ querier:
       cpu: "250m"
       memory: "512Mi"
     limits:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "2000m"
+      memory: "4Gi"
 
 compactor:
   replicas: 1
@@ -36,8 +36,8 @@ compactor:
       cpu: "250m"
       memory: "512Mi"
     limits:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "2000m"
+      memory: "4Gi"
 
 processingEngine:
   enabled: true
@@ -47,8 +47,8 @@ processingEngine:
       cpu: "250m"
       memory: "512Mi"
     limits:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "2000m"
+      memory: "4Gi"
   persistence:
     enabled: false
 

--- a/charts/influxdb3-enterprise/ci/auth-file-values.yaml
+++ b/charts/influxdb3-enterprise/ci/auth-file-values.yaml
@@ -68,3 +68,6 @@ extraVolumeMounts:
   - name: bootstrap-tokens
     mountPath: /etc/influxdb/bootstrap
     readOnly: true
+
+cluster:
+  waitForRunningIngestor: "60s"

--- a/charts/influxdb3-enterprise/ci/auth-file-values.yaml
+++ b/charts/influxdb3-enterprise/ci/auth-file-values.yaml
@@ -2,7 +2,11 @@ license:
   existingSecret: influxdb3-license
 
 objectStorage:
-  type: memory
+  type: file
+  file:
+    persistence:
+      accessMode: ReadWriteOnce
+      size: 5Gi
 
 ingress:
   enabled: false
@@ -68,6 +72,3 @@ extraVolumeMounts:
   - name: bootstrap-tokens
     mountPath: /etc/influxdb/bootstrap
     readOnly: true
-
-cluster:
-  waitForRunningIngestor: "60s"

--- a/charts/influxdb3-enterprise/ci/auth-file-values.yaml
+++ b/charts/influxdb3-enterprise/ci/auth-file-values.yaml
@@ -14,8 +14,8 @@ ingester:
       cpu: "250m"
       memory: "512Mi"
     limits:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "2000m"
+      memory: "4Gi"
   persistence:
     enabled: false
 
@@ -26,8 +26,8 @@ querier:
       cpu: "250m"
       memory: "512Mi"
     limits:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "2000m"
+      memory: "4Gi"
 
 compactor:
   replicas: 1
@@ -36,8 +36,8 @@ compactor:
       cpu: "250m"
       memory: "512Mi"
     limits:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "2000m"
+      memory: "4Gi"
 
 processingEngine:
   enabled: true
@@ -47,8 +47,8 @@ processingEngine:
       cpu: "250m"
       memory: "512Mi"
     limits:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "2000m"
+      memory: "4Gi"
   persistence:
     enabled: false
 

--- a/charts/influxdb3-enterprise/ci/component-extra-env-values.yaml
+++ b/charts/influxdb3-enterprise/ci/component-extra-env-values.yaml
@@ -2,7 +2,11 @@ license:
   existingSecret: influxdb3-license
 
 objectStorage:
-  type: memory
+  type: file
+  file:
+    persistence:
+      accessMode: ReadWriteOnce
+      size: 5Gi
 
 ingress:
   enabled: false
@@ -75,6 +79,3 @@ processingEngine:
       value: "processor-only"
   persistence:
     enabled: false
-
-cluster:
-  waitForRunningIngestor: "60s"

--- a/charts/influxdb3-enterprise/ci/component-extra-env-values.yaml
+++ b/charts/influxdb3-enterprise/ci/component-extra-env-values.yaml
@@ -75,3 +75,6 @@ processingEngine:
       value: "processor-only"
   persistence:
     enabled: false
+
+cluster:
+  waitForRunningIngestor: "60s"

--- a/charts/influxdb3-enterprise/ci/component-extra-env-values.yaml
+++ b/charts/influxdb3-enterprise/ci/component-extra-env-values.yaml
@@ -22,8 +22,8 @@ ingester:
       cpu: "250m"
       memory: "512Mi"
     limits:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "2000m"
+      memory: "4Gi"
   extraEnv:
     - name: INFLUXDB3_UNSET_VARS
       value: "INFLUXDB3_PLUGIN_DIR INFLUXDB3_HTTP_BIND_ADDR"
@@ -39,8 +39,8 @@ querier:
       cpu: "250m"
       memory: "512Mi"
     limits:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "2000m"
+      memory: "4Gi"
   extraEnv:
     - name: INFLUXDB3_UNSET_VARS
       value: "INFLUXDB3_PLUGIN_DIR INFLUXDB3_HTTP_BIND_ADDR"
@@ -52,8 +52,8 @@ compactor:
       cpu: "250m"
       memory: "512Mi"
     limits:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "2000m"
+      memory: "4Gi"
   extraEnv:
     - name: INFLUXDB3_UNSET_VARS
       value: "INFLUXDB3_PLUGIN_DIR INFLUXDB3_HTTP_BIND_ADDR"
@@ -66,8 +66,8 @@ processingEngine:
       cpu: "250m"
       memory: "512Mi"
     limits:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "2000m"
+      memory: "4Gi"
   extraEnv:
     - name: INFLUXDB3_UNSET_VARS
       value: "INFLUXDB3_HTTP_BIND_ADDR"

--- a/charts/influxdb3-enterprise/ci/default-values.yaml
+++ b/charts/influxdb3-enterprise/ci/default-values.yaml
@@ -2,7 +2,11 @@ license:
   existingSecret: influxdb3-license
 
 objectStorage:
-  type: memory
+  type: file
+  file:
+    persistence:
+      accessMode: ReadWriteOnce
+      size: 5Gi
 
 ingress:
   enabled: false
@@ -51,6 +55,3 @@ processingEngine:
       memory: "4Gi"
   persistence:
     enabled: false
-
-cluster:
-  waitForRunningIngestor: "60s"

--- a/charts/influxdb3-enterprise/ci/default-values.yaml
+++ b/charts/influxdb3-enterprise/ci/default-values.yaml
@@ -51,3 +51,6 @@ processingEngine:
       memory: "4Gi"
   persistence:
     enabled: false
+
+cluster:
+  waitForRunningIngestor: "60s"

--- a/charts/influxdb3-enterprise/ci/default-values.yaml
+++ b/charts/influxdb3-enterprise/ci/default-values.yaml
@@ -14,8 +14,8 @@ ingester:
       cpu: "250m"
       memory: "512Mi"
     limits:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "2000m"
+      memory: "4Gi"
   persistence:
     enabled: false
 
@@ -26,8 +26,8 @@ querier:
       cpu: "250m"
       memory: "512Mi"
     limits:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "2000m"
+      memory: "4Gi"
 
 compactor:
   replicas: 1
@@ -36,8 +36,8 @@ compactor:
       cpu: "250m"
       memory: "512Mi"
     limits:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "2000m"
+      memory: "4Gi"
 
 processingEngine:
   enabled: true
@@ -47,7 +47,7 @@ processingEngine:
       cpu: "250m"
       memory: "512Mi"
     limits:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "2000m"
+      memory: "4Gi"
   persistence:
     enabled: false

--- a/charts/influxdb3-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb3-enterprise/templates/_helpers.tpl
@@ -419,6 +419,10 @@ Image reference
 Shared volume mounts (license/TLS/GCS and user extras)
 */}}
 {{- define "influxdb3-enterprise.sharedVolumeMounts" -}}
+{{- if eq .Values.objectStorage.type "file" }}
+- name: object-storage
+  mountPath: {{ .Values.objectStorage.file.dataDir }}
+{{- end }}
 {{- if eq .Values.objectStorage.type "google" }}
 - name: google-service-account
   mountPath: /var/secrets/google

--- a/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
@@ -124,14 +124,6 @@ spec:
           resources:
             {{- toYaml .Values.ingester.resources | nindent 12 }}
           volumeMounts:
-          {{- if .Values.ingester.persistence.enabled }}
-            - name: wal
-              {{- if eq .Values.objectStorage.type "file" }}
-              mountPath: {{ .Values.objectStorage.file.dataDir }}/.wal
-              {{- else }}
-              mountPath: /var/lib/influxdb3/.wal
-              {{- end }}
-          {{- end }}
             {{ include "influxdb3-enterprise.sharedVolumeMounts" . | nindent 12 }}
             {{ include "influxdb3-enterprise.adminTokenVolumeMounts" . | nindent 12 }}
             {{ include "influxdb3-enterprise.permissionTokensVolumeMounts" . | nindent 12 }}
@@ -151,18 +143,4 @@ spec:
         {{ include "influxdb3-enterprise.sharedVolumes" . | nindent 8 }}
         {{ include "influxdb3-enterprise.adminTokenVolumes" . | nindent 8 }}
         {{ include "influxdb3-enterprise.permissionTokensVolumes" . | nindent 8 }}
-  {{- if .Values.ingester.persistence.enabled }}
-  volumeClaimTemplates:
-    - metadata:
-        name: wal
-      spec:
-        accessModes:
-          - {{ .Values.ingester.persistence.accessMode }}
-      {{- if .Values.ingester.persistence.storageClass }}
-        storageClassName: {{ .Values.ingester.persistence.storageClass | quote }}
-      {{- end }}
-        resources:
-          requests:
-            storage: {{ .Values.ingester.persistence.size }}
-  {{- end }}
 {{- end }}

--- a/charts/influxdb3-enterprise/templates/pvc-object-storage.yaml
+++ b/charts/influxdb3-enterprise/templates/pvc-object-storage.yaml
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/component: object-storage
 spec:
   accessModes:
-    - {{ .Values.objectStorage.file.persistence.accessMode }}
+    - {{ .Values.objectStorage.file.persistence.accessMode | default "ReadWriteMany" }}
   {{- if .Values.objectStorage.file.persistence.storageClass }}
   {{- if (eq "-" .Values.objectStorage.file.persistence.storageClass) }}
   storageClassName: ""

--- a/charts/influxdb3-enterprise/templates/pvc-object-storage.yaml
+++ b/charts/influxdb3-enterprise/templates/pvc-object-storage.yaml
@@ -4,15 +4,15 @@
 # This PVC is only created when objectStorage.type is "file"
 # All components (ingesters, queriers, compactor) will mount this shared volume
 #
-# IMPORTANT: Requires a StorageClass that supports ReadWriteMany (RWX) access mode
+# Access mode is configurable via objectStorage.file.persistence.accessMode (default ReadWriteMany).
+# RWX is required when components can run on different nodes; ReadWriteOnce is
+# only suitable when all pods run on the same node, such as single-node test clusters.
 # Common RWX-capable storage classes:
 # - NFS
 # - CephFS
 # - Azure Files
 # - GlusterFS
 # - EFS (AWS)
-#
-# For local testing without RWX support, consider using MinIO instead
 # ============================================================================
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/influxdb3-enterprise/templates/pvc-object-storage.yaml
+++ b/charts/influxdb3-enterprise/templates/pvc-object-storage.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.objectStorage.type "file" }}
 # PersistentVolumeClaim for file-based object storage
 #
 # This PVC is only created when objectStorage.type is "file"
@@ -13,7 +14,6 @@
 #
 # For local testing without RWX support, consider using MinIO instead
 # ============================================================================
-{{- if eq .Values.objectStorage.type "file" }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/component: object-storage
 spec:
   accessModes:
-    - ReadWriteMany  # Required: All pods need to access the same storage
+    - {{ .Values.objectStorage.file.persistence.accessMode }}
   {{- if .Values.objectStorage.file.persistence.storageClass }}
   {{- if (eq "-" .Values.objectStorage.file.persistence.storageClass) }}
   storageClassName: ""

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -121,10 +121,11 @@ objectStorage:
 
   # Local filesystem (for development/testing only)
   # NOT RECOMMENDED for production - use cloud object storage
-  # Requires RWX storage; PVC is always created when type=file
+  # Creates one shared RWX PVC mounted by Enterprise components when type=file
   file:
     dataDir: "/var/lib/influxdb3"
     persistence:
+      accessMode: ReadWriteMany     # Use ReadWriteOnce only for single-node local testing
       storageClass: ""
       size: 100Gi
 
@@ -206,9 +207,11 @@ ingester:
   #   snapshotFilesToKeep: 300          # Snapshotted WAL files to retain
   #   replayFailOnError: false
 
-  # Persistent storage for Write-Ahead Log (WAL)
+  # Deprecated: WAL files are persisted through the configured object store.
+  # This value is retained only for chart compatibility and is not used by
+  # default templates.
   persistence:
-    enabled: true
+    enabled: false
     storageClass: ""                # Use default storage class
     size: "10Gi"                    # Minimum 2Gi recommended
     accessMode: ReadWriteOnce

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -207,14 +207,12 @@ ingester:
   #   snapshotFilesToKeep: 300          # Snapshotted WAL files to retain
   #   replayFailOnError: false
 
-  # Deprecated: WAL files are persisted through the configured object store.
-  # This value is retained only for chart compatibility and is not used by
+  # Deprecated: retained only so old values files that set
+  # ingester.persistence.enabled remain recognizable. WAL files are persisted
+  # through the configured object store, and ingester.persistence is not used by
   # default templates.
   persistence:
     enabled: false
-    storageClass: ""                # Use default storage class
-    size: "10Gi"                    # Minimum 2Gi recommended
-    accessMode: ReadWriteOnce
 
   # Pod affinity/anti-affinity, node selectors, tolerations
   # Default: soft anti-affinity to spread pods across nodes when possible

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -664,12 +664,13 @@ probes:
 
   # Startup probe settings
   # Protects container during initialization. Once successful, never runs again.
-  # For ~15s startup: 10s initial + (12 × 5s) = 70s total (4-5x safety buffer)
+  # Allows slower startup without delaying successful readiness detection.
+  # 10s initial + (30 × 5s) = 160s total.
   startup:
-    initialDelaySeconds: 10           # Wait ~50% of expected startup time
+    initialDelaySeconds: 10
     periodSeconds: 5                  # Check every 5 seconds
     timeoutSeconds: 5
-    failureThreshold: 12              # 10s + (12 × 5s) = 70s total
+    failureThreshold: 30
 
   # Liveness probe settings
   # Only starts checking AFTER startup probe succeeds


### PR DESCRIPTION
Closes #806 

Removes the dedicated ingester WAL `PersistentVolumeClaim`. InfluxDB 3 Enterprise persists the WAL in the configured object store, so a separate volume isn't needed. Per the [durability docs](https://docs.influxdata.com/influxdb3/enterprise/reference/internals/durability/), no separate local disk volume is required for the WAL itself since it lives in the object store.

Changes:
  - Drops the ingester WAL `volumeClaimTemplate` and `mount`.
  - For `objectStorage.type=file`, mounts the shared object-storage PVC at `dataDir` across all components (previously declared but never mounted).
  - Makes the file object-storage PVC access mode configurable (`objectStorage.file.persistence.accessMode`, default `ReadWriteMany`).
  - Deprecates `ingester.persistence.*` (kept for compatibility, unused).
  -  Documents the 0.6.x upgrade path for the immutable `StatefulSet` change, including old WAL PVC cleanup and the `objectStorage.type=file` backup caveat. Object store of `file` type is dev/test-only, not recommended for production, which simplifies upgrade (no WAL data migration).  
