### PR TITLE
telegraf-ds: make host filesystem mounts optional

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.1.55
+version: 1.1.56
 appVersion: 1.40.0
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -55,12 +55,14 @@ spec:
               name: {{ .Values.envFromSecret }}
 {{- end }}
         volumeMounts:
+        {{- if .Values.hostMounts }}
         - name: varrunutmpro
           mountPath: /var/run/utmp
           readOnly: true
         - name: hostfsro
           mountPath: /hostfs
           readOnly: true
+        {{- end }}
         {{- if hasPrefix "unix" .Values.config.docker_endpoint }}
         - name: docker-socket
           mountPath: {{ trimPrefix "unix://" .Values.config.docker_endpoint }}
@@ -83,18 +85,22 @@ spec:
 {{ toYaml . | indent 8 }}
       {{- end }}
       volumes:
+      {{- if .Values.hostMounts }}
       - name: hostfsro
         hostPath:
           path: /
+      {{- end }}
       {{- if hasPrefix "unix" .Values.config.docker_endpoint }}
       - name: docker-socket
         hostPath:
           path: {{ trimPrefix "unix://" .Values.config.docker_endpoint }}
           type: Socket
       {{- end }}
+      {{- if .Values.hostMounts }}
       - name: varrunutmpro
         hostPath:
           path: /var/run/utmp
+      {{- end }}
       - name: config
         configMap:
           name:  {{ include "telegraf.fullname" . }}

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -54,6 +54,12 @@ env:
     value: "/hostfs/sys"
   - name: "HOST_MOUNT_PREFIX"
     value: "/hostfs"
+## Mount the host filesystem (/ at /hostfs, and /var/run/utmp) into the
+## container. Required by the default host-based input plugins (cpu, disk,
+## diskio, mem, system, ...). Can be disabled when running a custom config
+## (e.g. override_config) that does not use them.
+hostMounts: true
+
 ## Add custom volumes and mounts
 # volumes:
 # - name: telegraf-output-influxdb2


### PR DESCRIPTION
The chart unconditionally mounts the host root filesystem (`/` at `/hostfs`, read-only) and `/var/run/utmp` into every pod. These are only needed by the default host-based input plugins (cpu, disk, diskio, mem, system, ...). When running a custom config via `override_config` that doesn't use those plugins, mounting the host root filesystem into a DaemonSet pod on every node is unnecessary exposure.

This adds a `hostMounts` value gating both volumes and their mounts. Defaults to `true`, so existing deployments are unaffected.

Tested with `helm template`: default output is unchanged; with `hostMounts: false` the two volumes and volumeMounts are omitted. `helm lint` passes.