### PR TITLE
feat(influxdb3-ent): upgrade InfluxDB to 3.10

### DIFF
--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -69,13 +69,13 @@ jobs:
         run: |
           kubectl create secret generic influxdb3-license \
             --namespace=default \
-            --from-literal=license-email=${INFLUXDB3_ENTERPRISE_TRIAL_LICENSE_EMAIL}
+            --from-literal=license-file="${INFLUXDB3_ENTERPRISE_LICENSE_KEY}"
           kubectl create secret generic influxdb3-bootstrap-tokens \
             --namespace=default \
             --from-file=admin-token.json=./charts/influxdb3-enterprise/ci/admin-token.json \
             --from-file=permission-tokens.json=./charts/influxdb3-enterprise/ci/permission-tokens.json
         env:
-          INFLUXDB3_ENTERPRISE_TRIAL_LICENSE_EMAIL: "${{ secrets.INFLUXDB3_ENTERPRISE_TRIAL_LICENSE_EMAIL }}"
+          INFLUXDB3_ENTERPRISE_LICENSE_KEY: "${{ secrets.INFLUXDB3_ENTERPRISE_LICENSE_KEY }}"
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.8.0
-appVersion: "3.9.3"
+version: 0.9.0
+appVersion: "3.10.5"
 keywords:
   - influxdb
   - time-series

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -684,6 +684,7 @@ logs:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `ingester.replicas` | Number of ingester replicas | `2` |
+| `ingester.internode.port` | Internode gRPC port used when the Processing Engine is enabled | `8183` |
 | `querier.replicas` | Number of querier replicas | `2` |
 | `compactor.replicas` | Number of compactor replicas | `1` (fixed) |
 | `processingEngine.enabled` | Enable Processing Engine | `false` |

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -695,6 +695,14 @@ logs:
 | `*.podDisruptionBudget.enabled` | Enable PDB per component | `false` |
 | `*.podDisruptionBudget.maxUnavailable` | Max unavailable when PDB enabled | component-specific |
 
+### Ingester internode Services
+
+When `processingEngine.enabled=true`, the chart creates one internal ClusterIP
+Service per ingester replica. Each Service is named exactly like its target Pod
+because that name is advertised through `--conn-info`. Scale ingesters by
+changing `ingester.replicas` and running a Helm upgrade; scaling the StatefulSet
+directly does not create or remove the corresponding Services.
+
 ### TLS Parameters
 
 | Parameter | Description | Default |

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -451,6 +451,19 @@ processingEngine:
 
 ## Upgrading
 
