### PR TITLE
fix(influxdb3-ent): make catalog migration acknowledgement one-time

### DIFF
--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.9.0
+version: 0.9.1
 appVersion: "3.10.5"
 keywords:
   - influxdb

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -457,12 +457,19 @@ Chart 0.9.0 upgrades InfluxDB to 3.10.5. The first 3.10 startup automatically
 migrates catalog v2 to v3. This migration is one-way; restoring the catalog
 backup is required to return to 3.9.
 
-Follow [UPGRADING-3.9-TO-3.10.md](UPGRADING-3.9-TO-3.10.md). When Helm performs
-the upgrade, rendering is blocked until `acknowledgeCatalogMigration: true` is
-set in the values file. Template-only GitOps renderers such as Argo CD do not
-expose upgrade state, so the chart cannot enforce this gate. For those
-deployments, complete the guide and commit the acknowledgement to the GitOps
-values before synchronizing.
+Follow [UPGRADING-3.9-TO-3.10.md](UPGRADING-3.9-TO-3.10.md). When Helm upgrades
+a release without the catalog format v3 marker, rendering is blocked until
+`acknowledgeCatalogMigration: true` is set. The chart then records the marker
+so later upgrades do not require the flag. Chart 0.9.0 predates the marker and
+therefore requires one final acknowledgement.
+
+Client-side previews cannot query the live marker. For `helm template
+--is-upgrade`, client-side `helm upgrade --dry-run`, or `helm diff upgrade`,
+pass `--set acknowledgeCatalogMigration=true` for that command only. Do not
+persist it after the marker has been recorded.
+
+Template-only GitOps renderers such as Argo CD do not expose upgrade state, so
+the chart cannot enforce this gate. Complete the guide before synchronizing.
 
 ### Upgrade the Chart
 
@@ -640,7 +647,7 @@ logs:
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `acknowledgeCatalogMigration` | Acknowledge the one-way InfluxDB 3.10 catalog migration during Helm upgrades | `false` |
+| `acknowledgeCatalogMigration` | One-time acknowledgement for an upgrade without the catalog format v3 marker | `false` |
 | `cluster.id` | Cluster identifier | `cluster-01` |
 | `image.registry` | Image registry | `docker.io` |
 | `image.repository` | Image repository | `influxdb` |

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -453,8 +453,9 @@ processingEngine:
 
 ### Upgrade from InfluxDB 3.9
 
-Chart 0.9.0 upgrades InfluxDB to 3.10.5. The first 3.10 startup automatically
-migrates catalog v2 to v3. This migration is one-way; restoring the catalog
+Chart 0.9.0 introduced InfluxDB 3.10.5. The first 3.10 startup automatically
+migrates catalog v2 to v3. Chart 0.9.1 adds the catalog format marker and is the
+recommended upgrade target. The migration is one-way; restoring the catalog
 backup is required to return to 3.9.
 
 Follow [UPGRADING-3.9-TO-3.10.md](UPGRADING-3.9-TO-3.10.md). When Helm upgrades
@@ -463,10 +464,10 @@ a release without the catalog format v3 marker, rendering is blocked until
 so later upgrades do not require the flag. Chart 0.9.0 predates the marker and
 therefore requires one final acknowledgement.
 
-Client-side previews cannot query the live marker. For `helm template
---is-upgrade`, client-side `helm upgrade --dry-run`, or `helm diff upgrade`,
-pass `--set acknowledgeCatalogMigration=true` for that command only. Do not
-persist it after the marker has been recorded.
+Use `helm upgrade --dry-run=server` when cluster access is available so Helm can
+query the live marker. Client-side `helm template --is-upgrade`,
+`helm upgrade --dry-run=client`, and `helm diff upgrade` cannot query the marker
+and require `--set acknowledgeCatalogMigration=true`.
 
 Template-only GitOps renderers such as Argo CD do not expose upgrade state, so
 the chart cannot enforce this gate. Complete the guide before synchronizing.

--- a/charts/influxdb3-enterprise/UPGRADING-3.9-TO-3.10.md
+++ b/charts/influxdb3-enterprise/UPGRADING-3.9-TO-3.10.md
@@ -56,8 +56,9 @@ The chart records `influxdata.com/catalog-format: v3` on its ConfigMap when the
 effective image tag clearly identifies InfluxDB 3.10 or later. The marker
 records an acknowledged migration attempt, not a completed migration. Retain
 the backup until every pod is ready and the verification steps below succeed.
