### PR TITLE
fix(telegraf): hash only the config data in checksum/config

### DIFF
--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.76
+version: 1.8.77
 appVersion: 1.40.0
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/charts/telegraf/templates/_helpers.tpl
+++ b/charts/telegraf/templates/_helpers.tpl
@@ -724,3 +724,11 @@ Get health configuration
     {{- $health | toYaml -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Compute a ConfigMap or Secret checksum from its data only, for the checksum/* pod annotations.
+The full manifest carries the helm.sh/chart label, which changes on every chart version bump.
+*/}}
+{{- define "telegraf.configMapOrSecretContentHash" -}}
+{{ pick (include (print .ctx.Template.BasePath .name) .ctx | fromYaml) "data" "stringData" | toYaml | sha256sum }}
+{{- end -}}

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/config: {{ include "telegraf.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmap.yaml") }}
         {{- if .Values.podAnnotations }}
 {{ tpl (toYaml .Values.podAnnotations) . | indent 8 }}
         {{- end }}


### PR DESCRIPTION
`checksum/config` hashes the entire rendered ConfigMap, and the manifest's `metadata.labels` include `helm.sh/chart`. That value changes on every chart version bump, so the Telegraf pods are restarted on every `helm upgrade` even when the configuration is unchanged.

This adds a `telegraf.configMapOrSecretContentHash` helper that hashes only the `data`/`stringData` sections and uses it for the annotation. Chart bumped to 1.8.77.

Tested by rendering the chart against a bumped version with identical values — the checksum is unchanged — and by changing `config.agent.interval`, which still changes it. `helm lint` passes.

The same fix was recently made in the argo-cd chart (argoproj/argo-helm#4044); the loki chart uses the same data-only hashing.

- [x] Tests pass
- [ ] CLA signed (https://influxdata.com/community/cla/)