+### Upgrade from InfluxDB 3.9
+
+Chart 0.9.0 upgrades InfluxDB to 3.10.5. The first 3.10 startup automatically
+migrates catalog v2 to v3. This migration is one-way; restoring the catalog
+backup is required to return to 3.9.
+
+Follow [UPGRADING-3.9-TO-3.10.md](UPGRADING-3.9-TO-3.10.md). When Helm performs
+the upgrade, rendering is blocked until `acknowledgeCatalogMigration: true` is
+set in the values file. Template-only GitOps renderers such as Argo CD do not
+expose upgrade state, so the chart cannot enforce this gate. For those
+deployments, complete the guide and commit the acknowledgement to the GitOps
+values before synchronizing.
+
 ### Upgrade the Chart
 
 ```bash
@@ -627,6 +640,7 @@ logs:
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
+| `acknowledgeCatalogMigration` | Acknowledge the one-way InfluxDB 3.10 catalog migration during Helm upgrades | `false` |
 | `cluster.id` | Cluster identifier | `cluster-01` |
 | `image.registry` | Image registry | `docker.io` |
 | `image.repository` | Image repository | `influxdb` |

--- a/charts/influxdb3-enterprise/UPGRADING-3.9-TO-3.10.md
+++ b/charts/influxdb3-enterprise/UPGRADING-3.9-TO-3.10.md
@@ -1,0 +1,75 @@
+# Upgrade from InfluxDB 3 Enterprise 3.9 to 3.10
+
+InfluxDB 3.10 automatically, idempotently, and crash-safely migrates catalog
+v2 to v3 on first startup. The migration is one-way: InfluxDB 3.9 cannot read
+the migrated catalog. Returning to 3.9 requires restoring a pre-upgrade catalog
+backup.
+
+See the official [upgrade](https://docs.influxdata.com/influxdb3/enterprise/admin/upgrade/),
+[backup](https://docs.influxdata.com/influxdb3/enterprise/admin/backup-restore/),
+and [release](https://docs.influxdata.com/influxdb3/enterprise/release-notes/)
+documentation.
+
+## Before upgrading
+
+```bash
+export RELEASE=influxdb3-enterprise
+export NAMESPACE=influxdb3
+export VALUES_FILE=./my-values.yaml
+export TARGET_CHART_VERSION=0.9.0
+
+helm get values "$RELEASE" -n "$NAMESPACE" > pre-3.10-values.yaml
+kubectl get pods -n "$NAMESPACE" \
+  -l "app.kubernetes.io/instance=$RELEASE" \
+  -o custom-columns=NAME:.metadata.name,IMAGE:.spec.containers[0].image,READY:.status.containerStatuses[0].ready
+```
+
+Quiesce writes. Back up `{prefix}/catalog/v2/logs/` and
+`{prefix}/catalog/v2/snapshot` in object storage, and verify that the backup can
+be restored.
+
+If `VALUES_FILE` sets `image.tag`, remove the override or change it to
+`3.10.5-enterprise`. Otherwise, the chart continues deploying the overridden
+image.
+
+## Upgrade
+
+The chart does not enforce the documented ingester, querier, compactor upgrade
+order, so use a maintenance window.
+
+After completing the backup, persist the acknowledgement in your values file:
+
+```yaml
+acknowledgeCatalogMigration: true
+```
+
+```bash
+helm repo update
+helm upgrade "$RELEASE" influxdata/influxdb3-enterprise \
+  -n "$NAMESPACE" \
+  --version "$TARGET_CHART_VERSION" \
+  -f "$VALUES_FILE" \
+  --wait --timeout 30m
+```
+
+Do not use `--atomic`: after the catalog migration, rolling back to a 3.9 image
+fails unless the pre-upgrade catalog backup is restored. Do not enable
+`INFLUXDB3_UPGRADE_PACHA_TREE`; migrate the storage engine separately.
+
+## Verify
+
+```bash
+kubectl get pods -n "$NAMESPACE" \
+  -l "app.kubernetes.io/instance=$RELEASE" \
+  -o custom-columns=NAME:.metadata.name,IMAGE:.spec.containers[0].image,READY:.status.containerStatuses[0].ready
+```
+
+Confirm that every pod runs 3.10.5, then query existing data and test a new
+write. Do not downgrade without restoring the pre-upgrade catalog backup.
+
+## Existing 3.10 image override
+
+If the release already runs 3.10 through `image.tag`, its catalog is already
+migrated. Back up the catalog, remove or update the override, and still pass
+`acknowledgeCatalogMigration: true` in the values file; the chart cannot
+determine which image version was previously deployed.

--- a/charts/influxdb3-enterprise/UPGRADING-3.9-TO-3.10.md
+++ b/charts/influxdb3-enterprise/UPGRADING-3.9-TO-3.10.md
@@ -27,9 +27,9 @@ kubectl get pods -n "$NAMESPACE" \
   -o custom-columns=NAME:.metadata.name,IMAGE:.spec.containers[0].image,READY:.status.containerStatuses[0].ready
 ```
 
-Quiesce writes. Back up `{prefix}/catalog/v2/logs/` and
-`{prefix}/catalog/v2/snapshot` in object storage, and verify that the backup can
-be restored.
+Quiesce writes. Back up `{cluster-id}/catalog/v2/logs/` and
+`{cluster-id}/catalog/v2/snapshot` in object storage, where `{cluster-id}` is the
+configured `cluster.id` value. Verify that the backup can be restored.
 
 If `VALUES_FILE` sets `image.tag`, remove the override or change it to
 `3.10.5-enterprise`. Otherwise, the chart continues deploying the overridden

