### PR TITLE
feat(influxdb3-ent): add automountServiceAccountToken support

### DIFF
--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: "3.9.3"
 keywords:
   - influxdb

--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.7.1
+version: 0.7.2
 appVersion: "3.9.3"
 keywords:
   - influxdb

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -636,6 +636,7 @@ logs:
 | `security.auth.permissionTokens.existingSecret` | Secret with offline permission tokens key `permission-tokens.json` | `""` |
 | `security.auth.permissionTokens.file` | Path to offline permission tokens file; mutually exclusive with `security.auth.permissionTokens.existingSecret` | `""` |
 | `security.auth.adminToken.recovery.httpBind` | Bind address for admin token recovery endpoint (`INFLUXDB3_ADMIN_TOKEN_RECOVERY_HTTP_BIND`) | `""` |
+| `serviceAccount.automountServiceAccountToken` | Configure automatic mounting of the Kubernetes service account token in component pods and the created ServiceAccount | not set |
 | `extraEnv` | Extra environment variables applied to all components | `[]` |
 
 ### Object Storage Parameters

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -636,7 +636,7 @@ logs:
 | `security.auth.permissionTokens.existingSecret` | Secret with offline permission tokens key `permission-tokens.json` | `""` |
 | `security.auth.permissionTokens.file` | Path to offline permission tokens file; mutually exclusive with `security.auth.permissionTokens.existingSecret` | `""` |
 | `security.auth.adminToken.recovery.httpBind` | Bind address for admin token recovery endpoint (`INFLUXDB3_ADMIN_TOKEN_RECOVERY_HTTP_BIND`) | `""` |
-| `serviceAccount.automountServiceAccountToken` | Configure automatic mounting of the Kubernetes service account token in component pods and the created ServiceAccount | not set |
+| `serviceAccount.automountServiceAccountToken` | Configure automatic mounting of the Kubernetes service account token in component pods and the created ServiceAccount | `not set` |
 | `extraEnv` | Extra environment variables applied to all components | `[]` |
 
 ### Object Storage Parameters

--- a/charts/influxdb3-enterprise/ci/auth-existing-secret-values.yaml
+++ b/charts/influxdb3-enterprise/ci/auth-existing-secret-values.yaml
@@ -11,6 +11,9 @@ objectStorage:
 ingress:
   enabled: false
 
+serviceAccount:
+  automountServiceAccountToken: false
+
 ingester:
   replicas: 1
   resources:

--- a/charts/influxdb3-enterprise/templates/compactor-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/compactor-statefulset.yaml
@@ -44,6 +44,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "influxdb3-enterprise.serviceAccountName" . }}
+      {{- if not (kindIs "invalid" .Values.serviceAccount.automountServiceAccountToken) }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- end }}
       {{- if .Values.compactor.priorityClassName }}
       priorityClassName: {{ .Values.compactor.priorityClassName }}
       {{- end }}

--- a/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
@@ -39,6 +39,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "influxdb3-enterprise.serviceAccountName" . }}
+      {{- if not (kindIs "invalid" .Values.serviceAccount.automountServiceAccountToken) }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- end }}
       {{- if .Values.ingester.priorityClassName }}
       priorityClassName: {{ .Values.ingester.priorityClassName }}
       {{- end }}

--- a/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
@@ -83,6 +83,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "influxdb3-enterprise.serviceAccountName" . }}
+      {{- if not (kindIs "invalid" .Values.serviceAccount.automountServiceAccountToken) }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- end }}
       {{- if .Values.processingEngine.priorityClassName }}
       priorityClassName: {{ .Values.processingEngine.priorityClassName }}
       {{- end }}

--- a/charts/influxdb3-enterprise/templates/querier-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/querier-statefulset.yaml
@@ -39,6 +39,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "influxdb3-enterprise.serviceAccountName" . }}
+      {{- if not (kindIs "invalid" .Values.serviceAccount.automountServiceAccountToken) }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- end }}
       {{- if .Values.querier.priorityClassName }}
       priorityClassName: {{ .Values.querier.priorityClassName }}
       {{- end }}

--- a/charts/influxdb3-enterprise/templates/serviceaccount.yaml
+++ b/charts/influxdb3-enterprise/templates/serviceaccount.yaml
@@ -10,4 +10,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- if not (kindIs "invalid" .Values.serviceAccount.automountServiceAccountToken) }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -856,6 +856,10 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  # Specifies whether to automatically mount the Kubernetes service account token.
+  # Set to false to comply with policies that restrict token mounting.
+  # If not set, Kubernetes default behavior applies.
+  # automountServiceAccountToken: false
 
 # ============================================================================
 # Additional Configuration


### PR DESCRIPTION
Closes #810 

Adds optional control over k8s service account token mounting for pods.
  - When `serviceAccount.automountServiceAccountToken` is set, the chart applies it to the created `ServiceAccount` and all component pods. Set it to `false` to disable token mounting for security policy compliance.
  - For backward compatibility, the default `values.yaml` leaves this key commented out, so the “not set” behavior is preserved and k8s defaults continue to apply.

---

Validation:
```
$kubectl get serviceaccount influxdb3-ozone-influxdb3-enterprise -n influxdb3-ozone \
    -o yaml | grep automountServiceAccountToken

automountServiceAccountToken: false
```
```
$kubectl get statefulset -n influxdb3-ozone \
    influxdb3-ozone-influxdb3-enterprise-ingester \
    influxdb3-ozone-influxdb3-enterprise-querier \
    influxdb3-ozone-influxdb3-enterprise-compactor \
    influxdb3-ozone-influxdb3-enterprise-processor \
    -o yaml | grep automountServiceAccountToken

        automountServiceAccountToken: false
        automountServiceAccountToken: false
        automountServiceAccountToken: false
        automountServiceAccountToken: false
```
```
$for pod in $(kubectl get pods -n influxdb3-ozone \
    -l app.kubernetes.io/instance=influxdb3-ozone \
    -o jsonpath='{.items[*].metadata.name}'); do
    echo "== $pod =="
    kubectl exec -n influxdb3-ozone "$pod" -- \
      ls /var/run/secrets/kubernetes.io/serviceaccount/
  done

== influxdb3-ozone-influxdb3-enterprise-compactor-0 ==
ls: cannot access '/var/run/secrets/kubernetes.io/serviceaccount/': No such file or directory
command terminated with exit code 2
== influxdb3-ozone-influxdb3-enterprise-ingester-0 ==
ls: cannot access '/var/run/secrets/kubernetes.io/serviceaccount/': No such file or directory
command terminated with exit code 2
== influxdb3-ozone-influxdb3-enterprise-processor-0 ==
ls: cannot access '/var/run/secrets/kubernetes.io/serviceaccount/': No such file or directory
command terminated with exit code 2
== influxdb3-ozone-influxdb3-enterprise-querier-0 ==
ls: cannot access '/var/run/secrets/kubernetes.io/serviceaccount/': No such file or directory
command terminated with exit code 2
```
```
$ kubeaudit all --namespace influxdb3-ozone --no-color | grep AutomountServiceAccountTokenTrueAndDefaultSA

[WARNING]: kubernetes.io for override labels will soon be deprecated. Please, update them to use kubeaudit.io instead.
```