### PR TITLE
feat(telegraf-ds|telegraf): add annotations for the workload object

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.1.53
+version: 1.1.54
 appVersion: 1.39.3
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/ci/workload-annotations-values.yaml
+++ b/charts/telegraf-ds/ci/workload-annotations-values.yaml
@@ -1,0 +1,3 @@
+annotations:
+  pulumi.com/skipAwait: "true"
+  example.com/release: "{{ .Release.Name }}"

--- a/charts/telegraf-ds/ci/workload-annotations-values.yaml
+++ b/charts/telegraf-ds/ci/workload-annotations-values.yaml
@@ -1,3 +1,3 @@
-annotations:
+daemonSetAnnotations:
   pulumi.com/skipAwait: "true"
   example.com/release: "{{ .Release.Name }}"

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "telegraf.fullname" . }}
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+{{ tpl (toYaml .) $ | indent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "telegraf.fullname" . }}
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
-  {{- with .Values.annotations }}
+  {{- with .Values.daemonSetAnnotations }}
   annotations:
 {{ tpl (toYaml .) $ | indent 4 }}
   {{- end }}

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -16,6 +16,10 @@ resources:
   limits:
     memory: 2Gi
     cpu: 1
+## Annotations to add to the DaemonSet object itself.
+## Use podAnnotations below to annotate the pods.
+annotations: {}
+
 ## Pod annotations
 podAnnotations: {}
 ## Pod labels

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -18,7 +18,7 @@ resources:
     cpu: 1
 ## Annotations to add to the DaemonSet object itself.
 ## Use podAnnotations below to annotate the pods.
-annotations: {}
+daemonSetAnnotations: {}
 
 ## Pod annotations
 podAnnotations: {}

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.74
+version: 1.8.75
 appVersion: 1.39.3
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/ci/workload-annotations-values.yaml
+++ b/charts/telegraf/ci/workload-annotations-values.yaml
@@ -1,3 +1,3 @@
-annotations:
+deploymentAnnotations:
   pulumi.com/skipAwait: "true"
   example.com/release: "{{ .Release.Name }}"

--- a/charts/telegraf/ci/workload-annotations-values.yaml
+++ b/charts/telegraf/ci/workload-annotations-values.yaml
@@ -1,0 +1,3 @@
+annotations:
+  pulumi.com/skipAwait: "true"
+  example.com/release: "{{ .Release.Name }}"

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "telegraf.fullname" . }}
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
-  {{- with .Values.annotations }}
+  {{- with .Values.deploymentAnnotations }}
   annotations:
 {{ tpl (toYaml .) $ | indent 4 }}
   {{- end }}

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "telegraf.fullname" . }}
   labels:
     {{- include "telegraf.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+{{ tpl (toYaml .) $ | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -9,7 +9,7 @@ image:
   pullPolicy: IfNotPresent
 ## Annotations to add to the Deployment object itself.
 ## Use podAnnotations below to annotate the pods.
-annotations: {}
+deploymentAnnotations: {}
 podAnnotations: {}
 podLabels: {}
 imagePullSecrets: []

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -7,6 +7,9 @@ image:
   repo: "docker.io/library/telegraf"
   tag: "1.39-alpine"
   pullPolicy: IfNotPresent
+## Annotations to add to the Deployment object itself.
+## Use podAnnotations below to annotate the pods.
+annotations: {}
 podAnnotations: {}
 podLabels: {}
 imagePullSecrets: []


### PR DESCRIPTION
Why: both charts let you annotate the pods (podAnnotations) but not the DaemonSet/Deployment object itself. We need pulumi.com/skipAwait on the object and currently post-process the rendered manifest to get it.

How: adds a top-level annotations value on the workload object's metadata, guarded with {{- with }}, defaults to {}. Supports tpl like podAnnotations does since #777. Both charts changed together (same as #777); versions bumped 1.1.53→1.1.54 and 1.8.74→1.8.75.

Testing: with the version held equal, default render is byte-identical on both charts (211 / 186 lines). With the value set, only the object's metadata.annotations appears — verified via the new ci/workload-annotations-values.yaml, including tpl expansion. helm lint passes on both.

- [ ] CHANGELOG.md updated ( nothing to udpate - no changelog.md) 
- [X] Rebased/mergable
- [X] Tests pass
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