--- a/charts/influxdb3-enterprise/UPGRADING-3.9-TO-3.10.md
+++ b/charts/influxdb3-enterprise/UPGRADING-3.9-TO-3.10.md
@@ -13,8 +13,11 @@ documentation.
 ## Before upgrading
 
 ```bash
+# Set these to your existing Helm release name and namespace.
 export RELEASE=influxdb3-enterprise
 export NAMESPACE=influxdb3
+
+# Set this to the values file you will use for the upgrade.
 export VALUES_FILE=./my-values.yaml
 export TARGET_CHART_VERSION=0.9.0
 

--- a/charts/influxdb3-enterprise/UPGRADING-3.9-TO-3.10.md
+++ b/charts/influxdb3-enterprise/UPGRADING-3.9-TO-3.10.md
@@ -58,7 +58,8 @@ helm upgrade "$RELEASE" influxdata/influxdb3-enterprise \
 Do not use `--atomic`, and do not run `helm rollback` to a 3.9 revision after
 the catalog migration. Both can restore a 3.9 image while leaving the catalog
 at v3. To return to 3.9, first restore the pre-upgrade catalog backup. Do not
-enable `INFLUXDB3_UPGRADE_PACHA_TREE`; migrate the storage engine separately.
+enable `--use-pacha-tree` or set `INFLUXDB3_ENTERPRISE_USE_PACHA_TREE=true`
+during this upgrade; migrate the storage engine separately.
 
 ## Verify
 

--- a/charts/influxdb3-enterprise/UPGRADING-3.9-TO-3.10.md
+++ b/charts/influxdb3-enterprise/UPGRADING-3.9-TO-3.10.md
@@ -18,7 +18,7 @@ export NAMESPACE=influxdb3
 export VALUES_FILE=./my-values.yaml
 export TARGET_CHART_VERSION=0.9.0
 
-helm get values "$RELEASE" -n "$NAMESPACE" > pre-3.10-values.yaml
+helm get values "$RELEASE" -n "$NAMESPACE" -o yaml > pre-3.10-values.yaml
 kubectl get pods -n "$NAMESPACE" \
   -l "app.kubernetes.io/instance=$RELEASE" \
   -o custom-columns=NAME:.metadata.name,IMAGE:.spec.containers[0].image,READY:.status.containerStatuses[0].ready
@@ -52,9 +52,10 @@ helm upgrade "$RELEASE" influxdata/influxdb3-enterprise \
   --wait --timeout 30m
 ```
 
-Do not use `--atomic`: after the catalog migration, rolling back to a 3.9 image
-fails unless the pre-upgrade catalog backup is restored. Do not enable
-`INFLUXDB3_UPGRADE_PACHA_TREE`; migrate the storage engine separately.
+Do not use `--atomic`, and do not run `helm rollback` to a 3.9 revision after
+the catalog migration. Both can restore a 3.9 image while leaving the catalog
+at v3. To return to 3.9, first restore the pre-upgrade catalog backup. Do not
+enable `INFLUXDB3_UPGRADE_PACHA_TREE`; migrate the storage engine separately.
 
 ## Verify
 

--- a/charts/influxdb3-enterprise/ci/auth-existing-secret-values.yaml
+++ b/charts/influxdb3-enterprise/ci/auth-existing-secret-values.yaml
@@ -1,4 +1,5 @@
 license:
+  type: commercial
   existingSecret: influxdb3-license
 
 objectStorage:

--- a/charts/influxdb3-enterprise/ci/auth-file-values.yaml
+++ b/charts/influxdb3-enterprise/ci/auth-file-values.yaml
@@ -1,4 +1,5 @@
 license:
+  type: commercial
   existingSecret: influxdb3-license
 
 objectStorage:

--- a/charts/influxdb3-enterprise/ci/component-extra-env-values.yaml
+++ b/charts/influxdb3-enterprise/ci/component-extra-env-values.yaml
@@ -1,4 +1,5 @@
 license:
+  type: commercial
   existingSecret: influxdb3-license
 
 objectStorage:

--- a/charts/influxdb3-enterprise/ci/default-values.yaml
+++ b/charts/influxdb3-enterprise/ci/default-values.yaml
@@ -12,6 +12,9 @@ objectStorage:
 ingress:
   enabled: false
 
+networkPolicy:
+  enabled: true
+
 ingester:
   replicas: 1
   resources:

--- a/charts/influxdb3-enterprise/ci/default-values.yaml
+++ b/charts/influxdb3-enterprise/ci/default-values.yaml
@@ -1,4 +1,5 @@
 license:
