### PR TITLE
telegraf-ds: add updateStrategy value

### DIFF
--- a/charts/telegraf-ds/Chart.yaml
+++ b/charts/telegraf-ds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf-ds
-version: 1.1.55
+version: 1.1.56
 appVersion: 1.40.0
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -13,6 +13,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "telegraf.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- with .Values.updateStrategy }}
+  updateStrategy:
+{{ toYaml . | indent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -19,6 +19,15 @@ resources:
 ## Annotations to add to the DaemonSet object itself.
 ## Use podAnnotations below to annotate the pods.
 daemonSetAnnotations: {}
+## DaemonSet update strategy. Empty uses the Kubernetes default
+## (RollingUpdate with maxUnavailable: 1).
+# updateStrategy:
+#   type: RollingUpdate
+#   rollingUpdate:
+#     maxSurge: 0
+#     maxUnavailable: 4
+updateStrategy: {}
+
 ## Pod annotations
 podAnnotations: {}
 ## Pod labels


### PR DESCRIPTION
The DaemonSet spec doesn't expose `updateStrategy`, so rollouts always use the Kubernetes default (`RollingUpdate` with `maxUnavailable: 1`). On large clusters that makes image or config rollouts take hours, with no way to tune it from values.

This adds an `updateStrategy` value rendered into the DaemonSet spec. Defaults to empty, so existing deployments keep the current behavior.

Tested with `helm template`: default output is unchanged; setting the value renders it under `spec.updateStrategy`. `helm lint` passes.