### PR TITLE
fix(influxdb3-ent): avoid duplicate INFLUXDB3_UNSET_VARS

### DIFF
--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.7.1
+version: 0.7.2
 appVersion: "3.9.3"
 keywords:
   - influxdb

--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.7.2
+version: 0.7.3
 appVersion: "3.9.3"
 keywords:
   - influxdb

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -368,11 +368,13 @@ extraEnv:
 Use component-specific `extraEnv` to target only one component. Component-specific entries override top-level `extraEnv` entries with the same `name`.
 
 ```yaml
-processingEngine:
+ingester:
   extraEnv:
-    - name: INFLUXDB3_UNSET_VARS
-      value: "INFLUXDB3_PLUGIN_DIR"
+    - name: CUSTOM_INGESTER_VAR
+      value: "custom-value"
 ```
+
+Non-processor pods set `INFLUXDB3_UNSET_VARS=INFLUXDB3_PLUGIN_DIR` by default to keep the Processing Engine disabled. If you override `INFLUXDB3_UNSET_VARS` through top-level or component `extraEnv`, include `INFLUXDB3_PLUGIN_DIR` yourself or the Processing Engine may initialize on those pods.
 
 #### Monitoring
 

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -374,7 +374,9 @@ ingester:
       value: "custom-value"
 ```
 
-Non-processor pods set `INFLUXDB3_UNSET_VARS=INFLUXDB3_PLUGIN_DIR` by default to keep the Processing Engine disabled. If you override `INFLUXDB3_UNSET_VARS` through top-level or component `extraEnv`, include `INFLUXDB3_PLUGIN_DIR` yourself or the Processing Engine may initialize on those pods.
+Non-processor pods set `INFLUXDB3_UNSET_VARS=INFLUXDB3_PLUGIN_DIR` by default to keep the Processing Engine disabled. If you override `INFLUXDB3_UNSET_VARS`, include `INFLUXDB3_PLUGIN_DIR` yourself or the Processing Engine may initialize on those pods.
+
+When processor pods are enabled, configure `INFLUXDB3_UNSET_VARS` with component-specific overrides for `ingester`, `querier`, and `compactor` instead of top-level `extraEnv`. Component-specific overrides do not apply to processor pods; a top-level `INFLUXDB3_UNSET_VARS` override is also applied to processor pods and can disable the Processing Engine there.
 
 #### Monitoring
 

--- a/charts/influxdb3-enterprise/ci/component-extra-env-values.yaml
+++ b/charts/influxdb3-enterprise/ci/component-extra-env-values.yaml
@@ -30,7 +30,7 @@ ingester:
       memory: "4Gi"
   extraEnv:
     - name: INFLUXDB3_UNSET_VARS
-      value: "INFLUXDB3_PLUGIN_DIR,INFLUXDB3_HTTP_BIND_ADDR"
+      value: "INFLUXDB3_PLUGIN_DIR INFLUXDB3_HTTP_BIND_ADDR"
     - name: GLOBAL_COMPONENT_OVERRIDE_TEST
       value: "ingester"
   persistence:
@@ -47,7 +47,7 @@ querier:
       memory: "4Gi"
   extraEnv:
     - name: INFLUXDB3_UNSET_VARS
-      value: "INFLUXDB3_PLUGIN_DIR,INFLUXDB3_HTTP_BIND_ADDR"
+      value: "INFLUXDB3_PLUGIN_DIR INFLUXDB3_HTTP_BIND_ADDR"
 
 compactor:
   replicas: 1
@@ -60,7 +60,7 @@ compactor:
       memory: "4Gi"
   extraEnv:
     - name: INFLUXDB3_UNSET_VARS
-      value: "INFLUXDB3_PLUGIN_DIR,INFLUXDB3_HTTP_BIND_ADDR"
+      value: "INFLUXDB3_PLUGIN_DIR INFLUXDB3_HTTP_BIND_ADDR"
 
 processingEngine:
   enabled: true

--- a/charts/influxdb3-enterprise/ci/component-extra-env-values.yaml
+++ b/charts/influxdb3-enterprise/ci/component-extra-env-values.yaml
@@ -30,7 +30,7 @@ ingester:
       memory: "4Gi"
   extraEnv:
     - name: INFLUXDB3_UNSET_VARS
-      value: "INFLUXDB3_PLUGIN_DIR INFLUXDB3_HTTP_BIND_ADDR"
+      value: "INFLUXDB3_PLUGIN_DIR,INFLUXDB3_HTTP_BIND_ADDR"
     - name: GLOBAL_COMPONENT_OVERRIDE_TEST
       value: "ingester"
   persistence:
@@ -47,7 +47,7 @@ querier:
       memory: "4Gi"
   extraEnv:
     - name: INFLUXDB3_UNSET_VARS
-      value: "INFLUXDB3_PLUGIN_DIR INFLUXDB3_HTTP_BIND_ADDR"
+      value: "INFLUXDB3_PLUGIN_DIR,INFLUXDB3_HTTP_BIND_ADDR"
 
 compactor:
   replicas: 1
@@ -60,7 +60,7 @@ compactor:
       memory: "4Gi"
   extraEnv:
     - name: INFLUXDB3_UNSET_VARS
-      value: "INFLUXDB3_PLUGIN_DIR INFLUXDB3_HTTP_BIND_ADDR"
+      value: "INFLUXDB3_PLUGIN_DIR,INFLUXDB3_HTTP_BIND_ADDR"
 
 processingEngine:
   enabled: true

--- a/charts/influxdb3-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb3-enterprise/templates/_helpers.tpl
@@ -365,6 +365,27 @@ Component-specific entries override global entries with the same name.
 {{- end }}
 
 {{/*
+Air-gap protection for non-processor pods. If the user explicitly sets
+INFLUXDB3_UNSET_VARS through extraEnv, that value is authoritative.
+Docs:
+https://docs.influxdata.com/influxdb3/enterprise/reference/config-options/#disable-the-processing-engine
+*/}}
+{{- define "influxdb3-enterprise.nonProcessorUnsetVars" -}}
+{{- $global := .root.Values.extraEnv | default (list) -}}
+{{- $component := .component.extraEnv | default (list) -}}
+{{- $userSet := false -}}
+{{- range (concat $global $component) -}}
+{{- if eq (.name | default "") "INFLUXDB3_UNSET_VARS" -}}
+{{- $userSet = true -}}
+{{- end -}}
+{{- end -}}
+{{- if not $userSet }}
+- name: INFLUXDB3_UNSET_VARS
+  value: "INFLUXDB3_PLUGIN_DIR"
+{{- end -}}
+{{- end }}
+
+{{/*
 Probe configuration (shared across components)
 */}}
 {{- define "influxdb3-enterprise.probes" -}}

--- a/charts/influxdb3-enterprise/templates/compactor-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/compactor-statefulset.yaml
@@ -124,10 +124,7 @@ spec:
               value: {{ .config | quote }}
             {{- end }}
             {{- end }}
-            # Prevent Processing Engine initialization on non-processor pods (air-gapped deployments)
-            # Official docs: https://docs.influxdata.com/influxdb3/enterprise/reference/config-options/#disable-the-processing-engine
-            - name: INFLUXDB3_UNSET_VARS
-              value: "INFLUXDB3_PLUGIN_DIR"
+            {{- include "influxdb3-enterprise.nonProcessorUnsetVars" (dict "root" . "component" .Values.compactor) | nindent 12 }}
             {{- include "influxdb3-enterprise.componentExtraEnv" (dict "root" . "component" .Values.compactor) | nindent 12 }}
           ports:
             - name: http

--- a/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
@@ -115,10 +115,7 @@ spec:
               value: {{ .config | quote }}
             {{- end }}
             {{- end }}
-            # Prevent Processing Engine initialization on non-processor pods (air-gapped deployments)
-            # Official docs: https://docs.influxdata.com/influxdb3/enterprise/reference/config-options/#disable-the-processing-engine
-            - name: INFLUXDB3_UNSET_VARS
-              value: "INFLUXDB3_PLUGIN_DIR"
+            {{- include "influxdb3-enterprise.nonProcessorUnsetVars" (dict "root" . "component" .Values.ingester) | nindent 12 }}
             {{- include "influxdb3-enterprise.componentExtraEnv" (dict "root" . "component" .Values.ingester) | nindent 12 }}
           ports:
             - name: http

--- a/charts/influxdb3-enterprise/templates/querier-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/querier-statefulset.yaml
@@ -93,10 +93,7 @@ spec:
               value: {{ .config | quote }}
             {{- end }}
             {{- end }}
-            # Prevent Processing Engine initialization on non-processor pods (air-gapped deployments)
-            # Official docs: https://docs.influxdata.com/influxdb3/enterprise/reference/config-options/#disable-the-processing-engine
-            - name: INFLUXDB3_UNSET_VARS
-              value: "INFLUXDB3_PLUGIN_DIR"
+            {{- include "influxdb3-enterprise.nonProcessorUnsetVars" (dict "root" . "component" .Values.querier) | nindent 12 }}
             {{- include "influxdb3-enterprise.componentExtraEnv" (dict "root" . "component" .Values.querier) | nindent 12 }}
           ports:
             - name: http

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -868,8 +868,11 @@ serviceAccount:
 # Extra environment variables for all pods. Component-specific extraEnv entries override
 # entries with the same name for one component.
 # Non-processor pods set INFLUXDB3_UNSET_VARS=INFLUXDB3_PLUGIN_DIR by default.
-# If you override INFLUXDB3_UNSET_VARS, include INFLUXDB3_PLUGIN_DIR yourself
-# or the Processing Engine may initialize on non-processor pods.
+# If you override INFLUXDB3_UNSET_VARS, include INFLUXDB3_PLUGIN_DIR yourself or the
+# Processing Engine may initialize on non-processor pods. When processor pods are enabled,
+# configure INFLUXDB3_UNSET_VARS with component-specific overrides for ingester, querier,
+# and compactor instead of top-level extraEnv. Component-specific overrides do not apply to
+# processor pods; a top-level override can disable the Processing Engine there.
 extraEnv: []
   # - name: CUSTOM_VAR
   #   value: "custom-value"

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -863,6 +863,9 @@ serviceAccount:
 
 # Extra environment variables for all pods. Component-specific extraEnv entries override
 # entries with the same name for one component.
+# Non-processor pods set INFLUXDB3_UNSET_VARS=INFLUXDB3_PLUGIN_DIR by default.
+# If you override INFLUXDB3_UNSET_VARS, include INFLUXDB3_PLUGIN_DIR yourself
+# or the Processing Engine may initialize on non-processor pods.
 extraEnv: []
   # - name: CUSTOM_VAR
   #   value: "custom-value"


### PR DESCRIPTION
This PR changes rendering of `INFLUXDB3_UNSET_VARS`. Renders non-processor pods `INFLUXDB3_UNSET_VARS` env var, introduced in #794, only when users do not override it through `extraEnv`. This avoids duplicate env entries while keeping user-provided low-level unset vars authoritative.

Reasoning: 

`INFLUXDB3_UNSET_VARS` is a low-level, expert knob. A user who sets it is deliberately reaching under the hood. The possible alternative "merge" approach would silently mutate the user's value (appending `INFLUXDB3_PLUGIN_DIR` to their value), which would lead to surprise someone who expects their `extraEnv` to be honored verbatim. Also, implementation would be non-trivial.
"Override-wins" avoids that surprise and keeps the code simple and consistent with the rest of the `extraEnv` model.