+  type: commercial
   existingSecret: influxdb3-license
 
 objectStorage:

--- a/charts/influxdb3-enterprise/examples/values-production.yaml
+++ b/charts/influxdb3-enterprise/examples/values-production.yaml
@@ -16,7 +16,8 @@ objectStorage:
 
 license:
   type: "commercial"
-  email: "production@example.com"
+  # Secret must contain the commercial license under the `license-file` key.
+  existingSecret: "influxdb3-license"
 
 ingester:
   replicas: 3

--- a/charts/influxdb3-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb3-enterprise/templates/_helpers.tpl
@@ -94,7 +94,7 @@ License secret name
 Require acknowledgement of the InfluxDB 3.10 catalog migration.
 */}}
 {{- define "influxdb3-enterprise.validateCatalogMigrationAcknowledgement" -}}
-{{- if and .Release.IsUpgrade (not .Values.acknowledgeCatalogMigration) -}}
+{{- if and .Release.IsUpgrade (ne (toString .Values.acknowledgeCatalogMigration) "true") -}}
 {{- fail "InfluxDB 3.10 performs a one-way catalog migration. Follow UPGRADING-3.9-TO-3.10.md, then set acknowledgeCatalogMigration: true in your values file." -}}
 {{- end -}}
 {{- end }}

--- a/charts/influxdb3-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb3-enterprise/templates/_helpers.tpl
@@ -91,6 +91,15 @@ License secret name
 {{- end }}
 
 {{/*
+Require acknowledgement of the InfluxDB 3.10 catalog migration.
+*/}}
+{{- define "influxdb3-enterprise.validateCatalogMigrationAcknowledgement" -}}
+{{- if and .Release.IsUpgrade (not .Values.acknowledgeCatalogMigration) -}}
+{{- fail "InfluxDB 3.10 performs a one-way catalog migration. Follow UPGRADING-3.9-TO-3.10.md, then set acknowledgeCatalogMigration: true in your values file." -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Validate object storage type
 */}}
 {{- define "influxdb3-enterprise.validateObjectStorageType" -}}

--- a/charts/influxdb3-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb3-enterprise/templates/_helpers.tpl
@@ -457,6 +457,13 @@ ingester.internode.port.
 {{- end }}
 
 {{/*
+Ingester Pod name shared by the StatefulSet, per-pod Service, and test.
+*/}}
+{{- define "influxdb3-enterprise.ingesterPodName" -}}
+{{- printf "%s-ingester-%d" (include "influxdb3-enterprise.fullname" .root) (int .ordinal) -}}
+{{- end }}
+
+{{/*
 Shared volume mounts (license/TLS/GCS and user extras)
 */}}
 {{- define "influxdb3-enterprise.sharedVolumeMounts" -}}

--- a/charts/influxdb3-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb3-enterprise/templates/_helpers.tpl
@@ -446,6 +446,17 @@ Image reference
 {{- end }}
 
 {{/*
+Ingester internode gRPC port.
+The fallback supports upgrades using --reuse-values from releases that predate
+ingester.internode.port.
+*/}}
+{{- define "influxdb3-enterprise.ingesterInternodePort" -}}
+{{- $ingester := .Values.ingester | default dict -}}
+{{- $internode := get $ingester "internode" | default dict -}}
+{{- get $internode "port" | default 8183 -}}
+{{- end }}
+
+{{/*
 Shared volume mounts (license/TLS/GCS and user extras)
 */}}
 {{- define "influxdb3-enterprise.sharedVolumeMounts" -}}

--- a/charts/influxdb3-enterprise/templates/configmap.yaml
+++ b/charts/influxdb3-enterprise/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- include "influxdb3-enterprise.validateCatalogMigrationAcknowledgement" . }}
 {{- include "influxdb3-enterprise.validateObjectStorageType" . }}
 {{- include "influxdb3-enterprise.validateAzureObjectStorageAuth" . }}
 {{- include "influxdb3-enterprise.validateS3ObjectStorageAuth" . }}

