### PR TITLE
fix(influxdb3-ent): reject unsupported configurations

### DIFF
--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -3,7 +3,7 @@ name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
 version: 0.8.1
-appVersion: "3.9.9"
+appVersion: "3.9.11"
 keywords:
   - influxdb
   - time-series

--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.8.0
-appVersion: "3.9.3"
+version: 0.8.1
+appVersion: "3.9.9"
 keywords:
   - influxdb
   - time-series

--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.9.1
+version: 0.9.2
 appVersion: "3.10.5"
 keywords:
   - influxdb

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -30,7 +30,7 @@ InfluxDB 3 Enterprise is a high-performance time series database designed for pr
 - Helm 3.8+
 - Object storage (S3, Azure Blob Storage, or Google Cloud Storage)
 - RWX PersistentVolume provisioner support when using `objectStorage.type=file`
-- InfluxDB 3 Enterprise license (trial, home, or commercial)
+- InfluxDB 3 Enterprise license (trial or commercial)
 - **NGINX Ingress Controller** (required if using ingress, which is enabled by default)
 
 To install NGINX Ingress Controller:
@@ -250,14 +250,14 @@ For `objectStorage.type=s3`, `google`, or `azure`, the chart does not create a
 data or WAL PVC. WAL files, snapshots, catalog data, and Parquet files are
 persisted through the configured durable object store.
 
-For `objectStorage.type=memory` or `memory-throttled`, all object-store data
-(WAL files, snapshots, catalog data, and Parquet files) is held in memory and
-lost when the pod restarts. These modes are intended for testing only.
+`objectStorage.type=memory` and `memory-throttled` are not supported. Each
+component runs as a separate node, so in-process object storage cannot be
+shared across the cluster.
 
 For `objectStorage.type=file`, the chart creates one shared RWX object-storage
 PVC and mounts it at `objectStorage.file.dataDir` for Enterprise components.
-For single-node local testing only, where all pods run on the same node, you can
-set `objectStorage.file.persistence.accessMode=ReadWriteOnce` to use a
+For local testing where all pods run on the same Kubernetes node, you can set
+`objectStorage.file.persistence.accessMode=ReadWriteOnce` to use a
 local-path style StorageClass.
 
 #### Resource Configuration
@@ -631,8 +631,8 @@ logs:
 | `image.registry` | Image registry | `docker.io` |
 | `image.repository` | Image repository | `influxdb` |
 | `image.tag` | Image tag override (defaults to `<appVersion>-enterprise` when empty) | `""` |
-| `license.type` | trial, home, or commercial | `trial` |
-| `license.email` | Email for trial/home | `""` |
+| `license.type` | trial or commercial | `trial` |
+| `license.email` | Email for trial licenses | `""` |
 | `license.file` | License file content (use `--set-file license.file=/path/to/file`) | `""` |
 | `license.existingSecret` | Secret with `license-email` or `license-file` | `""` |
 | `security.auth.adminToken.existingSecret` | Secret with offline admin token key `admin-token.json` | `""` |
@@ -741,3 +741,8 @@ See `values.yaml` for complete parameter list.
 ## License
 
 InfluxDB 3 Enterprise software requires a valid license from InfluxData.
+
+This chart is designed exclusively for multi-node deployments and supports
+Trial and Commercial licenses. Home licenses are limited to one node and are
+not supported. For Home use, run the standalone Docker or binary deployment
+in all-mode.

--- a/charts/influxdb3-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb3-enterprise/templates/_helpers.tpl
@@ -95,9 +95,20 @@ Validate object storage type
 */}}
 {{- define "influxdb3-enterprise.validateObjectStorageType" -}}
 {{- $type := default "s3" .Values.objectStorage.type -}}
-{{- $valid := list "s3" "azure" "google" "file" "memory" "memory-throttled" -}}
+{{- $valid := list "s3" "azure" "google" "file" -}}
 {{- if not (has $type $valid) -}}
 {{- fail (printf "Invalid objectStorage.type: %s. Must be one of: %s" $type (join ", " $valid)) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate license type
+*/}}
+{{- define "influxdb3-enterprise.validateLicenseType" -}}
+{{- $type := default "trial" .Values.license.type -}}
+{{- $valid := list "trial" "commercial" -}}
+{{- if not (has $type $valid) -}}
+{{- fail (printf "Invalid license.type: %s. Must be one of: %s" $type (join ", " $valid)) -}}
 {{- end -}}
 {{- end }}
 