-After the marker is recorded, `acknowledgeCatalogMigration` is obsolete; it may
-remain `true` in stored release values without affecting later live upgrades.
+After the marker is recorded, `acknowledgeCatalogMigration` is no longer needed
+for live upgrades, although Helm may retain `true` in stored release values.
+Client-side previews still require the flag because they cannot query the marker.
 
 Do not use `--atomic`, and do not run `helm rollback` to a 3.9 revision after
 the catalog migration. Both can restore a 3.9 image while leaving the catalog

--- a/charts/influxdb3-enterprise/UPGRADING-3.9-TO-3.10.md
+++ b/charts/influxdb3-enterprise/UPGRADING-3.9-TO-3.10.md
@@ -19,7 +19,7 @@ export NAMESPACE=influxdb3
 
 # Set this to the values file you will use for the upgrade.
 export VALUES_FILE=./my-values.yaml
-export TARGET_CHART_VERSION=0.9.0
+export TARGET_CHART_VERSION=0.9.1
 
 helm get values "$RELEASE" -n "$NAMESPACE" -o yaml > pre-3.10-values.yaml
 kubectl get pods -n "$NAMESPACE" \
@@ -40,11 +40,7 @@ image.
 The chart does not enforce the documented ingester, querier, compactor upgrade
 order, so use a maintenance window.
 
-After completing the backup, persist the acknowledgement in your values file:
-
-```yaml
-acknowledgeCatalogMigration: true
-```
+After completing the backup, pass the acknowledgement for this upgrade only:
 
 ```bash
 helm repo update
@@ -52,8 +48,13 @@ helm upgrade "$RELEASE" influxdata/influxdb3-enterprise \
   -n "$NAMESPACE" \
   --version "$TARGET_CHART_VERSION" \
   -f "$VALUES_FILE" \
+  --set acknowledgeCatalogMigration=true \
   --wait --timeout 30m
 ```
+
+The chart records `influxdata.com/catalog-format: v3` on its ConfigMap when the
+effective image tag clearly identifies InfluxDB 3.10 or later. Do not persist
+`acknowledgeCatalogMigration` after the marker has been recorded.
 
 Do not use `--atomic`, and do not run `helm rollback` to a 3.9 revision after
 the catalog migration. Both can restore a 3.9 image while leaving the catalog
@@ -75,6 +76,6 @@ write. Do not downgrade without restoring the pre-upgrade catalog backup.
 ## Existing 3.10 image override
 
 If the release already runs 3.10 through `image.tag`, its catalog is already
-migrated. Back up the catalog, remove or update the override, and still pass
-`acknowledgeCatalogMigration: true` in the values file; the chart cannot
-determine which image version was previously deployed.
+migrated. Back up the catalog, remove or update the override, and pass the
+one-time acknowledgement if the release does not yet carry the marker. Unknown
+or pre-3.10 image tags do not receive the marker.

