### PR TITLE
feat(influxdb3-core): upgrade InfluxDB to 3.10.5

### DIFF
--- a/charts/influxdb3-core/Chart.yaml
+++ b/charts/influxdb3-core/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: influxdb3-core
 description: A Helm chart for deploying InfluxDB 3 Core on Kubernetes
 type: application
-version: 0.1.0
-appVersion: "3.10.0"
+version: 0.1.1
+appVersion: "3.10.5"
 keywords:
   - influxdb
   - time-series

--- a/charts/influxdb3-core/README.md
+++ b/charts/influxdb3-core/README.md
@@ -262,7 +262,7 @@ Remote object-store data is not deleted by uninstalling the chart.
 | `ingress.enabled` | Create HTTP and Flight ingresses | `false` |
 | `serviceMonitor.enabled` | Create a Prometheus Operator ServiceMonitor | `false` |
 | `serviceMonitor.tlsConfig` | Prometheus Operator TLS settings for metrics scraping | `{}` |
-| `serviceAccount.automountServiceAccountToken` | Configure automatic mounting of the Kubernetes service account token | `not set` |
+| `serviceAccount.automountServiceAccountToken` | Configure automatic mounting of the Kubernetes service account token in the pod and the created ServiceAccount | `not set` |
 | `updateStrategy.type` | StatefulSet update strategy | `RollingUpdate` |
 
 See `values.yaml` for the complete parameter list.

--- a/charts/influxdb3-core/README.md
+++ b/charts/influxdb3-core/README.md
@@ -262,6 +262,7 @@ Remote object-store data is not deleted by uninstalling the chart.
 | `ingress.enabled` | Create HTTP and Flight ingresses | `false` |
 | `serviceMonitor.enabled` | Create a Prometheus Operator ServiceMonitor | `false` |
 | `serviceMonitor.tlsConfig` | Prometheus Operator TLS settings for metrics scraping | `{}` |
+| `serviceAccount.automountServiceAccountToken` | Configure automatic mounting of the Kubernetes service account token | `not set` |
 | `updateStrategy.type` | StatefulSet update strategy | `RollingUpdate` |
 
 See `values.yaml` for the complete parameter list.

--- a/charts/influxdb3-core/ci/memory-values.yaml
+++ b/charts/influxdb3-core/ci/memory-values.yaml
@@ -1,2 +1,5 @@
 objectStorage:
   type: memory
+
+serviceAccount:
+  automountServiceAccountToken: false

--- a/charts/influxdb3-core/templates/serviceaccount.yaml
+++ b/charts/influxdb3-core/templates/serviceaccount.yaml
@@ -10,4 +10,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- if not (kindIs "invalid" .Values.serviceAccount.automountServiceAccountToken) }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/influxdb3-core/templates/statefulset.yaml
+++ b/charts/influxdb3-core/templates/statefulset.yaml
@@ -35,6 +35,9 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "influxdb3-core.serviceAccountName" . }}
+      {{- if not (kindIs "invalid" .Values.serviceAccount.automountServiceAccountToken) }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/influxdb3-core/values.yaml
+++ b/charts/influxdb3-core/values.yaml
@@ -428,3 +428,7 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  # Specifies whether to automatically mount the Kubernetes service account token.
+  # Set to false to comply with policies that restrict token mounting.
+  # If not set, Kubernetes default behavior applies.
+  # automountServiceAccountToken: false


### PR DESCRIPTION
- upgrades InfluxDB to 3.10.5
- makes SA token automount configurable => closes applicable parity gap with Enterprise chart