### PR TITLE
fix(influxdb3-ent): remove init plugins

### DIFF
--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.7.3
+version: 0.8.0
 appVersion: "3.9.3"
 keywords:
   - influxdb

--- a/charts/influxdb3-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb3-enterprise/templates/_helpers.tpl
@@ -537,20 +537,6 @@ Whether processor plugin volume mounts are present
 {{- end }}
 
 {{/*
-Whether processor pluginDir is actually mounted by processorPluginVolumeMounts
-*/}}
-{{- define "influxdb3-enterprise.hasProcessorPluginDirMount" -}}
-{{- $mounts := include "influxdb3-enterprise.processorPluginVolumeMounts" . -}}
-{{- $pluginDir := .pluginDir | default "/plugins" -}}
-{{- $needle := printf "mountPath: %s\n" $pluginDir -}}
-{{- if contains $needle (printf "%s\n" $mounts) -}}
-true
-{{- else -}}
-false
-{{- end -}}
-{{- end }}
-
-{{/*
 Shared volumes (license/TLS/GCS and user extras)
 */}}
 {{- define "influxdb3-enterprise.sharedVolumes" -}}

--- a/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
@@ -6,15 +6,10 @@
 {{- end }}
 {{- $pluginVolumeMountCtx := dict "root" . "pluginsPVCEnabled" $pluginsPVCEnabled "pluginDir" (.Values.processingEngine.pluginDir | default "/plugins") }}
 {{- $hasProcessorPluginVolumeMounts := eq (include "influxdb3-enterprise.hasProcessorPluginVolumeMounts" $pluginVolumeMountCtx) "true" }}
-{{- $hasProcessorPluginDirMount := eq (include "influxdb3-enterprise.hasProcessorPluginDirMount" $pluginVolumeMountCtx) "true" }}
 {{- $adminTokenVolumeMounts := include "influxdb3-enterprise.adminTokenVolumeMounts" . | trim }}
 {{- $hasAdminTokenVolumeMounts := ne $adminTokenVolumeMounts "" }}
 {{- $permissionTokensVolumeMounts := include "influxdb3-enterprise.permissionTokensVolumeMounts" . | trim }}
 {{- $hasPermissionTokensVolumeMounts := ne $permissionTokensVolumeMounts "" }}
-{{- $processorExtraEnv := include "influxdb3-enterprise.componentExtraEnv" (dict "root" . "component" .Values.processingEngine) | trim }}
-{{- if and (not $pluginsPVCEnabled) .Values.processingEngine.initPlugins (gt (len .Values.processingEngine.initPlugins) 0) (not $hasProcessorPluginDirMount) }}
-{{- fail "processingEngine.initPlugins requires processingEngine.pluginDir to be mounted. Set processingEngine.persistence.enabled=true or configure extraVolumes/extraVolumeMounts to mount processingEngine.pluginDir." }}
-{{- end }}
 
 apiVersion: apps/v1
 kind: StatefulSet
@@ -51,33 +46,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- if and .Values.processingEngine.initPlugins (gt (len .Values.processingEngine.initPlugins) 0) }}
-      initContainers:
-        {{- range .Values.processingEngine.initPlugins }}
-        - name: init-plugin-{{ .name | default "plugin" | replace "." "-" | replace "_" "-" | trunc 51 | trimSuffix "-" }}
-          image: {{ include "influxdb3-enterprise.image" $ }}
-          imagePullPolicy: {{ $.Values.image.pullPolicy }}
-          args:
-            - influxdb3
-            - install
-            - package
-            - {{ .name | quote }}
-            {{- with .source }}
-            - --source
-            - {{ . | quote }}
-            {{- end }}
-            - --plugin-dir
-            - {{ $.Values.processingEngine.pluginDir | default "/plugins" | quote }}
-          {{- if $processorExtraEnv }}
-          env:
-            {{- $processorExtraEnv | nindent 12 }}
-          {{- end }}
-          {{- if $hasProcessorPluginVolumeMounts }}
-          volumeMounts:
-            {{- include "influxdb3-enterprise.processorPluginVolumeMounts" $pluginVolumeMountCtx | nindent 12 }}
-          {{- end }}
-        {{- end }}
-      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -487,11 +487,6 @@ processingEngine:
     size: "5Gi"
     accessMode: ReadWriteOnce
 
-  # Pre-install plugins via initContainer (optional)
-  initPlugins: []
-    # - name: system-metrics
-    #   source: "gh:influxdata/system_metrics/system_metrics.py"
-
   # Pod affinity/anti-affinity, node selectors, tolerations
   # Default: soft anti-affinity to spread pods across nodes when possible
   affinity:


### PR DESCRIPTION
Closes #803 

Removes `processingEngine.initPlugins`, which is out of the chart's scope and broken by design: `influxdb3 install package` requires a running InfluxDB 3, which is not available from an init container.

Moreover, installing plugins is a one-time administrative task and not  something that should run on every chart install/upgrade.

Note: `influxdb3-core` chart has never supported it from the very beginning.