--- a/charts/influxdb3-enterprise/UPGRADING-3.9-TO-3.10.md
+++ b/charts/influxdb3-enterprise/UPGRADING-3.9-TO-3.10.md
@@ -53,8 +53,11 @@ helm upgrade "$RELEASE" influxdata/influxdb3-enterprise \
 ```
 
 The chart records `influxdata.com/catalog-format: v3` on its ConfigMap when the
-effective image tag clearly identifies InfluxDB 3.10 or later. Do not persist
-`acknowledgeCatalogMigration` after the marker has been recorded.
+effective image tag clearly identifies InfluxDB 3.10 or later. The marker
+records an acknowledged migration attempt, not a completed migration. Retain
+the backup until every pod is ready and the verification steps below succeed.
+After the marker is recorded, `acknowledgeCatalogMigration` is obsolete; it may
+remain `true` in stored release values without affecting later live upgrades.
 
 Do not use `--atomic`, and do not run `helm rollback` to a 3.9 revision after
 the catalog migration. Both can restore a 3.9 image while leaving the catalog

--- a/charts/influxdb3-enterprise/templates/_helpers.tpl
+++ b/charts/influxdb3-enterprise/templates/_helpers.tpl
@@ -22,6 +22,13 @@ Create a default fully qualified app name.
 {{- end }}
 
 {{/*
+Main configuration ConfigMap name.
+*/}}
+{{- define "influxdb3-enterprise.configMapName" -}}
+{{- printf "%s-config" (include "influxdb3-enterprise.fullname" .) }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "influxdb3-enterprise.chart" -}}
@@ -95,7 +102,15 @@ Require acknowledgement of the InfluxDB 3.10 catalog migration.
 */}}
 {{- define "influxdb3-enterprise.validateCatalogMigrationAcknowledgement" -}}
 {{- if and .Release.IsUpgrade (ne (toString .Values.acknowledgeCatalogMigration) "true") -}}
-{{- fail "InfluxDB 3.10 performs a one-way catalog migration. Follow UPGRADING-3.9-TO-3.10.md, then set acknowledgeCatalogMigration: true in your values file." -}}
+{{- $name := include "influxdb3-enterprise.configMapName" . -}}
+{{- $configMap := lookup "v1" "ConfigMap" .Release.Namespace $name -}}
+{{- $annotations := dict -}}
+{{- if $configMap -}}
+{{- $annotations = $configMap.metadata.annotations | default dict -}}
+{{- end -}}
+{{- if ne (get $annotations "influxdata.com/catalog-format") "v3" -}}
+{{- fail (printf "Could not verify influxdata.com/catalog-format=v3 on ConfigMap %q. Follow UPGRADING-3.9-TO-3.10.md, then set acknowledgeCatalogMigration: true for the one-time upgrade or client-side preview." $name) -}}
+{{- end -}}
 {{- end -}}
 {{- end }}
 
@@ -436,12 +451,31 @@ startupProbe:
 {{- end }}
 
 {{/*
+Effective image tag.
+*/}}
+{{- define "influxdb3-enterprise.imageTag" -}}
+{{- .Values.image.tag | default (printf "%s-enterprise" .Chart.AppVersion) }}
+{{- end }}
+
+{{/*
+Return true only when the effective image tag clearly identifies 3.10+.
+Unknown tags fail closed by not receiving the catalog v3 marker.
+*/}}
+{{- define "influxdb3-enterprise.targetUsesCatalogV3" -}}
+{{- $tag := include "influxdb3-enterprise.imageTag" . -}}
+{{- $version := regexFind "^v?[0-9]+\\.[0-9]+\\.[0-9]+" $tag | trimPrefix "v" -}}
+{{- if $version -}}
+{{- if semverCompare ">=3.10.0-0" $version -}}true{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Image reference
 */}}
 {{- define "influxdb3-enterprise.image" -}}
 {{- $registry := .Values.image.registry }}
 {{- $repository := .Values.image.repository }}
-{{- $tag := .Values.image.tag | default (printf "%s-enterprise" .Chart.AppVersion) }}
+{{- $tag := include "influxdb3-enterprise.imageTag" . }}
 {{- printf "%s/%s:%s" $registry $repository $tag }}
 {{- end }}
 

--- a/charts/influxdb3-enterprise/templates/compactor-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/compactor-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
             - --node-id=$(POD_NAME)
           envFrom:
             - configMapRef:
-                name: {{ include "influxdb3-enterprise.fullname" . }}-config
+                name: {{ include "influxdb3-enterprise.configMapName" . }}
           env:
             {{- include "influxdb3-enterprise.podNameEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.licenseEnv" . | nindent 12 }}

--- a/charts/influxdb3-enterprise/templates/configmap.yaml
+++ b/charts/influxdb3-enterprise/templates/configmap.yaml
@@ -6,6 +6,8 @@
 {{- include "influxdb3-enterprise.validateObjectStoreTlsCa" . }}
 {{- include "influxdb3-enterprise.validateAdminTokenConfig" . }}
 {{- include "influxdb3-enterprise.validatePermissionTokensConfig" . }}
+{{- $existing := lookup "v1" "ConfigMap" .Release.Namespace (include "influxdb3-enterprise.configMapName" .) | default dict }}
+{{- $recordedFormat := dig "metadata" "annotations" "influxdata.com/catalog-format" "" $existing }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,7 +15,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "influxdb3-enterprise.labels" . | nindent 4 }}
-  {{- if eq (include "influxdb3-enterprise.targetUsesCatalogV3" .) "true" }}
+  {{- if or (eq (include "influxdb3-enterprise.targetUsesCatalogV3" .) "true") (eq $recordedFormat "v3") }}
   annotations:
     influxdata.com/catalog-format: "v3"
   {{- end }}

--- a/charts/influxdb3-enterprise/templates/configmap.yaml
+++ b/charts/influxdb3-enterprise/templates/configmap.yaml
@@ -9,10 +9,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "influxdb3-enterprise.fullname" . }}-config
+  name: {{ include "influxdb3-enterprise.configMapName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "influxdb3-enterprise.labels" . | nindent 4 }}
+  {{- if eq (include "influxdb3-enterprise.targetUsesCatalogV3" .) "true" }}
+  annotations:
+    influxdata.com/catalog-format: "v3"
+  {{- end }}
 data:
   # Cluster configuration (env-style)
   INFLUXDB3_ENTERPRISE_CLUSTER_ID: {{ .Values.cluster.id | quote }}

--- a/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/ingester-statefulset.yaml
@@ -73,7 +73,7 @@ spec:
             {{- end }}
           envFrom:
             - configMapRef:
-                name: {{ include "influxdb3-enterprise.fullname" . }}-config
+                name: {{ include "influxdb3-enterprise.configMapName" . }}
           env:
             {{- include "influxdb3-enterprise.podNameEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.licenseEnv" . | nindent 12 }}

--- a/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/processor-statefulset.yaml
@@ -73,7 +73,7 @@ spec:
             - --node-id=$(POD_NAME)
           envFrom:
             - configMapRef:
-                name: {{ include "influxdb3-enterprise.fullname" . }}-config
+                name: {{ include "influxdb3-enterprise.configMapName" . }}
           env:
             {{- include "influxdb3-enterprise.podNameEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.licenseEnv" . | nindent 12 }}

--- a/charts/influxdb3-enterprise/templates/querier-statefulset.yaml
+++ b/charts/influxdb3-enterprise/templates/querier-statefulset.yaml
@@ -61,7 +61,7 @@ spec:
             - --node-id=$(POD_NAME)
           envFrom:
             - configMapRef:
-                name: {{ include "influxdb3-enterprise.fullname" . }}-config
+                name: {{ include "influxdb3-enterprise.configMapName" . }}
           env:
             {{- include "influxdb3-enterprise.podNameEnv" . | nindent 12 }}
             {{- include "influxdb3-enterprise.licenseEnv" . | nindent 12 }}

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -21,8 +21,9 @@ imagePullSecrets: []
 # Global Cluster Configuration
 # ============================================================================
 
-# Required on Helm upgrades to acknowledge the one-way InfluxDB 3.10 catalog
-# migration. Follow UPGRADING-3.9-TO-3.10.md before setting this to true.
+# One-time acknowledgement required when upgrading a release without the
+# catalog format v3 marker.
+# Follow UPGRADING-3.9-TO-3.10.md before setting this to true.
 acknowledgeCatalogMigration: false
 
 # Cluster configuration - all nodes must share the same cluster ID


### PR DESCRIPTION
 ## Summary

Fixes the InfluxDB 3.10 catalog-migration acknowledgement introduced in chart 0.9.0, which otherwise remained required for every future Helm upgrade.

  - Records `influxdata.com/catalog-format: v3` on the release `ConfigMap` for recognized InfluxDB 3.10+ images and preserves an existing marker during subsequent live upgrades.
  - Uses Helm lookup during live upgrades to skip the acknowledgement once the marker exists.

## User impact

- 0.8.x users must back up the catalog and acknowledge the one-way migration once.
- 0.9.0 users receive the missing marker during their 0.9.1 upgrade.
- Later live upgrades no longer require the acknowledgement.
- Client-side renders still require the flag because they cannot query the live marker.
- The supported migration path uses the chart’s default image. Users overriding `image.tag` are responsible for ensuring the selected image is compatible with the catalog format.

## Verification

- helm lint passed.
- Default and acknowledgement render paths passed.
- Missing-marker upgrades were blocked as expected.
- Marker emission was verified for supported image tags.
- Existing-marker preservation was verified when the target image would not independently emit the marker.
- Live server-side lookup was verified with the marker present and absent.
