### PR TITLE
fix(influxdb3-ent): widen startup probe window

### DIFF
--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.10.0
+version: 0.10.1
 appVersion: "3.11.2"
 keywords:
   - influxdb

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -310,10 +310,8 @@ narrower window (`3 × 10s`). A node that answers `/health` and then blocks
 during later startup work can still be restarted; raise
 `probes.liveness.failureThreshold` if that happens.
 
-Two alternatives shorten the startup itself rather than tolerating it:
-[Compacted-Data Startup](#compacted-data-startup) bounds the file-index load,
-and `ingester.persistence` keeps the WAL on a local volume instead of replaying
-it from object storage.
+This widens the window rather than shortening the startup. If nodes routinely
+need most of it, the boot work itself is worth investigating.
 
 #### TLS
 
@@ -640,17 +638,21 @@ kubectl describe pod -n influxdb3 influxdb3-enterprise-ingester-0
 ```
 
 A pod that restarts during startup while its logs show normal activity was
-either killed by the startup probe or ran out of memory. Both exit with code
-137, so check which before changing anything:
+either killed by the startup probe or ran out of memory. Read the termination
+reason and the events rather than the exit code:
 
 ```bash
 kubectl get pod -n influxdb3 influxdb3-enterprise-ingester-0 \
   -o jsonpath='{.status.containerStatuses[0].lastState.terminated.reason}'
+kubectl describe pod -n influxdb3 influxdb3-enterprise-ingester-0 | grep -i probe
 ```
 
 `OOMKilled` means raise the memory limit. `Error` together with a
 `Startup probe failed` event means the probe window is too short; see
-[Health Probes](#health-probes).
+[Health Probes](#health-probes). Exit code 137 is one possible signature of a
+probe kill, not proof of one: kubelet asks the runtime to terminate first and
+honours `terminationGracePeriodSeconds`, so a process that exits during that
+window reports a different code, and 137 is also what an OOM kill produces.
 
 #### License Issues
 

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -282,6 +282,39 @@ ingester:
     numThreads: 20
 ```
 
+#### Health Probes
+
+All components share one probe configuration. The startup probe guards the
+initialization window; liveness and readiness start only once it succeeds.
+
+```yaml
+probes:
+  startup:
+    initialDelaySeconds: 10
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 184   # 10s + (184 - 1) × 5s = 925s
+```
+
+Nodes replay from object storage on boot, so startup scales with how much data a
+node reads back, and clusters with a large history have been reported to need
+more than 12 minutes. Two things follow from a window this wide.
+
+`helm install` and `helm upgrade` with `--wait` default to a five-minute
+timeout, which is shorter than the startup they are waiting for. Pass
+`--timeout 20m` to match, or the release fails while the pods are still booting
+normally.
+
+Once the startup probe succeeds, the liveness probe takes over with a much
+narrower window (`3 × 10s`). A node that answers `/health` and then blocks
+during later startup work can still be restarted; raise
+`probes.liveness.failureThreshold` if that happens.
+
+Two alternatives shorten the startup itself rather than tolerating it:
+[Compacted-Data Startup](#compacted-data-startup) bounds the file-index load,
+and `ingester.persistence` keeps the WAL on a local volume instead of replaying
+it from object storage.
+
 #### TLS
 
 Enable TLS with inline cert/key or an existing secret:
@@ -606,6 +639,19 @@ Check events:
 kubectl describe pod -n influxdb3 influxdb3-enterprise-ingester-0
 ```
 
+A pod that restarts during startup while its logs show normal activity was
+either killed by the startup probe or ran out of memory. Both exit with code
+137, so check which before changing anything:
+
+```bash
+kubectl get pod -n influxdb3 influxdb3-enterprise-ingester-0 \
+  -o jsonpath='{.status.containerStatuses[0].lastState.terminated.reason}'
+```
+
+`OOMKilled` means raise the memory limit. `Error` together with a
+`Startup probe failed` event means the probe window is too short; see
+[Health Probes](#health-probes).
+
 #### License Issues
 
 Verify license configuration:
@@ -680,6 +726,12 @@ logs:
 | `security.auth.adminToken.recovery.httpBind` | Bind address for admin token recovery endpoint (`INFLUXDB3_ADMIN_TOKEN_RECOVERY_HTTP_BIND_ADDR`) | `""` |
 | `serviceAccount.automountServiceAccountToken` | Configure automatic mounting of the Kubernetes service account token in component pods and the created ServiceAccount | `not set` |
 | `extraEnv` | Extra environment variables applied to all components | `[]` |
+| `probes.enabled` | Enable liveness, readiness, and startup probes on all components | `true` |
+| `probes.startup.initialDelaySeconds` | Delay before the first startup check | `10` |
+| `probes.startup.periodSeconds` | Interval between startup checks | `5` |
+| `probes.startup.timeoutSeconds` | Timeout of a single startup check | `5` |
+| `probes.startup.failureThreshold` | Failed startup checks before the pod is killed | `184` |
+| `probes.liveness.*` / `probes.readiness.*` | Liveness and readiness timings; see `values.yaml` | see `values.yaml` |
 
 ### Object Storage Parameters
 

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -293,7 +293,7 @@ probes:
     initialDelaySeconds: 10
     periodSeconds: 5
     timeoutSeconds: 5
-    failureThreshold: 184   # 10s + (184 - 1) × 5s = 925s
+    failureThreshold: 184   # 10s + (184 - 1) × 5s = 925s to termination
 ```
 
 Nodes replay from object storage on boot, so startup scales with how much data a
@@ -637,22 +637,25 @@ Check events:
 kubectl describe pod -n influxdb3 influxdb3-enterprise-ingester-0
 ```
 
-A pod that restarts during startup while its logs show normal activity was
-either killed by the startup probe or ran out of memory. Read the termination
-reason and the events rather than the exit code:
+A pod that restarts during startup while its logs show normal activity is most
+often killed by the startup probe or out of memory, though an externally killed
+container can have other causes. Read the termination reason and the kill event
+rather than the exit code:
 
 ```bash
 kubectl get pod -n influxdb3 influxdb3-enterprise-ingester-0 \
   -o jsonpath='{.status.containerStatuses[0].lastState.terminated.reason}'
-kubectl describe pod -n influxdb3 influxdb3-enterprise-ingester-0 | grep -i probe
+kubectl describe pod -n influxdb3 influxdb3-enterprise-ingester-0 | grep -i killing
 ```
 
-`OOMKilled` means raise the memory limit. `Error` together with a
-`Startup probe failed` event means the probe window is too short; see
-[Health Probes](#health-probes). Exit code 137 is one possible signature of a
-probe kill, not proof of one: kubelet asks the runtime to terminate first and
-honours `terminationGracePeriodSeconds`, so a process that exits during that
-window reports a different code, and 137 is also what an OOM kill produces.
+`OOMKilled` means raise the memory limit. A `Killing` event reading
+`failed startup probe, will be restarted` means the probe window is too short;
+see [Health Probes](#health-probes). Use that event rather than
+`Startup probe failed`, which kubelet records for every failed attempt including
+those below `failureThreshold`. Exit code 137 is one possible signature, not
+proof: kubelet asks the runtime to terminate first and honours
+`terminationGracePeriodSeconds`, so a process that exits during that window
+reports a different code, and 137 is also what an OOM kill produces.
 
 #### License Issues
 

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -307,7 +307,7 @@ normally.
 
 Once the startup probe succeeds, the liveness probe takes over with a much
 narrower window (`3 × 10s`). A node that answers `/health` and then blocks
-during later startup work can still be restarted; raise
+during later startup work can still have its container restarted; raise
 `probes.liveness.failureThreshold` if that happens.
 
 This widens the window rather than shortening the startup. If nodes routinely
@@ -637,10 +637,10 @@ Check events:
 kubectl describe pod -n influxdb3 influxdb3-enterprise-ingester-0
 ```
 
-A pod that restarts during startup while its logs show normal activity is most
-often killed by the startup probe or out of memory, though an externally killed
-container can have other causes. Read the termination reason and the kill event
-rather than the exit code:
+A container that restarts during startup while its logs show normal activity is
+most often terminated by the startup probe or out of memory, though an
+externally killed container can have other causes. Read the termination reason
+and the kill event rather than the exit code:
 
 ```bash
 kubectl get pod -n influxdb3 influxdb3-enterprise-ingester-0 \
@@ -735,7 +735,7 @@ logs:
 | `probes.startup.initialDelaySeconds` | Delay before the first startup check | `10` |
 | `probes.startup.periodSeconds` | Interval between startup checks | `5` |
 | `probes.startup.timeoutSeconds` | Timeout of a single startup check | `5` |
-| `probes.startup.failureThreshold` | Failed startup checks before the pod is killed | `184` |
+| `probes.startup.failureThreshold` | Failed startup checks before container termination is triggered | `184` |
 | `probes.liveness.*` / `probes.readiness.*` | Liveness and readiness timings; see `values.yaml` | see `values.yaml` |
 
 ### Object Storage Parameters

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -731,13 +731,13 @@ probes:
 
   # Startup probe settings
   # Protects container during initialization. Once successful, never runs again.
-  # Allows slower startup without delaying successful readiness detection.
-  # 10s initial + (30 × 5s) = 160s total.
+  # 10s initial + (184 - 1) × 5s = 925s before the container is restarted.
+  # Nodes replay from object storage on boot, so startup scales with data size.
   startup:
     initialDelaySeconds: 10
     periodSeconds: 5                  # Check every 5 seconds
     timeoutSeconds: 5
-    failureThreshold: 30
+    failureThreshold: 184
 
   # Liveness probe settings
   # Only starts checking AFTER startup probe succeeds

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -731,7 +731,8 @@ probes:
 
   # Startup probe settings
   # Protects container during initialization. Once successful, never runs again.
-  # 10s initial + (184 - 1) × 5s = 925s before the container is restarted.
+  # 10s initial + (184 - 1) × 5s = 925s before the startup probe triggers
+  # termination; the restart itself follows terminationGracePeriodSeconds.
   # Nodes replay from object storage on boot, so startup scales with data size.
   startup:
     initialDelaySeconds: 10


### PR DESCRIPTION
Widens the startup probe window and documents the probe settings, which the README did not cover at all.

## Why

Nodes replay from object storage on boot, so startup scales with how much data a node reads back. Support cases report startups past 12 minutes, while the window was 155s in practice. A node killed mid-replay restarts and begins the replay again.

## What changes

`failureThreshold` goes from 30 to 184, leaving `initialDelaySeconds: 10` and `periodSeconds: 5` untouched, as #807 did when it last raised the window. That gives `10 + (184 - 1) × 5 = 925s` before the probe triggers termination; the restart itself then follows `terminationGracePeriodSeconds`.

The arithmetic in the old comments was one period optimistic - the window is `initialDelay + (threshold - 1) × period`, so the documented `10s + (30 × 5s) = 160s` was really 155s. Comments and docs now use the correct form.

## Documentation

A Health Probes section covering three things that were not written down anywhere: `helm --wait` defaults to a five-minute timeout, shorter than the startup it waits for; the liveness probe keeps a narrow `3 × 10s` window once the startup probe succeeds; and the troubleshooting note now uses the `Killing` event as the discriminator rather than exit code 137, which is also the OOMKilled signature.

## Testing

`helm lint`, a render of all four CI values files and stock `values.yaml`, and a kind cluster on the CI node image running the full `ct lint` and `ct install` chain. The probe mechanism itself was verified separately: two otherwise identical pods taking 90s to open `/health`, one with a window shorter than the startup and one longer - the first is killed and restarts, the second reaches `Ready`.

Supersedes #801, which proposed 230s before the longer startups were reported.

Closes #800