### PR TITLE
docs(influxdb3-ent): document the license secret key

### DIFF
--- a/charts/influxdb3-enterprise/Chart.yaml
+++ b/charts/influxdb3-enterprise/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-enterprise
 description: A Helm chart for deploying InfluxDB 3 Enterprise on Kubernetes
 type: application
-version: 0.10.0
+version: 0.10.1
 appVersion: "3.11.2"
 keywords:
   - influxdb

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -649,8 +649,12 @@ secret named in `license.existingSecret` has no `license-file` key, so the mount
 produced an empty directory. Check the key name:
 
 ```bash
-kubectl get secret -n influxdb3 SECRET_NAME -o jsonpath='{.data}' | tr ',' '\n'
+kubectl -n influxdb3 get secret SECRET_NAME \
+  -o go-template='{{range $k,$v := .data}}{{$k}}{{"\n"}}{{end}}'
 ```
+
+That prints key names only. Avoid `-o yaml` or `-o jsonpath='{.data}'` here: both
+print the base64-encoded licence along with the keys.
 
 The `no commercial license found in object store` line that follows is a
 fallback after the failed read, not a separate problem. See

--- a/charts/influxdb3-enterprise/README.md
+++ b/charts/influxdb3-enterprise/README.md
@@ -100,6 +100,37 @@ At minimum, you must configure:
        host: ""
    ```
 
+### Commercial License
+
+Store the license in a secret and point the chart at it.
+
+1. Create a Kubernetes secret from the license file. The key must be
+   `license-file`:
+   ```bash
+   kubectl -n influxdb3 create secret generic influxdb3-license \
+     --from-file=license-file=/path/to/license.jwt
+   ```
+
+2. Configure the chart:
+   ```yaml
+   license:
+     type: commercial
+     existingSecret: influxdb3-license
+   ```
+
+Notes:
+- Secret key must be `license-file`. The chart mounts that key at
+  `/etc/influxdb/license`. With any other key the mount produces an empty
+  directory and the server logs `failed to read license file from path: Is a
+  directory (os error 21)`.
+- `--from-file=/path/to/license.jwt` without the `license-file=` prefix names
+  the key after the file and hits exactly that case.
+- `license.type` must be `commercial`. It defaults to `trial`, and a trial
+  release reads only `license-email` from the secret and never sets the license
+  file path.
+- The chart does not read a license from object storage. A message about no
+  license found there follows a failed file read; it is not the cause.
+
 ### Preconfigured Admin Token
 
 Use this when you want the cluster to start with a known offline-generated admin token.
@@ -612,6 +643,18 @@ Verify license configuration:
 ```bash
 kubectl get secret -n influxdb3 influxdb3-enterprise-license -o yaml
 ```
+
+`failed to read license file from path: Is a directory (os error 21)` means the
+secret named in `license.existingSecret` has no `license-file` key, so the mount
+produced an empty directory. Check the key name:
+
+```bash
+kubectl get secret -n influxdb3 SECRET_NAME -o jsonpath='{.data}' | tr ',' '\n'
+```
+
+The `no commercial license found in object store` line that follows is a
+fallback after the failed read, not a separate problem. See
+[Commercial License](#commercial-license).
 
 #### Object Storage Connection
 

--- a/charts/influxdb3-enterprise/TROUBLESHOOTING.md
+++ b/charts/influxdb3-enterprise/TROUBLESHOOTING.md
@@ -101,6 +101,14 @@ kubectl exec -n influxdb3 influxdb3-enterprise-querier-0 -- curl -s http://local
 
 ## License Issues
 
+`failed to read license file from path: Is a directory (os error 21)` means the
+secret in `license.existingSecret` has no `license-file` key. The chart mounts
+that key at `/etc/influxdb/license`; with any other key the mount is an empty
+directory. Recreate the secret with `--from-file=license-file=...` and confirm
+`license.type` is `commercial`. The `no commercial license found in object
+store` line right after is a fallback, not the cause.
+
+
 ### License Email Not Accepted
 
 **Error Message:**


### PR DESCRIPTION
A customer set `license.existingSecret` and their nodes kept reporting that no license was found. The secret was fine and the licence was valid; its key was not `license-file`.

The chart mounts that specific key at `/etc/influxdb/license` with `optional: true`, so any other key name leaves an empty directory at that path. The server then logs:

```
WARN failed to read license file from path: Is a directory (os error 21)
INFO no commercial license found in object store
```

The second line reads as though the chart looks for the licence in object storage, which sends people looking in the wrong place. It is a fallback after the failed read.

Reproduced on a kind cluster against chart 0.10.0:

| Secret key | `/etc/influxdb/license` | Result |
|---|---|---|
| `license.jwt` | empty directory | `Is a directory (os error 21)` |
| `license-file` | file, 545 B | `Enterprise license verified` |

The required key was documented only in a `values.yaml` comment and one parameter-table row, while the admin token and permission tokens both have a worked example with the key called out. This adds the same for the licence, plus the `license.type: commercial` requirement, since the default `trial` never sets the license file path at all.

No `Chart.yaml` bump. This is documentation, and a version bump on master triggers a release; it can ship with the next one instead.