@@ -275,7 +286,7 @@ License environment (shared across components)
 {{- define "influxdb3-enterprise.licenseEnv" -}}
 {{- if or .Values.license.existingSecret (or .Values.license.email .Values.license.file) }}
 {{- $licenseType := .Values.license.type | default "trial" -}}
-{{- if and (or (eq $licenseType "trial") (eq $licenseType "home")) (or .Values.license.email .Values.license.existingSecret) }}
+{{- if and (eq $licenseType "trial") (or .Values.license.email .Values.license.existingSecret) }}
 - name: INFLUXDB3_ENTERPRISE_LICENSE_EMAIL
   valueFrom:
     secretKeyRef:
@@ -285,7 +296,7 @@ License environment (shared across components)
 {{- if .Values.license.file }}
 - name: INFLUXDB3_ENTERPRISE_LICENSE_FILE
   value: "/etc/influxdb/license"
-{{- else if and .Values.license.existingSecret (and (ne $licenseType "trial") (ne $licenseType "home")) }}
+{{- else if and .Values.license.existingSecret (eq $licenseType "commercial") }}
 - name: INFLUXDB3_ENTERPRISE_LICENSE_FILE
   value: "/etc/influxdb/license"
 {{- end }}
@@ -461,7 +472,7 @@ Shared volume mounts (license/TLS/GCS and user extras)
   mountPath: /etc/influxdb/license
   subPath: license
   readOnly: true
-{{- else if and .Values.license.existingSecret (and (ne $licenseType "trial") (ne $licenseType "home")) }}
+{{- else if and .Values.license.existingSecret (eq $licenseType "commercial") }}
 - name: license
   mountPath: /etc/influxdb/license
   subPath: license
@@ -571,7 +582,7 @@ Shared volumes (license/TLS/GCS and user extras)
     items:
       - key: license-file
         path: license
-{{- else if and .Values.license.existingSecret (and (ne $licenseType "trial") (ne $licenseType "home")) }}
+{{- else if and .Values.license.existingSecret (eq $licenseType "commercial") }}
 - name: license
   secret:
     secretName: {{ include "influxdb3-enterprise.licenseSecretName" . }}

--- a/charts/influxdb3-enterprise/templates/configmap.yaml
+++ b/charts/influxdb3-enterprise/templates/configmap.yaml
@@ -1,4 +1,5 @@
 {{- include "influxdb3-enterprise.validateObjectStorageType" . }}
+{{- include "influxdb3-enterprise.validateLicenseType" . }}
 {{- include "influxdb3-enterprise.validateAzureObjectStorageAuth" . }}
 {{- include "influxdb3-enterprise.validateS3ObjectStorageAuth" . }}
 {{- include "influxdb3-enterprise.validateGoogleObjectStorageAuth" . }}

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -38,7 +38,7 @@ cluster:
 # All nodes in the cluster must connect to the same object store.
 
 objectStorage:
-  # Object store type: s3, azure, google, file, memory, memory-throttled
+  # Object store type: s3, azure, google, file
   # Default: s3 (recommended for production)
   type: s3
 
@@ -125,30 +125,24 @@ objectStorage:
   file:
     dataDir: "/var/lib/influxdb3"
     persistence:
-      accessMode: ReadWriteMany     # Use ReadWriteOnce only for single-node local testing
+      accessMode: ReadWriteMany     # Use ReadWriteOnce only when all pods run on one Kubernetes node
       storageClass: ""
       size: 100Gi
-
-  # In-memory storage (no persistence)
-  # memory:
-
-  # In-memory storage (no persistence) but with latency and throughput that somewhat resembles a cloud object store
-  # memory-throttled:
 
 # ============================================================================
 # License Configuration (Shared across all components)
 # ============================================================================
-# InfluxDB 3 Enterprise requires a license. Three types available:
+# InfluxDB 3 Enterprise requires a license. Two types are supported:
 # - trial: 30-day trial with full features
-# - home: For at-home hobbyist use (limited to 2 cores)
 # - commercial: Full commercial license
+# Home licenses are single-node only and are not supported by this multi-node chart.
 
 license:
-  # License type: trial, home, or commercial
+  # License type: trial or commercial
   type: "trial"
 
-  # Email address for trial/home licenses
-  # Required for trial and home licenses
+  # Email address for trial licenses
+  # Required for trial licenses
   email: ""
 
   # License file content (for commercial licenses)


### PR DESCRIPTION
Rejects configurations that cannot work in this distributed (InfluxDB multi-node) chart:
- object store type `memory` and `memory-throttled` #809
- `home` license #814

Closes #809 #814 