--- a/charts/influxdb3-enterprise/templates/ingester-service.yaml
+++ b/charts/influxdb3-enterprise/templates/ingester-service.yaml
@@ -22,24 +22,29 @@ spec:
     {{- include "influxdb3-enterprise.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: ingester
 {{- if .Values.processingEngine.enabled }}
+{{- range $ordinal := until (int .Values.ingester.replicas) }}
+{{- $podName := include "influxdb3-enterprise.ingesterPodName" (dict "root" $ "ordinal" $ordinal) }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-ingester-internode" (include "influxdb3-enterprise.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ .Release.Namespace }}
+  # Must exactly match the StatefulSet Pod name advertised by --conn-info.
+  name: {{ $podName }}
+  namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "influxdb3-enterprise.labels" . | nindent 4 }}
+    {{- include "influxdb3-enterprise.labels" $ | nindent 4 }}
     app.kubernetes.io/component: ingester
 spec:
   type: ClusterIP
   ports:
-    - port: {{ include "influxdb3-enterprise.ingesterInternodePort" . }}
+    - port: {{ include "influxdb3-enterprise.ingesterInternodePort" $ }}
       targetPort: grpc-internode
       protocol: TCP
       name: grpc-internode
   selector:
-    {{- include "influxdb3-enterprise.selectorLabels" . | nindent 4 }}
+    {{- include "influxdb3-enterprise.selectorLabels" $ | nindent 4 }}
     app.kubernetes.io/component: ingester
