### PR TITLE
feat(influxdb3-ent): expose compacted-data startup options

### DIFF
--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.10.1
+version: 0.11.0
 appVersion: "3.11.2"
 keywords:
   - influxdb

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -100,6 +100,37 @@ At minimum, you must configure:
        host: ""
    ```
 
+### Commercial License
+
+Store the license in a secret and point the chart at it.
+
+1. Create a Kubernetes secret from the license file. The key must be
+   `license-file`:
+   ```bash
+   kubectl -n influxdb3 create secret generic influxdb3-license \
+     --from-file=license-file=/path/to/license.jwt
+   ```
+
+2. Configure the chart:
+   ```yaml
+   license:
+     type: commercial
+     existingSecret: influxdb3-license
+   ```
+
+Notes:
+- Secret key must be `license-file`. The chart mounts that key at
+  `/etc/influxdb/license`. With any other key the mount produces an empty
+  directory and the server logs `failed to read license file from path: Is a
+  directory (os error 21)`.
+- `--from-file=/path/to/license.jwt` without the `license-file=` prefix names
+  the key after the file and hits exactly that case.
+- `license.type` must be `commercial`. It defaults to `trial`, and a trial
+  release reads only `license-email` from the secret and never sets the license
+  file path.
+- The chart does not read a license from object storage. A message about no
+  license found there follows a failed file read; it is not the cause.
+
 ### Preconfigured Admin Token
 
 Use this when you want the cluster to start with a known offline-generated admin token.
@@ -722,6 +753,22 @@ Verify license configuration:
 ```bash
 kubectl get secret -n influxdb3 influxdb3-enterprise-license -o yaml
 ```
+
+`failed to read license file from path: Is a directory (os error 21)` means the
+secret named in `license.existingSecret` has no `license-file` key, so the mount
+produced an empty directory. Check the key name:
+
+```bash
+kubectl -n influxdb3 get secret SECRET_NAME \
+  -o go-template='{{range $k,$v := .data}}{{$k}}{{"\n"}}{{end}}'
+```
+
+That prints key names only. Avoid `-o yaml` or `-o jsonpath='{.data}'` here: both
+print the base64-encoded licence along with the keys.
+
+The `no commercial license found in object store` line that follows is a
+fallback after the failed read, not a separate problem. See
+[Commercial License](#commercial-license).
 
 #### Object Storage Connection
 

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -312,6 +312,62 @@ during later startup work can still have its container restarted; raise
 
 This widens the window rather than shortening the startup. If nodes routinely
 need most of it, the boot work itself is worth investigating.
+#### Compacted-Data Startup
+
+Before a node serves traffic it loads compaction state, including a file index
+that maps indexed column values to Parquet files. On clusters with a large
+compaction history that load can dominate startup: nodes take tens of minutes to
+answer `/health`, or run out of memory before they finish.
+
+```yaml
+compactedData:
+  skipFileIndex: true       # skip the in-memory file index
+  loadConcurrencyLimit: 8   # concurrent downloads while loading (server default 20)
+```
+
+`skipFileIndex` trades query-time file pruning for a bounded memory footprint at
+startup. Queries stay correct and time-range pruning still applies, but
+equality-predicate queries scan more files. The setting applies to the whole
+node, so a compactor started with it also skips index merges for newly compacted
+generations. Exempting a single component means overriding both spellings in its
+`extraEnv`, because the ConfigMap supplies both.
+`loadConcurrencyLimit` bounds the memory buffered by in-flight downloads; lower
+it when memory is tight during startup, raise it for faster startup where there
+is network headroom.
+
+Both options predate 3.11 under their `INFLUXDB3_ENTERPRISE_` names
+(`loadConcurrencyLimit` since 3.9.8 and 3.10.3, `skipFileIndex` since 3.9.9 and
+3.10.4), and the chart emits those alongside the 3.11 spelling, so a release
+works against either. On an image older than those patch releases the variable
+is simply unknown and the server ignores it without a message, so check the
+running version if the option appears to have no effect.
+
+**They apply to clusters on the Parquet storage engine only.** The file index is
+a Parquet mechanism, so once a node has fully adopted PachaTree the machinery
+that reads these options is never built and the server ignores them, logging
+that they can be removed. They stay live throughout the migration itself. In
+practice that means they help exactly where the problem occurs - a cluster still
+on Parquet, or one part-way through the upgrade - and are redundant on a cluster
+that has completed it.
+
+The option is per-node and fully reversible: the index is still written to object
+storage during compaction, so removing the option and restarting loads it as
+before. The index also keeps growing while the option is on, so it buys time
+rather than fixing anything.
+
+That reason is the indexing strategy rather than the node configuration. Every
+table is indexed: by default on `time` and every tag column, from generation 2
+of compaction onwards. An index outgrows memory when a table has many tags, or
+tags with high cardinality, and all of them are indexed whether queries use them
+or not.
+
+The fix is to narrow the strategy, not to remove it. `influxdb3 create
+file_index` defines a custom index over a chosen subset of columns, which is
+smaller than the default. Note that `influxdb3 delete file_index` does the
+opposite of what its name suggests: it drops a custom strategy and reverts to
+the default over every tag, which can be larger. Nothing in this chart governs
+this; see
+[Manage file indexes](https://docs.influxdata.com/influxdb3/enterprise/admin/file-index/).
 
 #### TLS
 
@@ -656,6 +712,9 @@ those below `failureThreshold`. Exit code 137 is one possible signature, not
 proof: kubelet asks the runtime to terminate first and honours
 `terminationGracePeriodSeconds`, so a process that exits during that window
 reports a different code, and 137 is also what an OOM kill produces.
+A node that stays `0/1` for a long time, or is OOM-killed before it answers
+`/health`, is usually loading its compaction file index. See
+[Compacted-Data Startup](#compacted-data-startup).
 
 #### License Issues
 
@@ -737,6 +796,8 @@ logs:
 | `probes.startup.timeoutSeconds` | Timeout of a single startup check | `5` |
 | `probes.startup.failureThreshold` | Failed startup checks before container termination is triggered | `184` |
 | `probes.liveness.*` / `probes.readiness.*` | Liveness and readiness timings; see `values.yaml` | see `values.yaml` |
+| `compactedData.skipFileIndex` | Skip loading the compacted-data file index into memory | not set (server default `false`) |
+| `compactedData.loadConcurrencyLimit` | Concurrent downloads while loading compaction summaries | not set (server default `20`) |
 
 ### Object Storage Parameters
 

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -343,6 +343,7 @@ during later startup work can still have its container restarted; raise
 
 This widens the window rather than shortening the startup. If nodes routinely
 need most of it, the boot work itself is worth investigating.
+
 #### Compacted-Data Startup
 
 Before a node serves traffic it loads compaction state, including a file index
@@ -743,28 +744,28 @@ those below `failureThreshold`. Exit code 137 is one possible signature, not
 proof: kubelet asks the runtime to terminate first and honours
 `terminationGracePeriodSeconds`, so a process that exits during that window
 reports a different code, and 137 is also what an OOM kill produces.
+
 A node that stays `0/1` for a long time, or is OOM-killed before it answers
 `/health`, is usually loading its compaction file index. See
 [Compacted-Data Startup](#compacted-data-startup).
 
 #### License Issues
 
-Verify license configuration:
-```bash
-kubectl get secret -n influxdb3 influxdb3-enterprise-license -o yaml
-```
-
 `failed to read license file from path: Is a directory (os error 21)` means the
-secret named in `license.existingSecret` has no `license-file` key, so the mount
-produced an empty directory. Check the key name:
+chart mounted nothing at `/etc/influxdb/license`. The volume is declared
+`optional`, so this happens both when the secret named in
+`license.existingSecret` does not exist in the release namespace and when it
+exists without a `license-file` key. Check for both:
 
 ```bash
 kubectl -n influxdb3 get secret SECRET_NAME \
   -o go-template='{{range $k,$v := .data}}{{$k}}{{"\n"}}{{end}}'
 ```
 
-That prints key names only. Avoid `-o yaml` or `-o jsonpath='{.data}'` here: both
-print the base64-encoded licence along with the keys.
+A `NotFound` error means the secret is missing or lives in another namespace;
+output without `license-file` means the key is wrong. The command prints key
+names only - avoid `-o yaml` and `-o jsonpath='{.data}'`, which print the
+base64-encoded licence itself.
 
 The `no commercial license found in object store` line that follows is a
 fallback after the failed read, not a separate problem. See

--- a/charts/influxdb3-enterprise/TROUBLESHOOTING.md
+++ b/charts/influxdb3-enterprise/TROUBLESHOOTING.md
@@ -77,6 +77,13 @@ kubectl logs -n influxdb3 influxdb3-enterprise-ingester-0 --previous
 
 ### Pods Not Ready
 
+A pod that stays `0/1` for many minutes, or is OOM-killed while its log shows
+normal startup activity, is usually loading its compacted-data file index rather
+than failing a probe. Widening the probe window does not shorten that load; see
+the Compacted-Data Startup section of the chart README for the two options that
+bound it.
+
+
 **Symptoms:**
 ```bash
 NAME                                  READY   STATUS    RESTARTS   AGE

