### PR TITLE
chore: Telegraf v1.40.0

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.1.54
-appVersion: 1.39.3
+version: 1.1.55
+appVersion: 1.40.0
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
 keywords:

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repo: "telegraf"
-  tag: "1.39-alpine"
+  tag: "1.40-alpine"
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 ## Configure resource requests and limits
@@ -19,7 +19,6 @@ resources:
 ## Annotations to add to the DaemonSet object itself.
 ## Use podAnnotations below to annotate the pods.
 daemonSetAnnotations: {}
-
 ## Pod annotations
 podAnnotations: {}
 ## Pod labels

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.75
-appVersion: 1.39.3
+version: 1.8.76
+appVersion: 1.40.0
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
 keywords:

--- a/charts/telegraf/ci/complex-values.yaml
+++ b/charts/telegraf/ci/complex-values.yaml
@@ -4,7 +4,7 @@ config:
     - enum:
         # this is wrong mapping copied from values.yaml to test compatibility hack in v2 code
         mapping:
-          field: "status"
+          fields: ["status"]
           dest: "status_code"
           value_mappings:
             healthy: 1
@@ -14,7 +14,7 @@ config:
     - enum:
         order: 1
         mapping:
-          - field: system_location_section
+          - fields: ["system_location_section"]
             dest: system_location_sectionFloorNumber
             value_mappings:
               2nd: 2
@@ -29,7 +29,7 @@ config:
     # issue 119
     - enum:
         mapping:
-          field: state
+          fields: ["state"]
           dest: status_code
           default: -1
           value_mappings:

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 image:
   repo: "docker.io/library/telegraf"
-  tag: "1.39-alpine"
+  tag: "1.40-alpine"
   pullPolicy: IfNotPresent
 ## Annotations to add to the Deployment object itself.
 ## Use podAnnotations below to annotate the pods.

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -153,7 +153,7 @@ config:
   processors:
     - enum:
         mapping:
-          field: "status"
+          fields: ["status"]
           dest: "status_code"
           value_mappings:
             healthy: 1


### PR DESCRIPTION
Bumps the `telegraf` and `telegraf-ds` charts to Telegraf 1.40.0 (`1.40-alpine` image, `appVersion` 1.40.0).

### Config change required by Telegraf 1.40

Telegraf 1.40.0 removed the singular `field` and `tag` options of `processors.enum.mapping`. They were deprecated in 1.35.0 in favour of the `fields` and `tags` lists, and from 1.40 a config that still uses them fails to load at startup:

```
E! DeprecationError: Option "field" of plugin "processors.enum" deprecated since version 1.35.0 and will be removed in 1.40.0: use 'fields' instead
E! loading config file /etc/telegraf/telegraf.conf failed: error parsing enum, plugin options "field" deprecated
```

The `telegraf` chart's default `values.yaml` and `ci/complex-values.yaml` shipped enum mappings with `field`, so this PR renames them to `fields: [...]`. Rendered configs were validated with `telegraf --test` on the 1.40 image.

### Breaking change for chart users

If your own `config.processors` values contain an enum mapping with `field:` or `tag:`, rename them to `fields: [...]` / `tags: [...]` before upgrading to this chart version, otherwise the pod will not start. The `telegraf-ds` chart ships no enum config and is unaffected unless you added one.