+    statefulset.kubernetes.io/pod-name: {{ $podName }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/influxdb3-enterprise/templates/ingester-service.yaml
+++ b/charts/influxdb3-enterprise/templates/ingester-service.yaml
@@ -18,13 +18,28 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    {{- if .Values.processingEngine.enabled }}
+  selector:
+    {{- include "influxdb3-enterprise.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ingester
+{{- if .Values.processingEngine.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-ingester-internode" (include "influxdb3-enterprise.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-enterprise.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ingester
+spec:
+  type: ClusterIP
+  ports:
     - port: 8183
       targetPort: grpc-internode
       protocol: TCP
       name: grpc-internode
-    {{- end }}
   selector:
     {{- include "influxdb3-enterprise.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: ingester
+{{- end }}
 {{- end }}

--- a/charts/influxdb3-enterprise/templates/ingester-service.yaml
+++ b/charts/influxdb3-enterprise/templates/ingester-service.yaml
@@ -34,7 +34,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: {{ .Values.ingester.internode.port }}
+    - port: {{ include "influxdb3-enterprise.ingesterInternodePort" . }}
       targetPort: grpc-internode
       protocol: TCP
       name: grpc-internode

--- a/charts/influxdb3-enterprise/templates/ingester-service.yaml
+++ b/charts/influxdb3-enterprise/templates/ingester-service.yaml
@@ -34,7 +34,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 8183
+    - port: {{ .Values.ingester.internode.port }}
       targetPort: grpc-internode
       protocol: TCP
       name: grpc-internode

--- a/charts/influxdb3-enterprise/templates/ingester-service.yaml
+++ b/charts/influxdb3-enterprise/templates/ingester-service.yaml
@@ -18,6 +18,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.processingEngine.enabled }}
+    - port: 8183
+      targetPort: grpc-internode
+      protocol: TCP
+      name: grpc-internode
+    {{- end }}
   selector:
     {{- include "influxdb3-enterprise.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: ingester

--- a/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
@@ -60,8 +60,8 @@ spec:
             - --mode=ingest
             - --node-id=$(POD_NAME)
             {{- if .Values.processingEngine.enabled }}
-            - --internode-bind-addr=0.0.0.0:8183
-            - --conn-info=$(POD_NAME).{{ include "influxdb3-enterprise.fullname" . }}-ingester:8183
+            - --internode-bind-addr=0.0.0.0:{{ .Values.ingester.internode.port }}
+            - --conn-info=$(POD_NAME).{{ include "influxdb3-enterprise.fullname" . }}-ingester:{{ .Values.ingester.internode.port }}
             {{- end }}
           envFrom:
             - configMapRef:
@@ -130,7 +130,7 @@ spec:
               protocol: TCP
             {{- if .Values.processingEngine.enabled }}
             - name: grpc-internode
-              containerPort: 8183
+              containerPort: {{ .Values.ingester.internode.port }}
               protocol: TCP
             {{- end }}
           {{- include "influxdb3-enterprise.probes" . | nindent 10 }}

--- a/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
@@ -1,4 +1,12 @@
 {{- if .Values.ingester.enabled }}
+{{- $replicas := int .Values.ingester.replicas }}
+{{- if gt $replicas 0 }}
+{{- $lastOrdinal := sub $replicas 1 }}
+{{- $lastPodName := include "influxdb3-enterprise.ingesterPodName" (dict "root" . "ordinal" $lastOrdinal) }}
+{{- if gt (len $lastPodName) 63 }}
+{{- fail (printf "Ingester Pod name %q exceeds Kubernetes' 63-character hostname limit; use a shorter release name or fullnameOverride." $lastPodName) }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -61,7 +69,7 @@ spec:
             - --node-id=$(POD_NAME)
             {{- if .Values.processingEngine.enabled }}
             - --internode-bind-addr=0.0.0.0:{{ include "influxdb3-enterprise.ingesterInternodePort" . }}
-            - --conn-info=$(POD_NAME).{{ include "influxdb3-enterprise.fullname" . }}-ingester:{{ include "influxdb3-enterprise.ingesterInternodePort" . }}
+            - --conn-info=$(POD_NAME):{{ include "influxdb3-enterprise.ingesterInternodePort" . }}
             {{- end }}
           envFrom:
             - configMapRef:

--- a/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
@@ -60,8 +60,8 @@ spec:
             - --mode=ingest
             - --node-id=$(POD_NAME)
             {{- if .Values.processingEngine.enabled }}
-            - --internode-bind-addr=0.0.0.0:{{ .Values.ingester.internode.port }}
-            - --conn-info=$(POD_NAME).{{ include "influxdb3-enterprise.fullname" . }}-ingester:{{ .Values.ingester.internode.port }}
+            - --internode-bind-addr=0.0.0.0:{{ include "influxdb3-enterprise.ingesterInternodePort" . }}
+            - --conn-info=$(POD_NAME).{{ include "influxdb3-enterprise.fullname" . }}-ingester:{{ include "influxdb3-enterprise.ingesterInternodePort" . }}
             {{- end }}
           envFrom:
             - configMapRef:
@@ -130,7 +130,7 @@ spec:
               protocol: TCP
             {{- if .Values.processingEngine.enabled }}
             - name: grpc-internode
-              containerPort: {{ .Values.ingester.internode.port }}
+              containerPort: {{ include "influxdb3-enterprise.ingesterInternodePort" . }}
               protocol: TCP
             {{- end }}
           {{- include "influxdb3-enterprise.probes" . | nindent 10 }}

--- a/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
@@ -59,6 +59,10 @@ spec:
             - serve
             - --mode=ingest
             - --node-id=$(POD_NAME)
+            {{- if .Values.processingEngine.enabled }}
+            - --internode-bind-addr=0.0.0.0:8183
+            - --conn-info=$(POD_NAME).{{ include "influxdb3-enterprise.fullname" . }}-ingester:8183
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "influxdb3-enterprise.fullname" . }}-config
@@ -124,6 +128,11 @@ spec:
             - name: http
               containerPort: 8181
               protocol: TCP
+            {{- if .Values.processingEngine.enabled }}
+            - name: grpc-internode
+              containerPort: 8183
+              protocol: TCP
+            {{- end }}
           {{- include "influxdb3-enterprise.probes" . | nindent 10 }}
           resources:
             {{- toYaml .Values.ingester.resources | nindent 12 }}

--- a/charts/influxdb3-enterprise/templates/networkpolicy.yaml
+++ b/charts/influxdb3-enterprise/templates/networkpolicy.yaml
@@ -53,6 +53,17 @@ spec:
       ports:
         - protocol: TCP
           port: 8181
+    {{- if .Values.processingEngine.enabled }}
+    # Allow processors to write through the internode gRPC endpoint
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "influxdb3-enterprise.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: processor
+      ports:
+        - protocol: TCP
+          port: 8183
+    {{- end }}
     {{- end }}
     # Allow Prometheus to scrape metrics
     {{- if .Values.networkPolicy.ingress.fromPrometheus }}
@@ -434,6 +445,15 @@ spec:
       ports:
         - protocol: TCP
           port: 8181
+    # Allow Processing Engine writes to ingesters over internode gRPC
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "influxdb3-enterprise.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: ingester
+      ports:
+        - protocol: TCP
+          port: 8183
     # Allow outbound HTTP/HTTPS for plugin operations (webhooks, notifications, etc.)
     {{- if .Values.networkPolicy.egress.toPluginEndpoints }}
     {{- if .Values.networkPolicy.egress.pluginEndpointCidrs }}

--- a/charts/influxdb3-enterprise/templates/networkpolicy.yaml
+++ b/charts/influxdb3-enterprise/templates/networkpolicy.yaml
@@ -137,6 +137,7 @@ spec:
 
 {{- end }}
 {{- if and .Values.networkPolicy.enabled .Values.querier.enabled }}
+---
 # NetworkPolicy for Querier nodes
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -244,6 +245,7 @@ spec:
 
 {{- end }}
 {{- if and .Values.networkPolicy.enabled .Values.compactor.enabled }}
+---
 # NetworkPolicy for Compactor node
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/influxdb3-enterprise/templates/networkpolicy.yaml
+++ b/charts/influxdb3-enterprise/templates/networkpolicy.yaml
@@ -62,7 +62,7 @@ spec:
               app.kubernetes.io/component: processor
       ports:
         - protocol: TCP
-          port: 8183
+          port: {{ .Values.ingester.internode.port }}
     {{- end }}
     {{- end }}
     # Allow Prometheus to scrape metrics
@@ -455,7 +455,7 @@ spec:
               app.kubernetes.io/component: ingester
       ports:
         - protocol: TCP
-          port: 8183
+          port: {{ .Values.ingester.internode.port }}
     # Allow outbound HTTP/HTTPS for plugin operations (webhooks, notifications, etc.)
     {{- if .Values.networkPolicy.egress.toPluginEndpoints }}
     {{- if .Values.networkPolicy.egress.pluginEndpointCidrs }}

--- a/charts/influxdb3-enterprise/templates/networkpolicy.yaml
+++ b/charts/influxdb3-enterprise/templates/networkpolicy.yaml
@@ -62,7 +62,7 @@ spec:
               app.kubernetes.io/component: processor
       ports:
         - protocol: TCP
-          port: {{ .Values.ingester.internode.port }}
+          port: {{ include "influxdb3-enterprise.ingesterInternodePort" . }}
     {{- end }}
     {{- end }}
     # Allow Prometheus to scrape metrics
@@ -455,7 +455,7 @@ spec:
               app.kubernetes.io/component: ingester
       ports:
         - protocol: TCP
-          port: {{ .Values.ingester.internode.port }}
+          port: {{ include "influxdb3-enterprise.ingesterInternodePort" . }}
     # Allow outbound HTTP/HTTPS for plugin operations (webhooks, notifications, etc.)
     {{- if .Values.networkPolicy.egress.toPluginEndpoints }}
     {{- if .Values.networkPolicy.egress.pluginEndpointCidrs }}

--- a/charts/influxdb3-enterprise/templates/tests/test-internode-grpc.yaml
+++ b/charts/influxdb3-enterprise/templates/tests/test-internode-grpc.yaml
@@ -1,0 +1,50 @@
+{{- if and .Values.ingester.enabled .Values.processingEngine.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ printf "%s-test-internode-grpc" (include "influxdb3-enterprise.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-enterprise.labels" . | nindent 4 }}
+    app.kubernetes.io/component: processor
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  automountServiceAccountToken: false
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: test-internode-grpc
+      image: busybox:1.37.0
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+      command:
+        - /bin/sh
+        - -ec
+      args:
+        - |
+          nc -z -w 10 \
+            {{ printf "%s-ingester-internode" (include "influxdb3-enterprise.fullname" .) | trunc 63 | trimSuffix "-" }} \
+            {{ .Values.ingester.internode.port }}
+          nc -z -w 10 \
+            {{ include "influxdb3-enterprise.fullname" . }}-ingester-0.{{ include "influxdb3-enterprise.fullname" . }}-ingester \
+            {{ .Values.ingester.internode.port }}
+      resources:
+        requests:
+          cpu: 10m
+          memory: 8Mi
+        limits:
+          cpu: 100m
+          memory: 32Mi
+{{- end }}

--- a/charts/influxdb3-enterprise/templates/tests/test-internode-grpc.yaml
+++ b/charts/influxdb3-enterprise/templates/tests/test-internode-grpc.yaml
@@ -34,12 +34,11 @@ spec:
         - -ec
       args:
         - |
+          {{- range $ordinal := until (int .Values.ingester.replicas) }}
           nc -z -w 10 \
-            {{ printf "%s-ingester-internode" (include "influxdb3-enterprise.fullname" .) | trunc 63 | trimSuffix "-" }} \
-            {{ include "influxdb3-enterprise.ingesterInternodePort" . }}
-          nc -z -w 10 \
-            {{ include "influxdb3-enterprise.fullname" . }}-ingester-0.{{ include "influxdb3-enterprise.fullname" . }}-ingester \
-            {{ include "influxdb3-enterprise.ingesterInternodePort" . }}
+            {{ include "influxdb3-enterprise.ingesterPodName" (dict "root" $ "ordinal" $ordinal) }} \
+            {{ include "influxdb3-enterprise.ingesterInternodePort" $ }}
+          {{- end }}
       resources:
         requests:
           cpu: 10m

--- a/charts/influxdb3-enterprise/templates/tests/test-internode-grpc.yaml
+++ b/charts/influxdb3-enterprise/templates/tests/test-internode-grpc.yaml
@@ -36,10 +36,10 @@ spec:
         - |
           nc -z -w 10 \
             {{ printf "%s-ingester-internode" (include "influxdb3-enterprise.fullname" .) | trunc 63 | trimSuffix "-" }} \
-            {{ .Values.ingester.internode.port }}
+            {{ include "influxdb3-enterprise.ingesterInternodePort" . }}
           nc -z -w 10 \
             {{ include "influxdb3-enterprise.fullname" . }}-ingester-0.{{ include "influxdb3-enterprise.fullname" . }}-ingester \
-            {{ .Values.ingester.internode.port }}
+            {{ include "influxdb3-enterprise.ingesterInternodePort" . }}
       resources:
         requests:
           cpu: 10m

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -21,6 +21,10 @@ imagePullSecrets: []
 # Global Cluster Configuration
 # ============================================================================
 
+# Required on Helm upgrades to acknowledge the one-way InfluxDB 3.10 catalog
+# migration. Follow UPGRADING-3.9-TO-3.10.md before setting this to true.
+acknowledgeCatalogMigration: false
+
 # Cluster configuration - all nodes must share the same cluster ID
 cluster:
   # Unique identifier for the cluster (must be different from any node-id)

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -253,6 +253,10 @@ ingester:
     port: 8181
     annotations: {}
 
+  # Internode gRPC communication with Processing Engine nodes
+  internode:
+    port: 8183
+
   # Priority class for pod scheduling priority
   # Higher priority pods are scheduled before lower priority pods
   # Use "system-cluster-critical" or "system-node-critical" for critical workloads


### PR DESCRIPTION
## Summary

Updates the InfluxDB 3 Enterprise from `3.9` to `3.10.5`. InfluxDB 3.10 automatically performs a one-way catalog v2->v3 migration, so this PR adds an upgrade guide, explicit acknowledgement gate.

### Helm users

Back up the catalog by following `UPGRADING-3.9-TO-3.10.md`, then persist `acknowledgeCatalogMigration: true` in the values file. Helm blocks the upgrade until the acknowledgement is set.

### GitOps users

Template-only renderers such as Argo CD do not expose Helm upgrade state, so the chart cannot enforce the gate. Back up the catalog and commit the acknowledgement to the Git-managed values before synchronizing.

## Design notes

- Helm can't detect the previous `appVersion`, so the gate fires on any upgrade
- No rollout ordering; `--atomic` and `helm rollback` unsafe post-migration
- A headless governing Service is the preferred long-term internode design, but adopting it requires recreating the StatefulSet because `spec.serviceName` is immutable. To avoid combining that risk with the one-way catalog migration, this release uses one pod-selecting `ClusterIP` Service per ingester replica. We will address headless discovery in a future chart release; until then, ingesters should be scaled through Helm.