--- a/charts/influxdb3-enterprise/TROUBLESHOOTING.md
+++ b/charts/influxdb3-enterprise/TROUBLESHOOTING.md
@@ -108,6 +108,14 @@ kubectl exec -n influxdb3 influxdb3-enterprise-querier-0 -- curl -s http://local
 
 ## License Issues
 
+`failed to read license file from path: Is a directory (os error 21)` means the
+secret in `license.existingSecret` has no `license-file` key. The chart mounts
+that key at `/etc/influxdb/license`; with any other key the mount is an empty
+directory. Recreate the secret with `--from-file=license-file=...` and confirm
+`license.type` is `commercial`. The `no commercial license found in object
+store` line right after is a fallback, not the cause.
+
+
 ### License Email Not Accepted
 
 **Error Message:**

--- a/charts/influxdb3-enterprise/TROUBLESHOOTING.md
+++ b/charts/influxdb3-enterprise/TROUBLESHOOTING.md
@@ -108,8 +108,10 @@ kubectl exec -n influxdb3 influxdb3-enterprise-querier-0 -- curl -s http://local
 
 ## License Issues
 
-`failed to read license file from path: Is a directory (os error 21)` means the
-secret in `license.existingSecret` has no `license-file` key. The chart mounts
+`failed to read license file from path: Is a directory (os error 21)` means
+nothing was mounted at `/etc/influxdb/license`. The volume is optional, so this
+covers both a secret that does not exist in the release namespace and one
+without a `license-file` key. The chart mounts
 that key at `/etc/influxdb/license`; with any other key the mount is an empty
 directory. Recreate the secret with `--from-file=license-file=...` and confirm
 `license.type` is `commercial`. The `no commercial license found in object

--- a/charts/influxdb3-enterprise/ci/component-extra-env-values.yaml
+++ b/charts/influxdb3-enterprise/ci/component-extra-env-values.yaml
@@ -80,3 +80,7 @@ processingEngine:
       value: "processor-only"
   persistence:
     enabled: false
+
+compactedData:
+  skipFileIndex: false
+  loadConcurrencyLimit: 8

--- a/charts/influxdb3-enterprise/templates/configmap.yaml
+++ b/charts/influxdb3-enterprise/templates/configmap.yaml
@@ -197,6 +197,19 @@ data:
   {{- if .tableIndexCacheConcurrencyLimit }}
   INFLUXDB3_TABLE_INDEX_CACHE_CONCURRENCY_LIMIT: {{ .tableIndexCacheConcurrencyLimit | quote }}
   {{- end }}
+
+  {{- end }}
+
+  # Compacted-data startup
+  {{- with .Values.compactedData }}
+  {{- if kindIs "bool" .skipFileIndex }}
+  INFLUXDB3_COMPACTED_DATA_SKIP_FILE_INDEX: {{ ternary "true" "false" .skipFileIndex | quote }}
+  INFLUXDB3_ENTERPRISE_COMPACTED_DATA_SKIP_FILE_INDEX: {{ ternary "true" "false" .skipFileIndex | quote }}
+  {{- end }}
+  {{- if hasKey . "loadConcurrencyLimit" }}
+  INFLUXDB3_COMPACTED_DATA_LOAD_CONCURRENCY_LIMIT: {{ .loadConcurrencyLimit | quote }}
+  INFLUXDB3_ENTERPRISE_COMPACTED_DATA_LOAD_CONCURRENCY_LIMIT: {{ .loadConcurrencyLimit | quote }}
+  {{- end }}
   {{- end }}
 
   # Resource limits

--- a/charts/influxdb3-enterprise/templates/configmap.yaml
+++ b/charts/influxdb3-enterprise/templates/configmap.yaml
@@ -202,7 +202,10 @@ data:
 
   # Compacted-data startup
   {{- with .Values.compactedData }}
-  {{- if kindIs "bool" .skipFileIndex }}
+  {{- if hasKey . "skipFileIndex" }}
+  {{- if not (kindIs "bool" .skipFileIndex) }}
+  {{- fail (printf "compactedData.skipFileIndex must be an unquoted boolean (true or false), got %s: %v" (kindOf .skipFileIndex) .skipFileIndex) }}
+  {{- end }}
   INFLUXDB3_COMPACTED_DATA_SKIP_FILE_INDEX: {{ ternary "true" "false" .skipFileIndex | quote }}
   INFLUXDB3_ENTERPRISE_COMPACTED_DATA_SKIP_FILE_INDEX: {{ ternary "true" "false" .skipFileIndex | quote }}
   {{- end }}

--- a/charts/influxdb3-enterprise/values.yaml
+++ b/charts/influxdb3-enterprise/values.yaml
@@ -683,6 +683,23 @@ caching:
   # tableIndexCacheMaxEntries: 1000
   # tableIndexCacheConcurrencyLimit: 8
 
+# Compacted-data startup: bounds the state a node loads before serving traffic.
+# Parquet engine only; a fully migrated PachaTree node ignores both.
+
+compactedData:
+  # Skip loading the compacted-data file index into memory. Queries stay
+  # correct and time-range pruning still applies, but equality-predicate
+  # queries scan more files. The setting applies to the whole node, so a
+  # compactor started with it also skips index merges for new generations.
+  # Use when nodes cannot start because the index has grown close to the
+  # container memory limit.
+  # skipFileIndex: false
+
+  # Concurrent downloads while loading compaction summaries (server default 20).
+  # Lower it when memory is tight during startup or the object store throttles
+  # the load; raise it for faster startup on hosts with more network headroom.
+  # loadConcurrencyLimit: 20
+
 # Resource limits
 # resourceLimits:
 #   numDatabases: 100                 # Max databases


### PR DESCRIPTION
Adds `compactedData.skipFileIndex` and `compactedData.loadConcurrencyLimit`.

## Why

Before a node serves traffic it loads compaction state, including a file index mapping indexed column values to Parquet files. On clusters with a large compaction history that load dominates startup: support cases show nodes taking tens of minutes to answer `/health`, and nodes running out of memory before they finish while the application log stays clean.

Both options bound that work and the chart had no way to set them. `skipFileIndex` trades query-time file pruning for a bounded startup footprint; queries stay correct and time-range pruning still applies. It applies to the whole node, so a compactor started with it also skips index merges for new generations. `loadConcurrencyLimit` bounds the memory buffered by in-flight downloads.

This addresses the cause rather than the symptom. #827 widens the startup probe so a slow start is not turned into a restart loop, but the start itself stays slow; these options shorten it.

## Version compatibility

The options predate 3.11 under `INFLUXDB3_ENTERPRISE_COMPACTED_DATA_*` and 3.11 keeps those names as aliases, so the chart emits both spellings. A release therefore works against a pinned 3.9 or 3.10 image as well as 3.11, which matters during the staged rollout described in UPGRADING-3.10-TO-3.11.md.

## Note on ordering with #827

This conflicts with #827 in `Chart.yaml` and `README.md`, since both bump the version and add a section in the same place. They are independent changes; whichever merges second needs a rebase. Suggest merging #827 first as it is the smaller change, and I will rebase this one on top.

## Testing

`helm lint` and a render of all four CI values files plus stock `values.yaml`. `ci/component-extra-env-values.yaml` now exercises both options, so the rendered variable names are covered by `ct install` without adding an install run. Neither option renders when unset, so existing releases are unchanged. Verified against a kind cluster on the CI node image with the full `ct lint` and `ct install` chain.